### PR TITLE
Rw/comptime

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,9 +8,8 @@
             "preLaunchTask": "build compiler debug",
             "program": "${workspaceFolder}/src/Buckle/CommandLine/bin/Debug/net10.0/CommandLine.dll",
             "args": [
-                // "-r",
-                // "--clearsubmissions",
-                ".tmp/delegate.blt"
+                "-r",
+                "--clearsubmissions",
             ],
             "cwd": "${workspaceFolder}",
             "console": "externalTerminal",

--- a/docs/Current/Data.md
+++ b/docs/Current/Data.md
@@ -6,6 +6,7 @@
 - [3.4](#34-attributes-and-modifiers) Attributes and Modifiers
 - [3.5](#35-references) References
 - [3.6](#36-arrays) Arrays
+- [3.7](#37-compile-time-expressions) Compile-Time Expressions
 
 ## 3.1 Data Types
 
@@ -157,3 +158,65 @@ a[2] = 6;
 
 Note that this functionality will eventually be moved to be exclusive to low-level contexts, and be replaced with more
 powerful collection types.
+
+## 3.7 Compile-Time Expressions
+
+To evaluate an expression at compile-time, you can precede it with `$` or `$?`.
+
+For example:
+
+```belte
+int myInt = $Add(4, 5);
+
+int Add(int x, int y) {
+  return x + y;
+}
+```
+
+In the above example, the program produced by the compiler will evaluate the expression `Add(4, 5)` and put the result,
+`9`, in its place:
+
+```belte
+int myInt = 9;
+
+int Add(int x, int y) {
+  return x + y;
+}
+```
+
+Some expressions are not computable at compile-time. One possibility is that the expression tries to use data from
+outside the scope of the expression:
+
+```belte
+var myClass = new MyClass();
+var myInt = $myClass.GetF(); // Fails to compute
+
+class MyClass {
+  public int f = 10;
+
+  public int GetF() {
+    return f;
+  }
+}
+```
+
+In the above example, the expression cannot be computed at compile-time because it references local `myClass` which is
+defined outside of the scope of the compile-time expression.
+
+If you want to ignore any compile-time evaluation errors and continue you can use `$?`:
+
+```belte
+var myClass = new MyClass();
+var myInt = $?myClass.GetF();
+
+class MyClass {
+  public int f = 10;
+
+  public int GetF() {
+    return f;
+  }
+}
+```
+
+The above example will not replace the `myInt` declaration with anything and will retain its original initializer of
+`myClass.GetF()` because the compile-time evaluation failed.

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,7 @@ Many code samples can be viewed at [github.com/ryanwilsond/belte/main/samples](h
     - [3.4](Current/Data.md#34-attributes-and-modifiers) Attributes and Modifiers
     - [3.5](Current/Data.md#35-references) References
     - [3.6](Current/Data.md#36-arrays) Arrays
+    - [3.7](Current/Data.md#37-compile-time-expressions) Compile-Time Expressions
   - [4](Current/ClassesAndObjects.md) Classes and Objects
     - [4.1](Current/ClassesAndObjects.md#41-classes) Classes
     - [4.2](Current/ClassesAndObjects.md#42-members) Members

--- a/src/Buckle/Compiler.Tests/CodeAnalysis/Parser/LexerTests.cs
+++ b/src/Buckle/Compiler.Tests/CodeAnalysis/Parser/LexerTests.cs
@@ -361,6 +361,18 @@ public sealed class LexerTests {
             return true;
         if (t1Kind == SyntaxKind.MinusToken && t2Kind == SyntaxKind.MinusGreaterThanToken)
             return true;
+        if (t1Kind == SyntaxKind.DollarToken && t2Kind == SyntaxKind.QuestionOpenBracketToken)
+            return true;
+        if (t1Kind == SyntaxKind.DollarToken && t2Kind == SyntaxKind.QuestionPeriodToken)
+            return true;
+        if (t1Kind == SyntaxKind.DollarToken && t2Kind == SyntaxKind.QuestionQuestionEqualsToken)
+            return true;
+        if (t1Kind == SyntaxKind.DollarToken && t2Kind == SyntaxKind.QuestionToken)
+            return true;
+        if (t1Kind == SyntaxKind.DollarToken && t2Kind == SyntaxKind.DollarQuestionToken)
+            return true;
+        if (t1Kind == SyntaxKind.DollarToken && t2Kind == SyntaxKind.QuestionQuestionToken)
+            return true;
 
         return false;
     }

--- a/src/Buckle/Compiler.Tests/Diagnostics/DiagnosticTests.cs
+++ b/src/Buckle/Compiler.Tests/Diagnostics/DiagnosticTests.cs
@@ -3516,4 +3516,23 @@ public sealed class DiagnosticTests {
 
         AssertDiagnostics(text, diagnostics, _writer);
     }
+
+
+    [Fact]
+    public void Reports_Error_BU0357_InvalidCompileTimeExpression() {
+        var text = @"
+            class A {
+                public int Method() { return 3; }
+            }
+
+            var a = new A();
+            var b = [$a.Method()];
+        ";
+
+        var diagnostics = @"
+            expression is not computable at compile time
+        ";
+
+        AssertDiagnostics(text, diagnostics, _writer);
+    }
 }

--- a/src/Buckle/Compiler/CodeAnalysis/Binding/Binder.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Binding/Binder.cs
@@ -7807,6 +7807,12 @@ internal partial class Binder {
         return new BoundPointerIndirectionOperator(node, operand, false, pointedAtType ?? CreateErrorType(), hasErrors);
     }
 
+    private BoundExpression BindCompileTimeExpression(UnaryExpressionSyntax node, BelteDiagnosticQueue diagnostics) {
+        var operand = BindExpression(node.operand, diagnostics);
+        var conditional = node.operatorToken.kind == SyntaxKind.DollarQuestionToken;
+        return new BoundCompileTimeExpression(node, operand, conditional, operand.type);
+    }
+
     private static void BindPointerIndirectionExpressionInternal(
         ExpressionSyntax node,
         BelteDiagnosticQueue diagnostics,
@@ -7841,6 +7847,9 @@ internal partial class Binder {
 
         if (node.operatorToken.kind == SyntaxKind.AsteriskToken)
             return BindPointerIndirectionExpression(node, diagnostics);
+
+        if (node.operatorToken.kind is SyntaxKind.DollarToken or SyntaxKind.DollarQuestionToken)
+            return BindCompileTimeExpression(node, diagnostics);
 
         var operatorText = node.operatorToken.text;
         var operand = BindToNaturalType(BindValue(node.operand, diagnostics, BindValueKind.RValue), diagnostics);

--- a/src/Buckle/Compiler/CodeAnalysis/Binding/Binder.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Binding/Binder.cs
@@ -10228,19 +10228,26 @@ symIsHidden:;
         var expression = BindRValueWithoutTargetType(node.expression, diagnostics);
 
         if (!compilation.options.isScript) {
-            if (expression is not BoundCallExpression
+            if (IsInvalidExpressionStatement(expression))
+                diagnostics.Push(Error.InvalidExpressionStatement(node.location));
+        }
+
+        return new BoundExpressionStatement(node, expression);
+
+        static bool IsInvalidExpressionStatement(BoundExpression expression) {
+            if (expression is BoundCompileTimeExpression cte)
+                return IsInvalidExpressionStatement(cte.expression);
+
+            return expression is not BoundCallExpression
                           and not BoundAssignmentOperator
                           and not BoundErrorExpression
                           and not BoundCompoundAssignmentOperator
                           and not BoundThrowExpression
                           and not BoundIncrementOperator
                           and not BoundNullCoalescingAssignmentOperator
-                          and not BoundFunctionPointerCallExpression) {
-                diagnostics.Push(Error.InvalidExpressionStatement(node.location));
-            }
+                          and not BoundFunctionPointerCallExpression
+                          and not BoundCompileTimeExpression;
         }
-
-        return new BoundExpressionStatement(node, expression);
     }
 
     private BindValueKind GetRequiredReturnValueKind(RefKind refKind) {

--- a/src/Buckle/Compiler/CodeAnalysis/Binding/BoundTree/BoundNodes.xml
+++ b/src/Buckle/Compiler/CodeAnalysis/Binding/BoundTree/BoundNodes.xml
@@ -80,6 +80,10 @@
     <Field Name="receiver" Type="BoundExpression"/>
     <Field Name="index" Type="BoundExpression"/>
   </Node>
+  <Node Name="BoundCompileTimeExpression" Base="BoundExpression">
+    <Field Name="expression" Type="BoundExpression"/>
+    <Field Name="conditional" Type="bool"/>
+  </Node>
   <Node Name="BoundUnconvertedNullptrExpression" Base="BoundExpression">
     <Field Name="type" Type="TypeSymbol?" Override="true" Null="always"/>
   </Node>

--- a/src/Buckle/Compiler/CodeAnalysis/Binding/BoundTree/BoundTreeExpander.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Binding/BoundTree/BoundTreeExpander.cs
@@ -253,12 +253,20 @@ internal abstract class BoundTreeExpander {
             BoundKind.FunctionPointerLoad => ExpandFunctionPointerLoad((BoundFunctionPointerLoad)expression, out replacement),
             BoundKind.FunctionPointerCallExpression => ExpandFunctionPointerCallExpression((BoundFunctionPointerCallExpression)expression, out replacement),
             BoundKind.UnconvertedNullptrExpression => ExpandUnconvertedNullptrExpression((BoundUnconvertedNullptrExpression)expression, out replacement),
+            BoundKind.CompileTimeExpression => ExpandCompileTimeExpression((BoundCompileTimeExpression)expression, out replacement),
             _ => throw ExceptionUtilities.UnexpectedValue(expression.kind),
         };
     }
 
     private protected virtual List<BoundStatement> ExpandMethodGroup(
         BoundMethodGroup expression,
+        out BoundExpression replacement) {
+        replacement = expression;
+        return [];
+    }
+
+    private protected virtual List<BoundStatement> ExpandCompileTimeExpression(
+        BoundCompileTimeExpression expression,
         out BoundExpression replacement) {
         replacement = expression;
         return [];

--- a/src/Buckle/Compiler/CodeAnalysis/Compilation/MethodCompiler.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Compilation/MethodCompiler.cs
@@ -126,16 +126,25 @@ internal sealed class MethodCompiler : SymbolVisitor<TypeCompilationState, objec
         var newMethodLayouts = new Dictionary<MethodSymbol, EvaluatorSlotManager>();
 
         if (!_compilation.options.buildMode.Evaluating()) {
-            foreach (var (key, value) in _methodBodies) {
-                newMethodBodies.Add(key, EvaluatorSlotRewriter.Rewrite(
-                    key,
-                    value,
-                    _typeLayouts,
-                    _compilation.previous?.boundProgram,
-                    out var manager
-                ));
+            var current = _methodBodies;
+            var currentCompilation = _compilation;
 
-                newMethodLayouts.Add(key, manager);
+            while (currentCompilation is not null) {
+                foreach (var (key, value) in current) {
+                    newMethodBodies.Add(key, EvaluatorSlotRewriter.Rewrite(
+                        key,
+                        value,
+                        _typeLayouts,
+                        _compilation.previous?.boundProgram,
+                        out var manager
+                    ));
+
+                    newMethodLayouts.Add(key, manager);
+                }
+
+                // We have to recompute libraries because they aren't build with evaluator slots in mind
+                currentCompilation = currentCompilation.previous;
+                current = currentCompilation?.boundProgram?.methodBodies?.ToDictionary();
             }
         } else {
             newMethodBodies = _methodBodies;

--- a/src/Buckle/Compiler/CodeAnalysis/Compilation/MethodCompiler.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Compilation/MethodCompiler.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Buckle.CodeAnalysis.Binding;
+using Buckle.CodeAnalysis.Evaluating;
 using Buckle.CodeAnalysis.FlowAnalysis;
 using Buckle.CodeAnalysis.Lowering;
 using Buckle.CodeAnalysis.Symbols;
@@ -58,13 +59,7 @@ internal sealed class MethodCompiler : SymbolVisitor<TypeCompilationState, objec
 
         var globalNamespace = compilation.globalNamespaceInternal;
 
-        Dictionary<NamedTypeSymbol, EvaluatorSlotManager> typeLayouts;
-
-        if (compilation.options.buildMode.Evaluating())
-            typeLayouts = EvaluatorTypeLayoutVisitor.CreateTypeLayouts(globalNamespace);
-        else
-            typeLayouts = [];
-
+        var typeLayouts = EvaluatorTypeLayoutVisitor.CreateTypeLayouts(globalNamespace);
         var previousLayouts = compilation?.previous?.boundProgram?.typeLayouts;
 
         if (previousLayouts is not null) {
@@ -93,6 +88,7 @@ internal sealed class MethodCompiler : SymbolVisitor<TypeCompilationState, objec
         );
 
         methodCompiler.CompileNamespace(globalNamespace);
+        methodCompiler.ComputeCompileTimeExpressions();
 
         if (compilation.options.isScript && methodCompiler._updatePoint is null)
             methodCompiler._updatePoint = compilation.GetLateScriptUpdatePoint(methodCompiler._methodBodies);
@@ -123,6 +119,53 @@ internal sealed class MethodCompiler : SymbolVisitor<TypeCompilationState, objec
             _updatePoint,
             _compilation.previous?.boundProgram
         );
+    }
+
+    private void ComputeCompileTimeExpressions() {
+        var newMethodBodies = new Dictionary<MethodSymbol, BoundBlockStatement>();
+        var newMethodLayouts = new Dictionary<MethodSymbol, EvaluatorSlotManager>();
+
+        if (!_compilation.options.buildMode.Evaluating()) {
+            foreach (var (key, value) in _methodBodies) {
+                newMethodBodies.Add(key, EvaluatorSlotRewriter.Rewrite(
+                    key,
+                    value,
+                    _typeLayouts,
+                    _compilation.previous?.boundProgram,
+                    out var manager
+                ));
+
+                newMethodLayouts.Add(key, manager);
+            }
+        } else {
+            newMethodBodies = _methodBodies;
+            newMethodLayouts = _methodLayouts;
+        }
+
+        var boundProgram = new BoundProgram(
+            _compilation,
+            newMethodBodies.ToImmutableDictionary(),
+            newMethodLayouts.ToImmutableDictionary(),
+            _types.ToImmutableArray(),
+            _typeLayouts.ToImmutableDictionary(),
+            _synthesizedNestedTypes,
+            null,
+            null,
+            _compilation.previous?.boundProgram
+        );
+
+        var evaluatorContext = new EvaluatorContext(_compilation.options);
+
+        foreach (var (method, body) in _methodBodies) {
+            var loweredBody = CompileTimeLowerer.Lower(
+                body,
+                _diagnostics,
+                boundProgram,
+                evaluatorContext
+            );
+
+            _methodBodies[method] = (BoundBlockStatement)loweredBody;
+        }
     }
 
     private void CompileNamespace(NamespaceSymbol symbol) {
@@ -273,7 +316,14 @@ internal sealed class MethodCompiler : SymbolVisitor<TypeCompilationState, objec
             currentDiagnostics.Push(Error.NotAllPathsReturn(method.location));
 
         if (_compilation.options.buildMode.Evaluating()) {
-            loweredBody = EvaluatorSlotRewriter.Rewrite(method, loweredBody, _typeLayouts, out var slotManager);
+            loweredBody = EvaluatorSlotRewriter.Rewrite(
+                method,
+                loweredBody,
+                _typeLayouts,
+                _compilation.previous?.boundProgram,
+                out var slotManager
+            );
+
             _methodLayouts.Add(method, slotManager);
         }
 

--- a/src/Buckle/Compiler/CodeAnalysis/Display/DisplayText.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Display/DisplayText.cs
@@ -291,6 +291,9 @@ public sealed class DisplayText {
             case BoundKind.FunctionPointerCallExpression:
                 DisplayFunctionPointerCallExpression(text, (BoundFunctionPointerCallExpression)node);
                 break;
+            case BoundKind.CompileTimeExpression:
+                DisplayCompileTimeExpression(text, (BoundCompileTimeExpression)node);
+                break;
             default:
                 throw ExceptionUtilities.UnexpectedValue(node.kind);
         }
@@ -770,6 +773,11 @@ public sealed class DisplayText {
         BoundFunctionPointerCallExpression node) {
         SymbolDisplay.AppendToDisplayText(text, node.functionPointer.signature, SymbolDisplayFormat.QualifiedNameFormat);
         DisplayArguments(text, node.arguments);
+    }
+
+    private static void DisplayCompileTimeExpression(DisplayText text, BoundCompileTimeExpression node) {
+        text.Write(CreatePunctuation(SyntaxKind.DollarToken));
+        DisplayNode(text, node.expression);
     }
 
     private static void DisplayPointerIndirectionOperator(DisplayText text, BoundPointerIndirectionOperator node) {

--- a/src/Buckle/Compiler/CodeAnalysis/Evaluating/Evaluator.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Evaluating/Evaluator.cs
@@ -153,6 +153,13 @@ internal sealed class Evaluator {
         return hasValue ? EvaluatorValue.Format(result, _context) : null;
     }
 
+    internal object EvaluateExpression(BoundExpression expression, out bool hasValue) {
+        _hasValue = true;
+        var result = EvaluateExpression(expression, true, false);
+        hasValue = _hasValue;
+        return hasValue ? EvaluatorValue.Format(result, _context) : null;
+    }
+
     private TypeSymbol GetResultType(EvaluatorValue result) {
         switch (result.kind) {
             case ValueKind.Int8:
@@ -2365,7 +2372,6 @@ internal sealed class Evaluator {
     #endregion
 
     #region Libraries
-
 
     private bool CheckStandardMap(
         TextLocation location,

--- a/src/Buckle/Compiler/CodeAnalysis/Evaluating/Evaluator.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Evaluating/Evaluator.cs
@@ -41,6 +41,7 @@ internal sealed class Evaluator {
     private Random _lazyRandom;
     private bool _insideTry;
     private bool _insideUpdate;
+    private bool _insideExpressionEvaluation;
 
     /// <summary>
     /// Creates an <see cref="Evaluator" /> that can evaluate a <see cref="BoundProgram" /> (provided globals).
@@ -154,9 +155,11 @@ internal sealed class Evaluator {
     }
 
     internal object EvaluateExpression(BoundExpression expression, out bool hasValue) {
+        _insideExpressionEvaluation = true;
         _hasValue = true;
         var result = EvaluateExpression(expression, true, false);
         hasValue = _hasValue;
+        _insideExpressionEvaluation = false;
         return hasValue ? EvaluatorValue.Format(result, _context) : null;
     }
 
@@ -450,7 +453,7 @@ internal sealed class Evaluator {
             if (abort)
                 return EvaluatorValue.None;
 
-            if (_insideTry)
+            if (_insideTry || _insideExpressionEvaluation)
                 throw;
 
             exceptions.Add(e);

--- a/src/Buckle/Compiler/CodeAnalysis/Lowering/CompileTimeLowerer.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Lowering/CompileTimeLowerer.cs
@@ -1,0 +1,36 @@
+using Buckle.CodeAnalysis.Binding;
+using Buckle.CodeAnalysis.Evaluating;
+using Buckle.Diagnostics;
+
+namespace Buckle.CodeAnalysis.Lowering;
+
+internal sealed class CompileTimeLowerer : BoundTreeRewriter {
+    private readonly BelteDiagnosticQueue _diagnostics;
+    private readonly Evaluator _evaluator;
+
+    private CompileTimeLowerer(BoundProgram program, EvaluatorContext context, BelteDiagnosticQueue diagnostics) {
+        _diagnostics = diagnostics;
+        _evaluator = new Evaluator(program, context, []);
+    }
+
+    internal static BoundStatement Lower(
+        BoundStatement statement,
+        BelteDiagnosticQueue diagnostics,
+        BoundProgram program,
+        EvaluatorContext context) {
+        var lowerer = new CompileTimeLowerer(program, context, diagnostics);
+        return (BoundStatement)lowerer.Visit(statement);
+    }
+
+    internal override BoundNode VisitCompileTimeExpression(BoundCompileTimeExpression node) {
+        try {
+            var result = _evaluator.EvaluateExpression(node.expression, out var hasValue);
+            return BoundFactory.Literal(node.syntax, result, node.type);
+        } catch {
+            if (!node.conditional)
+                _diagnostics.Push(Error.InvalidCompileTimeExpression(node.syntax.location));
+
+            return node.expression;
+        }
+    }
+}

--- a/src/Buckle/Compiler/CodeAnalysis/Lowering/EvaluatorSlotRewriter.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Lowering/EvaluatorSlotRewriter.cs
@@ -3,12 +3,14 @@ using Buckle.CodeAnalysis.Binding;
 using Buckle.CodeAnalysis.CodeGeneration;
 using Buckle.CodeAnalysis.Symbols;
 using Buckle.Libraries;
+using Buckle.Utilities;
 using static Buckle.CodeAnalysis.Binding.BoundFactory;
 
 namespace Buckle.CodeAnalysis.Lowering;
 
 internal sealed class EvaluatorSlotRewriter : BoundTreeRewriter {
     private readonly Dictionary<NamedTypeSymbol, EvaluatorSlotManager> _typeLayouts;
+    private readonly BoundProgram _previous;
 
     private int _lateTempCount;
 
@@ -16,8 +18,10 @@ internal sealed class EvaluatorSlotRewriter : BoundTreeRewriter {
 
     private EvaluatorSlotRewriter(
         MethodSymbol method,
-        Dictionary<NamedTypeSymbol, EvaluatorSlotManager> typeLayouts) {
+        Dictionary<NamedTypeSymbol, EvaluatorSlotManager> typeLayouts,
+        BoundProgram previous) {
         _typeLayouts = typeLayouts;
+        _previous = previous;
         localSlotManager = new EvaluatorSlotManager(method);
     }
 
@@ -25,8 +29,9 @@ internal sealed class EvaluatorSlotRewriter : BoundTreeRewriter {
         MethodSymbol method,
         BoundStatement statement,
         Dictionary<NamedTypeSymbol, EvaluatorSlotManager> typeLayouts,
+        BoundProgram previous,
         out EvaluatorSlotManager slotManager) {
-        var rewriter = new EvaluatorSlotRewriter(method, typeLayouts);
+        var rewriter = new EvaluatorSlotRewriter(method, typeLayouts, previous);
         rewriter.AssignParameterSlots(method);
         var rewrittenBlock = (BoundBlockStatement)rewriter.Visit(statement);
 
@@ -118,7 +123,12 @@ internal sealed class EvaluatorSlotRewriter : BoundTreeRewriter {
         var field = node.field;
         var receiver = (BoundExpression)Visit(node.receiver);
         var receiverType = (receiver?.StrippedType() ?? field.containingType).originalDefinition;
-        var layout = _typeLayouts[(NamedTypeSymbol)receiverType];
+
+        if (!_typeLayouts.TryGetValue((NamedTypeSymbol)receiverType, out var layout)) {
+            if (!_previous.TryGetTypeLayoutIncludingParents((NamedTypeSymbol)receiverType, out layout))
+                throw ExceptionUtilities.Unreachable();
+        }
+
         var slot = layout.GetLocal(field).slot;
         return new BoundFieldSlotExpression(node.syntax, node, receiver, field, slot, node.Type());
     }

--- a/src/Buckle/Compiler/CodeAnalysis/Lowering/LocalFunctionRewriter/LocalFunctionRewriter.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Lowering/LocalFunctionRewriter/LocalFunctionRewriter.cs
@@ -826,6 +826,7 @@ internal sealed partial class LocalFunctionRewriter : MethodToClassRewriter {
                     synthesizedMethod,
                     body,
                     _compilationState.typeLayouts,
+                    _compilationState.compilation.previous?.boundProgram,
                     out var slotManager
                 );
 

--- a/src/Buckle/Compiler/CodeAnalysis/Parser/Lexer.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Parser/Lexer.cs
@@ -367,6 +367,11 @@ internal sealed class Lexer : IDisposable {
                 _position++;
                 _kind = SyntaxKind.TildeToken;
                 break;
+            case '$':
+                _position++;
+                if (AdvanceIfMatches('?')) _kind = SyntaxKind.DollarQuestionToken;
+                else _kind = SyntaxKind.DollarToken;
+                break;
             case ':':
                 _position++;
                 if (AdvanceIfMatches(':')) _kind = SyntaxKind.ColonColonToken;

--- a/src/Buckle/Compiler/CodeAnalysis/Syntax/SyntaxFacts.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Syntax/SyntaxFacts.cs
@@ -99,6 +99,8 @@ public static class SyntaxFacts {
             case SyntaxKind.TildeToken:
             case SyntaxKind.AmpersandToken:
             case SyntaxKind.AsteriskToken:
+            case SyntaxKind.DollarToken:
+            case SyntaxKind.DollarQuestionToken:
                 return 17;
             default:
                 return 0;
@@ -259,6 +261,8 @@ public static class SyntaxFacts {
             SyntaxKind.QuestionOpenBracketToken => "?[",
             SyntaxKind.HashToken => "#",
             SyntaxKind.MinusGreaterThanToken => "->",
+            SyntaxKind.DollarToken => "$",
+            SyntaxKind.DollarQuestionToken => "$?",
             SyntaxKind.TrueKeyword => "true",
             SyntaxKind.FalseKeyword => "false",
             SyntaxKind.NullKeyword => "null",

--- a/src/Buckle/Compiler/CodeAnalysis/Syntax/SyntaxKind.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Syntax/SyntaxKind.cs
@@ -35,6 +35,7 @@ public enum SyntaxKind : ushort {
     ColonColonToken,
     PeriodToken,
     HashToken,
+    DollarToken,
 
     // Compound punctuation
     PipePipeToken,
@@ -66,6 +67,7 @@ public enum SyntaxKind : ushort {
     QuestionPeriodToken,
     QuestionOpenBracketToken,
     MinusGreaterThanToken,
+    DollarQuestionToken,
 
     // Keywords
     TypeOfKeyword,

--- a/src/Buckle/Compiler/Diagnostics/DiagnosticCode.cs
+++ b/src/Buckle/Compiler/Diagnostics/DiagnosticCode.cs
@@ -365,6 +365,7 @@ public enum DiagnosticCode : ushort {
     ERR_FixedFieldMustNotBeRef = 354,
     ERR_IllegalFixedType = 355,
     ERR_NullptrNoTargetType = 356,
+    ERR_InvalidCompileTimeExpression = 357,
 
     // Carving out >=9000 for unsupported errors
     UNS_IndependentCompilation = 9000,

--- a/src/Buckle/Compiler/Diagnostics/Error.cs
+++ b/src/Buckle/Compiler/Diagnostics/Error.cs
@@ -1723,6 +1723,11 @@ internal static class Error {
         return CreateError(DiagnosticCode.ERR_IllegalFixedType, location, message);
     }
 
+    internal static BelteDiagnostic InvalidCompileTimeExpression(TextLocation location) {
+        var message = $"expression is not computable at compile time";
+        return CreateError(DiagnosticCode.ERR_InvalidCompileTimeExpression, location, message);
+    }
+
     private static DiagnosticInfo ErrorInfo(DiagnosticCode code) {
         return new DiagnosticInfo((int)code, "BU", DiagnosticSeverity.Error);
     }


### PR DESCRIPTION
# Description

Ability to manually call the Evaluator at compile-time to evaluate an arbitrary expression. This is done using the `$` or `$?` unary operators, the latter silently continuing on error.

E.g.

```cs
var myInt = $Add(4, 5); // Lowers to `var myInt = 9;`

int Add(int x, int y) {
  return x + y;
}
```

More info in the docs.