### PR TITLE
Rw/preprocessor

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,9 +8,8 @@
             "preLaunchTask": "build compiler debug",
             "program": "${workspaceFolder}/src/Buckle/CommandLine/bin/Debug/net10.0/CommandLine.dll",
             "args": [
-                // "-r",
-                // "--clearsubmissions",
-                ".tmp/test.blt"
+                "-r",
+                "--clearsubmissions",
             ],
             "cwd": "${workspaceFolder}",
             "console": "externalTerminal",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,8 +8,9 @@
             "preLaunchTask": "build compiler debug",
             "program": "${workspaceFolder}/src/Buckle/CommandLine/bin/Debug/net10.0/CommandLine.dll",
             "args": [
-                "-r",
-                "--clearsubmissions",
+                // "-r",
+                // "--clearsubmissions",
+                ".tmp/test.blt"
             ],
             "cwd": "${workspaceFolder}",
             "console": "externalTerminal",

--- a/docs/Current/Preprocessor.md
+++ b/docs/Current/Preprocessor.md
@@ -1,0 +1,51 @@
+# 7 Preprocessor Directives
+
+A very limited set of preprocessor directives exist, primarily to determine
+whether or not a program was compiled in debug mode.
+
+> Note: The REPL disables preprocessor directives completely in place of [REPL-specific commands](../Repl.md#repl-meta-commands)
+
+- [7.1](#71-defineundef) Define/Undef
+- [7.2](#72-control) Control
+
+## 7.1 Define/Undef
+
+Use `#define <name>` to define a constant. Use `#undef <name>` to remove that
+constant. Constants do not have values that are textually replaced by the
+preprocessor like in C, but rather exist as flags to determine whether or not
+something is true.
+
+```belte
+#define SOME_CONSTANT
+
+#if SOME_CONSTANT
+
+...
+
+#endif
+```
+
+When building debug mode, `DEBUG` is defined. Otherwise, `RELEASE` is defined.
+
+## 7.2 Control
+
+`#if`, `#elif`, `#else`, and `#endif` can be used to conditionally include
+certain pieces of source.
+
+For example:
+
+```belte
+#define SOME_CONSTANT
+
+#if SOME_CONSTANT
+
+Console.PrintLine("SOME_CONSTANT is defined");
+
+#else
+
+Console.PrintLine("SOME_CONSTANT is not defined");
+
+#endif
+```
+
+In this example, only the first print call is compiled.

--- a/docs/README.md
+++ b/docs/README.md
@@ -66,6 +66,9 @@
     - [6.9](Current/LowLevelFeatures.md#69-sizeof-operator) Sizeof Operator
     - [6.10](Current/LowLevelFeatures.md#610-stackalloc-operator) Stackalloc Operator
     - [6.11](Current/LowLevelFeatures.md#611-inline-il) Inline IL
+  - [7](Current/Preprocessor.md) Preprocessor Directives
+    - [7.1](Current/Preprocessor.md#71-defineundef) Define/Undef
+    - [7.2](Current/Preprocessor.md#72-control) Control
 
 ___
 

--- a/src/Buckle/Compiler.Tests/Diagnostics/DiagnosticTests.cs
+++ b/src/Buckle/Compiler.Tests/Diagnostics/DiagnosticTests.cs
@@ -4523,4 +4523,73 @@ public sealed class DiagnosticTests {
 
         AssertDiagnostics(text, diagnostics, _writer);
     }
+
+    // !
+    // TODO Fix diagnostic locations for directives
+    // [Fact]
+    // public void Reports_Error_BU0374_InvalidDirectivePlacement() {
+    //     var text = @"
+    //         int a = 3; [#if]
+    //     ";
+
+    //     var diagnostics = @"
+    //         preprocessor directives must appear as the first non-whitespace character on a line
+    //     ";
+
+    //     AssertDiagnostics(text, diagnostics, _writer);
+    // }
+
+    // [Fact]
+    // public void Reports_Error_BU0375_EndifDirectiveExpected() {
+    //     var text = @"
+    //         #if ASDF[]
+    //     ";
+
+    //     var diagnostics = @"
+    //         #endif directive expected
+    //     ";
+
+    //     AssertDiagnostics(text, diagnostics, _writer);
+    // }
+
+    // [Fact]
+    // public void Reports_Error_BU0376_UnexpectedDirective() {
+    //     var text = @"
+    //         [#asdf]
+    //     ";
+
+    //     var diagnostics = @"
+    //         unexpected preprocessor directive
+    //     ";
+
+    //     AssertDiagnostics(text, diagnostics, _writer);
+    // }
+
+    // [Fact]
+    // public void Reports_Error_BU0377_DirectiveFollowsToken() {
+    //     var text = @"
+    //         int a = 3;
+    //         [#define] ASDF
+    //     ";
+
+    //     var diagnostics = @"
+    //         cannot define/undefine preprocessor symbols after first token in file
+    //     ";
+
+    //     AssertDiagnostics(text, diagnostics, _writer);
+    // }
+
+    // [Fact]
+    // public void Reports_Error_BU0378_InvalidDirectiveExpression() {
+    //     var text = @"
+    //         #if [3]
+    //         #endif
+    //     ";
+
+    //     var diagnostics = @"
+    //         invalid preprocessor expression
+    //     ";
+
+    //     AssertDiagnostics(text, diagnostics, _writer);
+    // }
 }

--- a/src/Buckle/Compiler/CodeAnalysis/Compilation/ParseOptions.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Compilation/ParseOptions.cs
@@ -1,0 +1,11 @@
+using System.Collections.Immutable;
+
+namespace Buckle.CodeAnalysis;
+
+public sealed class ParseOptions {
+    internal ParseOptions(ImmutableArray<string> preprocessorSymbols) {
+        this.preprocessorSymbols = preprocessorSymbols;
+    }
+
+    public ImmutableArray<string> preprocessorSymbols { get; }
+}

--- a/src/Buckle/Compiler/CodeAnalysis/Evaluating/Interpreter.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Evaluating/Interpreter.cs
@@ -33,7 +33,7 @@ internal sealed class Interpreter {
         // code. This is not perfect, as the goal is to be a "true" interpreter, but without doing this at once the
         // parser would have to be written to support partial parsing. This would be a large undertaking, but maybe
         // could be done in the future.
-        var parsedSyntaxTree = SyntaxTree.Parse(syntaxTree.text);
+        var parsedSyntaxTree = SyntaxTree.Parse(syntaxTree.text, syntaxTree.options);
         // This represents how much of the text has been evaluated. For diagnostics to have the correct location, each
         // compilation needs to have a copy of the text starting at this index.
         var textOffset = 0;
@@ -56,7 +56,8 @@ internal sealed class Interpreter {
                     root.usings,
                     new SyntaxList<MemberDeclarationSyntax>(member),
                     parsedSyntaxTree.endOfFile
-                )
+                ),
+                syntaxTree.options
             );
 
             previous = Compilation.CreateScript("interpreter", options, newSyntaxTree, previous);

--- a/src/Buckle/Compiler/CodeAnalysis/Parser/DefineState.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Parser/DefineState.cs
@@ -1,0 +1,8 @@
+
+namespace Buckle.CodeAnalysis.Syntax.InternalSyntax;
+
+internal enum DefineState : byte {
+    Defined,
+    Undefined,
+    Unspecified
+}

--- a/src/Buckle/Compiler/CodeAnalysis/Parser/Directive.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Parser/Directive.cs
@@ -9,4 +9,21 @@ internal class Directive {
     }
 
     internal SyntaxKind kind => _node.kind;
+
+    internal bool branchTaken {
+        get {
+            if (_node is BranchingDirectiveTriviaSyntax branching)
+                return branching.branchTaken;
+
+            return false;
+        }
+    }
+
+    internal string GetIdentifier() {
+        return _node.kind switch {
+            SyntaxKind.DefineDirectiveTrivia => ((DefineDirectiveTriviaSyntax)_node).name.text,
+            SyntaxKind.UndefDirectiveTrivia => ((UndefDirectiveTriviaSyntax)_node).name.text,
+            _ => null,
+        };
+    }
 }

--- a/src/Buckle/Compiler/CodeAnalysis/Parser/DirectiveParser.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Parser/DirectiveParser.cs
@@ -1,3 +1,4 @@
+using Buckle.Diagnostics;
 
 namespace Buckle.CodeAnalysis.Syntax.InternalSyntax;
 
@@ -9,21 +10,45 @@ internal sealed class DirectiveParser : SyntaxParser {
         _context = context;
     }
 
-    internal BelteSyntaxNode ParseDirective(bool isAfterFirstTokenInFile, bool isAfterNonWhitespaceOnLine) {
-        // TODO Implement after directives are added
+    internal BelteSyntaxNode ParseDirective(
+        bool isActive,
+        bool endIsActive,
+        bool isAfterFirstTokenInFile,
+        bool isAfterNonWhitespaceOnLine) {
         var position = _lexer.position;
         var hash = Match(SyntaxKind.HashToken);
 
-        if (isAfterNonWhitespaceOnLine) {
-            // hash = AddDiagnostic(hash, Error.InvalidDirectivePlacement());
-        }
+        if (isAfterNonWhitespaceOnLine)
+            hash = AddDiagnostic(hash, Error.InvalidDirectivePlacement());
 
         BelteSyntaxNode result;
         switch (currentToken.kind) {
+            case SyntaxKind.IfKeyword:
+                result = ParseIfDirective(hash, EatToken(), isActive);
+                break;
+            case SyntaxKind.ElifKeyword:
+                result = ParseElifDirective(hash, EatToken(), isActive, endIsActive);
+                break;
+            case SyntaxKind.ElseKeyword:
+                result = ParseElseDirective(hash, EatToken(), isActive, endIsActive);
+                break;
+            case SyntaxKind.EndifKeyword:
+                result = ParseEndIfDirective(hash, EatToken(), isActive, endIsActive);
+                break;
+            case SyntaxKind.DefineKeyword:
+            case SyntaxKind.UndefKeyword:
+                result = ParseDefineOrUndefDirective(
+                    hash,
+                    EatToken(),
+                    isActive,
+                    isAfterFirstTokenInFile && !isAfterNonWhitespaceOnLine
+                );
+
+                break;
             default:
                 var identifier = Match(SyntaxKind.IdentifierToken);
                 var end = ParseEndOfDirective();
-                result = SyntaxFactory.BadDirectiveTrivia(hash, identifier, end);
+                result = SyntaxFactory.BadDirectiveTrivia(hash, identifier, end, isActive);
                 break;
         }
 
@@ -53,5 +78,223 @@ internal sealed class DirectiveParser : SyntaxParser {
         }
 
         return endOfDirective;
+    }
+
+    private DirectiveTriviaSyntax ParseElseDirective(SyntaxToken hash, SyntaxToken keyword, bool isActive, bool endIsActive) {
+        var eod = ParseEndOfDirective();
+
+        if (_context.HasPreviousIfOrElif()) {
+            var branchTaken = endIsActive && !_context.PreviousBranchTaken();
+            return SyntaxFactory.ElseDirectiveTrivia(hash, keyword, eod, endIsActive, branchTaken);
+        } else if (_context.HasUnfinishedIf()) {
+            return AddDiagnostic(
+                SyntaxFactory.BadDirectiveTrivia(hash, keyword, eod, isActive),
+                Error.EndifDirectiveExpected()
+            );
+        } else {
+            return AddDiagnostic(
+                SyntaxFactory.BadDirectiveTrivia(hash, keyword, eod, isActive),
+                Error.UnexpectedDirective()
+            );
+        }
+    }
+
+    private DirectiveTriviaSyntax ParseEndIfDirective(SyntaxToken hash, SyntaxToken keyword, bool isActive, bool endIsActive) {
+        var eod = ParseEndOfDirective();
+
+        if (_context.HasUnfinishedIf()) {
+            return SyntaxFactory.EndIfDirectiveTrivia(hash, keyword, eod, endIsActive);
+        } else {
+            return AddDiagnostic(
+                SyntaxFactory.BadDirectiveTrivia(hash, keyword, eod, isActive),
+                Error.UnexpectedDirective()
+            );
+        }
+    }
+
+    private DirectiveTriviaSyntax ParseIfDirective(SyntaxToken hash, SyntaxToken keyword, bool isActive) {
+        var expr = ParseExpression();
+        var eod = ParseEndOfDirective();
+        var isTrue = EvaluateBool(expr);
+        var branchTaken = isTrue;
+        return SyntaxFactory.IfDirectiveTrivia(hash, keyword, expr, eod, isActive, branchTaken, isTrue);
+    }
+
+    private DirectiveTriviaSyntax ParseElifDirective(SyntaxToken hash, SyntaxToken keyword, bool isActive, bool endIsActive) {
+        var expr = ParseExpression();
+        var eod = ParseEndOfDirective();
+
+        if (_context.HasPreviousIfOrElif()) {
+            var isTrue = EvaluateBool(expr);
+            var branchTaken = endIsActive && isTrue && !_context.PreviousBranchTaken();
+            return SyntaxFactory.ElifDirectiveTrivia(hash, keyword, expr, eod, endIsActive, branchTaken, isTrue);
+        } else {
+            eod = eod.TokenWithLeadingTrivia(
+                SyntaxList.Concat(SyntaxFactory.DisabledText(expr.ToString()), eod.GetLeadingTrivia())
+            );
+
+            if (_context.HasUnfinishedIf()) {
+                return AddDiagnostic(
+                    SyntaxFactory.BadDirectiveTrivia(hash, keyword, eod, isActive),
+                    Error.EndifDirectiveExpected()
+                );
+            } else {
+                return AddDiagnostic(
+                    SyntaxFactory.BadDirectiveTrivia(hash, keyword, eod, isActive),
+                    Error.UnexpectedDirective()
+                );
+            }
+        }
+    }
+
+    private DirectiveTriviaSyntax ParseDefineOrUndefDirective(
+        SyntaxToken hash,
+        SyntaxToken keyword,
+        bool isActive,
+        bool isFollowingToken) {
+        if (isFollowingToken)
+            keyword = AddDiagnostic(keyword, Error.DirectiveFollowsToken());
+
+        var name = Match(SyntaxKind.IdentifierToken);
+        var end = ParseEndOfDirective();
+
+        if (keyword.kind == SyntaxKind.DefineKeyword)
+            return SyntaxFactory.DefineDirectiveTrivia(hash, keyword, name, end, isActive);
+        else
+            return SyntaxFactory.UndefDirectiveTrivia(hash, keyword, name, end, isActive);
+    }
+
+    private ExpressionSyntax ParseExpression() {
+        return ParseLogicalOr();
+    }
+
+    private ExpressionSyntax ParseLogicalOr() {
+        var left = ParseLogicalAnd();
+
+        while (currentToken.kind == SyntaxKind.PipePipeToken) {
+            var op = EatToken();
+            var right = ParseLogicalAnd();
+            left = SyntaxFactory.BinaryExpression(left, op, right);
+        }
+
+        return left;
+    }
+
+    private ExpressionSyntax ParseLogicalAnd() {
+        var left = ParseEquality();
+
+        while (currentToken.kind == SyntaxKind.AmpersandAmpersandToken) {
+            var op = EatToken();
+            var right = ParseEquality();
+            left = SyntaxFactory.BinaryExpression(left, op, right);
+        }
+
+        return left;
+    }
+
+    private ExpressionSyntax ParseEquality() {
+        var left = ParseLogicalNot();
+
+        while (currentToken.kind is SyntaxKind.EqualsEqualsToken or SyntaxKind.ExclamationEqualsToken) {
+            var op = EatToken();
+            var right = ParseEquality();
+            left = SyntaxFactory.BinaryExpression(left, op, right);
+        }
+
+        return left;
+    }
+
+    private ExpressionSyntax ParseLogicalNot() {
+        if (currentToken.kind == SyntaxKind.ExclamationToken) {
+            var op = EatToken();
+            return SyntaxFactory.UnaryExpression(op, ParseLogicalNot());
+        }
+
+        return ParsePrimary();
+    }
+
+    private ExpressionSyntax ParsePrimary() {
+        var k = currentToken.kind;
+
+        switch (k) {
+            case SyntaxKind.OpenParenToken:
+                var open = EatToken();
+                var expr = ParseExpression();
+                var close = Match(SyntaxKind.CloseParenToken);
+                return SyntaxFactory.ParenthesisExpression(open, expr, close);
+            case SyntaxKind.IdentifierToken:
+                var identifier = EatToken();
+                return SyntaxFactory.IdentifierName(identifier);
+            case SyntaxKind.TrueKeyword:
+            case SyntaxKind.FalseKeyword:
+                return SyntaxFactory.LiteralExpression(EatToken());
+            default:
+                return SyntaxFactory.IdentifierName(
+                    WithAdditionalDiagnostics(Match(SyntaxKind.IdentifierToken), Error.InvalidDirectiveExpression())
+                );
+        }
+    }
+
+    private bool EvaluateBool(ExpressionSyntax expr) {
+        var result = Evaluate(expr);
+
+        if (result is bool v)
+            return v;
+
+        return false;
+    }
+
+    private object Evaluate(ExpressionSyntax expr) {
+        switch (expr.kind) {
+            case SyntaxKind.ParenthesizedExpression:
+                return Evaluate(((ParenthesisExpressionSyntax)expr).expression);
+            case SyntaxKind.LiteralExpression:
+                return ((LiteralExpressionSyntax)expr).token.value;
+            case SyntaxKind.BinaryExpression:
+                var op = ((BinaryExpressionSyntax)expr).operatorToken;
+
+                switch (op.kind) {
+                    case SyntaxKind.AmpersandAmpersandToken:
+                    case SyntaxKind.AmpersandToken:
+                        return EvaluateBool(((BinaryExpressionSyntax)expr).left) && EvaluateBool(((BinaryExpressionSyntax)expr).right);
+                    case SyntaxKind.PipePipeToken:
+                    case SyntaxKind.PipeToken:
+                        return EvaluateBool(((BinaryExpressionSyntax)expr).left) || EvaluateBool(((BinaryExpressionSyntax)expr).right);
+                    case SyntaxKind.EqualsToken:
+                        return Equals(Evaluate(((BinaryExpressionSyntax)expr).left), Evaluate(((BinaryExpressionSyntax)expr).right));
+                    case SyntaxKind.ExclamationEqualsToken:
+                        return !Equals(Evaluate(((BinaryExpressionSyntax)expr).left), Evaluate(((BinaryExpressionSyntax)expr).right));
+                }
+
+                break;
+            case SyntaxKind.UnaryExpression:
+                if (((UnaryExpressionSyntax)expr).operand.kind == SyntaxKind.ExclamationToken)
+                    return !EvaluateBool(((UnaryExpressionSyntax)expr).operand);
+
+                break;
+            case SyntaxKind.IdentifierName:
+                var id = ((IdentifierNameSyntax)expr).identifier.text;
+
+                if (bool.TryParse(id, out var constantValue))
+                    return constantValue;
+
+                return IsDefined(id);
+        }
+
+        return false;
+    }
+
+    private bool IsDefined(string id) {
+        var defState = _context.IsDefined(id);
+
+        switch (defState) {
+            default:
+            case DefineState.Unspecified:
+                return options.preprocessorSymbols.Contains(id);
+            case DefineState.Defined:
+                return true;
+            case DefineState.Undefined:
+                return false;
+        }
     }
 }

--- a/src/Buckle/Compiler/CodeAnalysis/Parser/DirectiveStack.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Parser/DirectiveStack.cs
@@ -10,7 +10,77 @@ internal sealed class DirectiveStack {
         _directives = directives;
     }
 
+    internal DefineState IsDefined(string id) {
+        for (var current = _directives; current is not null && current.Any(); current = current.tail) {
+
+            switch (current.head.kind) {
+                case SyntaxKind.DefineDirectiveTrivia:
+                    if (current.head.GetIdentifier() == id)
+                        return DefineState.Defined;
+
+                    break;
+                case SyntaxKind.UndefDirectiveTrivia:
+                    if (current.head.GetIdentifier() == id)
+                        return DefineState.Undefined;
+
+                    break;
+                case SyntaxKind.ElifDirectiveTrivia:
+                case SyntaxKind.ElseDirectiveTrivia:
+                    do {
+                        current = current.tail;
+
+                        if (current is null || !current.Any())
+                            return DefineState.Unspecified;
+                    } while (current.head.kind != SyntaxKind.IfDirectiveTrivia);
+
+                    break;
+            }
+        }
+
+        return DefineState.Unspecified;
+    }
+
     internal DirectiveStack Add(Directive directive) {
         return new DirectiveStack(new ConsList<Directive>(directive, _directives ?? ConsList<Directive>.Empty));
+    }
+
+    internal bool HasUnfinishedIf() {
+        var prev = GetPreviousIfElifElseOrRegion(_directives);
+        return prev != null && prev.Any();
+    }
+
+    internal bool HasPreviousIfOrElif() {
+        var prev = GetPreviousIfElifElseOrRegion(_directives);
+        return prev is not null && prev.Any() &&
+            (prev.head.kind is SyntaxKind.IfDirectiveTrivia or SyntaxKind.ElifDirectiveTrivia);
+    }
+
+    internal bool PreviousBranchTaken() {
+        for (var current = _directives; current is not null && current.Any(); current = current.tail) {
+            if (current.head.branchTaken) {
+                return true;
+            } else if (current.head.kind == SyntaxKind.IfDirectiveTrivia) {
+                return false;
+            }
+        }
+
+        return false;
+    }
+
+    private static ConsList<Directive>? GetPreviousIfElifElseOrRegion(ConsList<Directive> directives) {
+        var current = directives;
+
+        while (current is not null && current.Any()) {
+            switch (current.head.kind) {
+                case SyntaxKind.IfDirectiveTrivia:
+                case SyntaxKind.ElifDirectiveTrivia:
+                case SyntaxKind.ElseDirectiveTrivia:
+                    return current;
+            }
+
+            current = current.tail;
+        }
+
+        return current;
     }
 }

--- a/src/Buckle/Compiler/CodeAnalysis/Parser/Lexer.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Parser/Lexer.cs
@@ -35,8 +35,9 @@ internal sealed class Lexer : IDisposable {
     /// <summary>
     /// Creates a new <see cref="Lexer" />
     /// </summary>
-    internal Lexer(SourceText text, bool allowPreprocessorDirectives) {
+    internal Lexer(SourceText text, ParseOptions parseOptions, bool allowPreprocessorDirectives) {
         this.text = text;
+        options = parseOptions;
         _allowPreprocessorDirectives = allowPreprocessorDirectives;
         _diagnostics = [];
         _directives = DirectiveStack.Empty;
@@ -54,6 +55,8 @@ internal sealed class Lexer : IDisposable {
     /// All lexed preprocessor directives so far.
     /// </summary>
     internal DirectiveStack directives => _directives;
+
+    internal ParseOptions options { get; }
 
     private char _current => Peek(0);
 
@@ -227,7 +230,7 @@ internal sealed class Lexer : IDisposable {
                     break;
                 case '#':
                     if (_allowPreprocessorDirectives)
-                        ReadDirective(afterFirstToken, isTrailing);
+                        ReadDirective(afterFirstToken, isTrailing, ref triviaList);
                     else
                         done = true;
 
@@ -809,16 +812,100 @@ internal sealed class Lexer : IDisposable {
         _kind = SyntaxKind.EndOfLineTrivia;
     }
 
-    private void ReadDirective(bool afterFirstToken, bool afterNonWhitespaceOnLine) {
+    private void ReadDirective(bool afterFirstToken, bool afterNonWhitespaceOnLine, ref SyntaxListBuilder triviaList) {
+        var directive = ReadDirective(true, true, afterFirstToken, afterNonWhitespaceOnLine);
+
+        if (directive is BranchingDirectiveTriviaSyntax branching && !branching.branchTaken)
+            ReadExcludedDirectivesAndTrivia(true, ref triviaList);
+    }
+
+    private void ReadExcludedDirectivesAndTrivia(bool endIsActive, ref SyntaxListBuilder triviaList) {
+        while (true) {
+            var text = ReadDisabledText(out var hasFollowingDirective);
+
+            if (text is not null)
+                triviaList.Add(text);
+
+            if (!hasFollowingDirective)
+                break;
+
+            var directive = ReadDirective(false, endIsActive, false, false);
+            var branching = directive as BranchingDirectiveTriviaSyntax;
+
+            if (directive.kind == SyntaxKind.EndIfDirectiveTrivia || (branching is not null && branching.branchTaken))
+                break;
+            else if (directive.kind == SyntaxKind.IfDirectiveTrivia)
+                ReadExcludedDirectivesAndTrivia(false, ref triviaList);
+        }
+    }
+
+    private BelteSyntaxNode ReadDisabledText(out bool followedByDirective) {
+        var lastLineStart = _position;
+        var lines = 0;
+        var allWhitespace = true;
+        var sb = new StringBuilder();
+
+        while (true) {
+            var ch = _current;
+
+            switch (ch) {
+                case '\0':
+                    followedByDirective = false;
+                    return _position > lastLineStart ? SyntaxFactory.DisabledText(sb.ToString()) : null;
+                case '#':
+                    if (!_allowPreprocessorDirectives)
+                        goto default;
+
+                    followedByDirective = true;
+
+                    if (lastLineStart < _position && !allWhitespace)
+                        goto default;
+
+                    var delta = _position - lastLineStart;
+                    _position = lastLineStart;
+                    return delta > 0 ? SyntaxFactory.DisabledText(sb.ToString()) : null;
+                case '\r':
+                case '\n':
+                    sb.Append(ch);
+
+                    if (Peek(1) == '\n')
+                        sb.Append(Peek(1));
+
+                    ReadLineBreak();
+                    lastLineStart = _position;
+                    allWhitespace = true;
+                    lines++;
+                    break;
+                default:
+                    allWhitespace = allWhitespace && char.IsWhiteSpace(ch);
+                    sb.Append(ch);
+                    _position++;
+                    break;
+            }
+        }
+    }
+
+    private BelteSyntaxNode ReadDirective(
+        bool isActive,
+        bool endIsActive,
+        bool afterFirstToken,
+        bool afterNonWhitespaceOnLine) {
         var saveMode = _mode;
         var directiveParser = new DirectiveParser(this, _directives);
-        var directive = directiveParser.ParseDirective(afterFirstToken, afterNonWhitespaceOnLine);
+        var directive = directiveParser.ParseDirective(
+            isActive,
+            endIsActive,
+            afterFirstToken,
+            afterNonWhitespaceOnLine
+        );
 
         var triviaList = afterNonWhitespaceOnLine ? _trailingTriviaCache : _leadingTriviaCache;
         triviaList.Add(directive);
 
         _directives = directive.ApplyDirectives(_directives);
         _mode = saveMode;
+
+        return directive;
     }
 
     private void ReadDirectiveTrailingTrivia(bool includeEndOfLine) {

--- a/src/Buckle/Compiler/CodeAnalysis/Parser/SyntaxParser.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Parser/SyntaxParser.cs
@@ -71,6 +71,8 @@ internal abstract partial class SyntaxParser : IDisposable {
 
     internal DirectiveStack directives => _lexer.directives;
 
+    internal ParseOptions options => _lexer.options;
+
     public void Dispose() { }
 
     private void PreLex() {

--- a/src/Buckle/Compiler/CodeAnalysis/Syntax/BelteSyntaxNode.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Syntax/BelteSyntaxNode.cs
@@ -23,7 +23,7 @@ public abstract class BelteSyntaxNode : SyntaxNode {
 
     internal abstract void Accept(SyntaxVisitor visitor);
 
-    private static SyntaxTree ComputeSyntaxTree(BelteSyntaxNode node) {
+    private static SyntaxTree ComputeSyntaxTree(BelteSyntaxNode node, ParseOptions options = null) {
         ArrayBuilder<BelteSyntaxNode> nodes = null;
         SyntaxTree tree;
 
@@ -36,7 +36,7 @@ public abstract class BelteSyntaxNode : SyntaxNode {
             var parent = node.parent;
 
             if (parent is null) {
-                Interlocked.CompareExchange(ref node._syntaxTree, SyntaxTree.CreateWithoutClone(node), null);
+                Interlocked.CompareExchange(ref node._syntaxTree, SyntaxTree.CreateWithoutClone(node, options), null);
                 tree = node._syntaxTree;
                 break;
             }

--- a/src/Buckle/Compiler/CodeAnalysis/Syntax/InternalSyntax/SyntaxFactory.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Syntax/InternalSyntax/SyntaxFactory.cs
@@ -59,6 +59,13 @@ internal static partial class SyntaxFactory {
     }
 
     /// <summary>
+    /// Creates a disabled text <see cref="SyntaxTrivia"/>.
+    /// </summary>
+    internal static SyntaxTrivia DisabledText(string text) {
+        return new SyntaxTrivia(SyntaxKind.DisabledTextTrivia, text);
+    }
+
+    /// <summary>
     /// Creates a missing <see cref="SyntaxToken" />.
     /// </summary>
     internal static SyntaxToken Missing(SyntaxKind kind) {

--- a/src/Buckle/Compiler/CodeAnalysis/Syntax/Syntax.xml
+++ b/src/Buckle/Compiler/CodeAnalysis/Syntax/Syntax.xml
@@ -222,6 +222,107 @@
     <Field Name="endOfDirective" Type="SyntaxToken" Override="true">
       <Kind Name="EndOfDirectiveToken" />
     </Field>
+    <Field Name="isActive" Type="bool" Override="true"/>
+  </Node>
+  <AbstractNode Name="BranchingDirectiveTriviaSyntax" Base="DirectiveTriviaSyntax">
+    <Field Name="isActive" Type="bool" Override="true"/>
+    <Field Name="branchTaken" Type="bool"/>
+  </AbstractNode>
+  <AbstractNode Name="ConditionalDirectiveTriviaSyntax" Base="BranchingDirectiveTriviaSyntax">
+    <Field Name="condition" Type="ExpressionSyntax"/>
+    <Field Name="isActive" Type="bool" Override="true"/>
+    <Field Name="conditionValue" Type="bool"/>
+  </AbstractNode>
+  <Node Name="IfDirectiveTriviaSyntax" Base="ConditionalDirectiveTriviaSyntax">
+    <Kind Name="IfDirectiveTrivia"/>
+    <Field Name="hash" Type="SyntaxToken" Override="true">
+      <Kind Name="HashToken"/>
+    </Field>
+    <Field Name="ifKeyword" Type="SyntaxToken">
+      <Kind Name="IfKeyword"/>
+    </Field>
+    <Field Name="condition" Type="ExpressionSyntax" Override="true"/>
+    <Field Name="endOfDirective" Type="SyntaxToken" Override="true">
+      <Kind Name="EndOfDirectiveToken"/>
+    </Field>
+    <Field Name="isActive" Type="bool" Override="true"/>
+    <Field Name="branchTaken" Type="bool" Override="true"/>
+    <Field Name="conditionValue" Type="bool" Override="true"/>
+  </Node>
+  <Node Name="ElifDirectiveTriviaSyntax" Base="ConditionalDirectiveTriviaSyntax">
+    <Kind Name="ElifDirectiveTrivia"/>
+    <Field Name="hash" Type="SyntaxToken" Override="true">
+      <Kind Name="HashToken"/>
+    </Field>
+    <Field Name="elifKeyword" Type="SyntaxToken">
+      <Kind Name="ElifKeyword"/>
+    </Field>
+    <Field Name="condition" Type="ExpressionSyntax" Override="true"/>
+    <Field Name="endOfDirective" Type="SyntaxToken" Override="true">
+      <Kind Name="EndOfDirectiveToken"/>
+    </Field>
+    <Field Name="isActive" Type="bool" Override="true"/>
+    <Field Name="branchTaken" Type="bool" Override="true"/>
+    <Field Name="conditionValue" Type="bool" Override="true"/>
+  </Node>
+  <Node Name="ElseDirectiveTriviaSyntax" Base="BranchingDirectiveTriviaSyntax">
+    <Kind Name="ElseDirectiveTrivia"/>
+    <Field Name="hash" Type="SyntaxToken" Override="true">
+      <Kind Name="HashToken"/>
+    </Field>
+    <Field Name="elseKeyword" Type="SyntaxToken">
+      <Kind Name="ElseKeyword"/>
+    </Field>
+    <Field Name="endOfDirective" Type="SyntaxToken" Override="true">
+      <Kind Name="EndOfDirectiveToken"/>
+    </Field>
+    <Field Name="isActive" Type="bool" Override="true"/>
+    <Field Name="branchTaken" Type="bool" Override="true"/>
+  </Node>
+  <Node Name="EndIfDirectiveTriviaSyntax" Base="DirectiveTriviaSyntax">
+    <Kind Name="EndIfDirectiveTrivia"/>
+    <Field Name="hash" Type="SyntaxToken" Override="true">
+      <Kind Name="HashToken"/>
+    </Field>
+    <Field Name="endIfKeyword" Type="SyntaxToken">
+      <Kind Name="EndifKeyword"/>
+    </Field>
+    <Field Name="endOfDirective" Type="SyntaxToken" Override="true">
+      <Kind Name="EndOfDirectiveToken"/>
+    </Field>
+    <Field Name="isActive" Type="bool" Override="true"/>
+  </Node>
+  <Node Name="DefineDirectiveTriviaSyntax" Base="DirectiveTriviaSyntax">
+    <Kind Name="DefineDirectiveTrivia"/>
+    <Field Name="hash" Type="SyntaxToken" Override="true">
+      <Kind Name="HashToken"/>
+    </Field>
+    <Field Name="defineKeyword" Type="SyntaxToken">
+      <Kind Name="DefineKeyword"/>
+    </Field>
+    <Field Name="name" Type="SyntaxToken">
+      <Kind Name="IdentifierToken"/>
+    </Field>
+    <Field Name="endOfDirective" Type="SyntaxToken" Override="true">
+      <Kind Name="EndOfDirectiveToken"/>
+    </Field>
+    <Field Name="isActive" Type="bool" Override="true"/>
+  </Node>
+  <Node Name="UndefDirectiveTriviaSyntax" Base="DirectiveTriviaSyntax">
+    <Kind Name="UndefDirectiveTrivia"/>
+    <Field Name="hash" Type="SyntaxToken" Override="true">
+      <Kind Name="HashToken"/>
+    </Field>
+    <Field Name="undefKeyword" Type="SyntaxToken">
+      <Kind Name="UndefKeyword"/>
+    </Field>
+    <Field Name="name" Type="SyntaxToken">
+      <Kind Name="IdentifierToken"/>
+    </Field>
+    <Field Name="endOfDirective" Type="SyntaxToken" Override="true">
+      <Kind Name="EndOfDirectiveToken"/>
+    </Field>
+    <Field Name="isActive" Type="bool" Override="true"/>
   </Node>
   <Node Name="UsingDirectiveSyntax" Base="SyntaxNode">
     <Kind Name="UsingDirective"/>

--- a/src/Buckle/Compiler/CodeAnalysis/Syntax/SyntaxFactory.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Syntax/SyntaxFactory.cs
@@ -277,16 +277,17 @@ public static partial class SyntaxFactory {
         );
     }
 
-    public static CompilationUnitSyntax ParseCompilationUnit(string text, int offset = 0) {
-        using var lexer = MakeLexer(text, offset);
+    public static CompilationUnitSyntax ParseCompilationUnit(string text, int offset = 0, ParseOptions options = null) {
+        using var lexer = MakeLexer(text, offset, options);
         using var parser = MakeParser(lexer);
         var node = parser.ParseCompilationUnit();
         return (CompilationUnitSyntax)node.CreateRed();
     }
 
-    private static Lexer MakeLexer(string text, int offset) {
+    private static Lexer MakeLexer(string text, int offset, ParseOptions options) {
         return new Lexer(
             MakeSourceText(text, offset),
+            options,
             false
         );
     }

--- a/src/Buckle/Compiler/CodeAnalysis/Syntax/SyntaxFacts.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Syntax/SyntaxFacts.cs
@@ -207,6 +207,10 @@ public static class SyntaxFacts {
             "enum" => SyntaxKind.EnumKeyword,
             "il" => SyntaxKind.ILKeyword,
             "noverify" => SyntaxKind.NoVerifyKeyword,
+            "elif" => SyntaxKind.ElifKeyword,
+            "endif" => SyntaxKind.EndifKeyword,
+            "define" => SyntaxKind.DefineKeyword,
+            "undef" => SyntaxKind.UndefKeyword,
             _ => SyntaxKind.IdentifierToken,
         };
     }
@@ -335,6 +339,10 @@ public static class SyntaxFacts {
             SyntaxKind.EnumKeyword => "enum",
             SyntaxKind.ILKeyword => "il",
             SyntaxKind.NoVerifyKeyword => "noverify",
+            SyntaxKind.ElifKeyword => "elif",
+            SyntaxKind.EndifKeyword => "endif",
+            SyntaxKind.DefineKeyword => "define",
+            SyntaxKind.UndefKeyword => "undef",
             _ => null,
         };
     }

--- a/src/Buckle/Compiler/CodeAnalysis/Syntax/SyntaxKind.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Syntax/SyntaxKind.cs
@@ -130,6 +130,10 @@ public enum SyntaxKind : ushort {
     EnumKeyword,
     ILKeyword,
     NoVerifyKeyword,
+    ElifKeyword,
+    EndifKeyword,
+    DefineKeyword,
+    UndefKeyword,
 
     // Tokens with text
     BadToken,
@@ -145,6 +149,13 @@ public enum SyntaxKind : ushort {
     MultiLineCommentTrivia,
     SkippedTokensTrivia,
     BadDirectiveTrivia,
+    IfDirectiveTrivia,
+    ElifDirectiveTrivia,
+    ElseDirectiveTrivia,
+    EndIfDirectiveTrivia,
+    DefineDirectiveTrivia,
+    UndefDirectiveTrivia,
+    DisabledTextTrivia,
 
     // Expressions
     ParenthesizedExpression,

--- a/src/Buckle/Compiler/CodeAnalysis/Syntax/SyntaxTree.DummySyntaxTree.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Syntax/SyntaxTree.DummySyntaxTree.cs
@@ -5,7 +5,7 @@ public partial class SyntaxTree {
     internal sealed class DummySyntaxTree : SyntaxTree {
         private readonly CompilationUnitSyntax _node;
 
-        internal DummySyntaxTree() : base(null, SourceCodeKind.Regular) {
+        internal DummySyntaxTree() : base(null, SourceCodeKind.Regular, null) {
             _node = CloneNodeAsRoot(SyntaxFactory.ParseCompilationUnit(""));
         }
 

--- a/src/Buckle/Compiler/CodeAnalysis/Syntax/SyntaxTree.ParsedSyntaxTree.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Syntax/SyntaxTree.ParsedSyntaxTree.cs
@@ -6,8 +6,13 @@ public partial class SyntaxTree {
     private class ParsedSyntaxTree : SyntaxTree {
         private readonly BelteSyntaxNode _root;
 
-        internal ParsedSyntaxTree(SourceText text, BelteSyntaxNode root, bool cloneRoot, SourceCodeKind kind)
-            : base(text, kind) {
+        internal ParsedSyntaxTree(
+            SourceText text,
+            BelteSyntaxNode root,
+            bool cloneRoot,
+            SourceCodeKind kind,
+            ParseOptions options)
+            : base(text, kind, options) {
             _root = cloneRoot ? CloneNodeAsRoot(root) : root;
             endOfFile = _root.GetLastToken(true);
         }

--- a/src/Buckle/Compiler/CodeAnalysis/Syntax/SyntaxTree.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Syntax/SyntaxTree.cs
@@ -13,24 +13,25 @@ namespace Buckle.CodeAnalysis.Syntax;
 public partial class SyntaxTree {
     internal static readonly SyntaxTree Dummy = new DummySyntaxTree();
 
-    internal SyntaxTree(SourceText text, SourceCodeKind kind) {
+    internal SyntaxTree(SourceText text, SourceCodeKind kind, ParseOptions options) {
         this.kind = kind;
         this.text = text;
+        this.options = options;
     }
 
     /// <summary>
     /// Creates a new <see cref="SyntaxTree" /> with the given node as the root.
     /// </summary>
-    internal static SyntaxTree Create(SourceText text, BelteSyntaxNode root) {
-        return new ParsedSyntaxTree(text, root, true, SourceCodeKind.Regular);
+    internal static SyntaxTree Create(SourceText text, BelteSyntaxNode root, ParseOptions options) {
+        return new ParsedSyntaxTree(text, root, true, SourceCodeKind.Regular, options);
     }
 
     /// <summary>
     /// Creates a new <see cref="SyntaxTree" /> with the given node as the root, but does not assign the
     /// given node's syntax tree.
     /// </summary>
-    internal static SyntaxTree CreateWithoutClone(BelteSyntaxNode root) {
-        return new ParsedSyntaxTree(null, root, false, SourceCodeKind.Regular);
+    internal static SyntaxTree CreateWithoutClone(BelteSyntaxNode root, ParseOptions options) {
+        return new ParsedSyntaxTree(null, root, false, SourceCodeKind.Regular, options);
     }
 
     /// <summary>
@@ -54,14 +55,19 @@ public partial class SyntaxTree {
     /// </summary>
     private protected virtual int _length => text.length;
 
+    internal ParseOptions options { get; }
+
     /// <summary>
     /// Parses text (not necessarily related to a source file).
     /// </summary>
     /// <param name="text">Text to generate <see cref="SyntaxTree" /> from.</param>
     /// <returns>Parsed result as <see cref="SyntaxTree" />.</returns>
-    public static SyntaxTree Parse(string text, SourceCodeKind kind = SourceCodeKind.Regular) {
+    public static SyntaxTree Parse(
+        string text,
+        ParseOptions options = null,
+        SourceCodeKind kind = SourceCodeKind.Regular) {
         var sourceText = SourceText.From(text);
-        return Parse(sourceText, kind);
+        return Parse(sourceText, options, kind);
     }
 
     public override string ToString() {
@@ -94,10 +100,10 @@ public partial class SyntaxTree {
     /// <param name="fileName">File name of source file.</param>
     /// <param name="text">Content of source file.</param>
     /// <returns>Parsed result as <see cref="SyntaxTree" />.</returns>
-    internal static SyntaxTree Load(string fileName, string text) {
+    internal static SyntaxTree Load(string fileName, string text, ParseOptions options) {
         var sourceText = SourceText.From(text, fileName);
 
-        return Parse(sourceText);
+        return Parse(sourceText, options);
     }
 
     /// <summary>
@@ -105,11 +111,11 @@ public partial class SyntaxTree {
     /// </summary>
     /// <param name="fileName">File name of source file.</param>
     /// <returns>Parsed result as <see cref="SyntaxTree" />.</returns>
-    internal static SyntaxTree Load(string fileName) {
+    internal static SyntaxTree Load(string fileName, ParseOptions options) {
         var text = File.ReadAllText(fileName);
         var sourceText = SourceText.From(text, fileName);
 
-        return Parse(sourceText);
+        return Parse(sourceText, options);
     }
 
     /// <summary>
@@ -117,11 +123,14 @@ public partial class SyntaxTree {
     /// </summary>
     /// <param name="text">Text to generate <see cref="SyntaxTree" /> from.</param>
     /// <returns>Parsed result as <see cref="SyntaxTree" />.</returns>
-    internal static SyntaxTree Parse(SourceText text, SourceCodeKind kind = SourceCodeKind.Regular) {
-        var lexer = new Lexer(text, kind == SourceCodeKind.Regular);
+    internal static SyntaxTree Parse(
+        SourceText text,
+        ParseOptions options,
+        SourceCodeKind kind = SourceCodeKind.Regular) {
+        var lexer = new Lexer(text, options, kind == SourceCodeKind.Regular);
         var parser = new LanguageParser(lexer);
         var compilationUnit = (CompilationUnitSyntax)parser.ParseCompilationUnit().CreateRed();
-        var parsedTree = new ParsedSyntaxTree(text, compilationUnit, true, kind);
+        var parsedTree = new ParsedSyntaxTree(text, compilationUnit, true, kind, options);
         return parsedTree;
     }
 
@@ -188,11 +197,11 @@ public partial class SyntaxTree {
             oldTree = null;
         }
 
-        var lexer = new Lexer(newText, kind == SourceCodeKind.Regular);
+        var lexer = new Lexer(newText, options, kind == SourceCodeKind.Regular);
         var parser = new LanguageParser(lexer, oldTree?.GetRoot(), workingChanges);
 
         var compilationUnit = (CompilationUnitSyntax)parser.ParseCompilationUnit().CreateRed();
-        var parsedTree = new ParsedSyntaxTree(newText, compilationUnit, true, kind);
+        var parsedTree = new ParsedSyntaxTree(newText, compilationUnit, true, kind, options);
         return parsedTree;
     }
 }

--- a/src/Buckle/Compiler/CodeAnalysis/Syntax/SyntaxTreeDiagnosticEnumerator.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Syntax/SyntaxTreeDiagnosticEnumerator.cs
@@ -74,9 +74,9 @@ tryAgain:
             if (slotIndex < node.slotCount - 1) {
                 slotIndex++;
                 var child = node.GetSlot(slotIndex);
-                if (child is null) {
+
+                if (child is null)
                     goto tryAgain;
-                }
 
                 if (!child.containsDiagnostics) {
                     _position += child.fullWidth;
@@ -86,9 +86,8 @@ tryAgain:
                 _stack.UpdateSlotIndexForStackTop(slotIndex);
                 _stack.PushNodeOrToken(child);
             } else {
-                if (node.slotCount == 0) {
+                if (node.slotCount == 0)
                     _position += node.width;
-                }
 
                 _stack.Pop();
             }

--- a/src/Buckle/Compiler/CodeAnalysis/Syntax/SyntaxTreeExtensions.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Syntax/SyntaxTreeExtensions.cs
@@ -29,9 +29,10 @@ public static class SyntaxTreeExtensions {
     /// <returns>SyntaxTokens in order.</returns>
     internal static InternalSyntax.SyntaxList<InternalSyntax.SyntaxToken> ParseTokens(
         SourceText text,
-        bool includeEOF = false) {
+        bool includeEOF = false,
+        ParseOptions options = null) {
         var tokens = new InternalSyntax.SyntaxListBuilder<InternalSyntax.SyntaxToken>(32);
-        var lexer = new Lexer(text, true);
+        var lexer = new Lexer(text, options, true);
 
         while (true) {
             var token = lexer.LexNext(LexerMode.Syntax);

--- a/src/Buckle/Compiler/CodeAnalysis/Text/SourceText.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Text/SourceText.cs
@@ -218,7 +218,7 @@ public abstract class SourceText {
     /// <param name="span"><see cref="TextSpan" /> to check.</param>
     /// <returns>If the <see cref="TextSpan" /> is at the end of the text.</returns>
     public bool IsAtEndOfInput(TextSpan span) {
-        if (span.start == length)
+        if (span.start >= length)
             return true;
 
         return false;

--- a/src/Buckle/Compiler/Compiler.cs
+++ b/src/Buckle/Compiler/Compiler.cs
@@ -184,7 +184,7 @@ public sealed class Compiler {
 
             ref var task = ref state.tasks[0];
             var sourceText = new StringText(task.inputFileName, task.fileContent.text);
-            var syntaxTree = new SyntaxTree(sourceText, SourceCodeKind.Regular);
+            var syntaxTree = new SyntaxTree(sourceText, SourceCodeKind.Regular, CreateParseOptions());
             task.stage = CompilerStage.Finished;
 
             var compilation = Compilation.CreateScript(state.moduleName, options, syntaxTree, corLibrary);
@@ -244,7 +244,7 @@ public sealed class Compiler {
             ref var task = ref tasks[i];
 
             if (task.stage == CompilerStage.Raw) {
-                var syntaxTree = SyntaxTree.Load(task.inputFileName, task.fileContent.text);
+                var syntaxTree = SyntaxTree.Load(task.inputFileName, task.fileContent.text, CreateParseOptions());
                 builder.Add(syntaxTree);
                 task.stage = stageToSet;
             }
@@ -303,5 +303,12 @@ public sealed class Compiler {
 
         wrapperThread.Start(abort);
         wrapperThread.Join();
+    }
+
+    private ParseOptions CreateParseOptions() {
+        if (state.debugMode)
+            return new ParseOptions(["DEBUG"]);
+        else
+            return new ParseOptions(["RELEASE"]);
     }
 }

--- a/src/Buckle/Compiler/Diagnostics/DiagnosticCode.cs
+++ b/src/Buckle/Compiler/Diagnostics/DiagnosticCode.cs
@@ -382,6 +382,11 @@ public enum DiagnosticCode : ushort {
     ERR_UnknownILOpCode = 371,
     ERR_InvalidILOperandKind = 372,
     ERR_InvalidILOperand = 373,
+    ERR_InvalidDirectivePlacement = 374,
+    ERR_EndifDirectiveExpected = 375,
+    ERR_UnexpectedDirective = 376,
+    ERR_DirectiveFollowsToken = 377,
+    ERR_InvalidDirectiveExpression = 378,
 
     // Carving out >=9000 for unsupported errors
     UNS_IndependentCompilation = 9000,

--- a/src/Buckle/Compiler/Diagnostics/Error.cs
+++ b/src/Buckle/Compiler/Diagnostics/Error.cs
@@ -1823,6 +1823,31 @@ internal static class Error {
         return CreateError(DiagnosticCode.ERR_InvalidILOperand, location, message);
     }
 
+    internal static Diagnostic InvalidDirectivePlacement() {
+        var message = $"preprocessor directives must appear as the first non-whitespace character on a line";
+        return CreateError(DiagnosticCode.ERR_InvalidDirectivePlacement, message);
+    }
+
+    internal static Diagnostic EndifDirectiveExpected() {
+        var message = $"#endif directive expected";
+        return CreateError(DiagnosticCode.ERR_EndifDirectiveExpected, message);
+    }
+
+    internal static Diagnostic UnexpectedDirective() {
+        var message = $"unexpected preprocessor directive";
+        return CreateError(DiagnosticCode.ERR_UnexpectedDirective, message);
+    }
+
+    internal static Diagnostic DirectiveFollowsToken() {
+        var message = $"cannot define/undefine preprocessor symbols after first token in file";
+        return CreateError(DiagnosticCode.ERR_DirectiveFollowsToken, message);
+    }
+
+    internal static Diagnostic InvalidDirectiveExpression() {
+        var message = $"invalid preprocessor expression";
+        return CreateError(DiagnosticCode.ERR_InvalidDirectiveExpression, message);
+    }
+
     private static DiagnosticInfo ErrorInfo(DiagnosticCode code) {
         return new DiagnosticInfo((int)code, "BU", DiagnosticSeverity.Error);
     }

--- a/src/Buckle/Compiler/Libraries/LibraryHelpers.cs
+++ b/src/Buckle/Compiler/Libraries/LibraryHelpers.cs
@@ -88,7 +88,7 @@ public static class LibraryHelpers {
             using var reader = new StreamReader(stream);
             var text = reader.ReadToEnd().TrimEnd();
 
-            var syntaxTree = SyntaxTree.Load(libraryName, text);
+            var syntaxTree = SyntaxTree.Load(libraryName, text, null);
             syntaxTrees.Add(syntaxTree);
         }
 

--- a/src/Buckle/Repl/BelteRepl.cs
+++ b/src/Buckle/Repl/BelteRepl.cs
@@ -200,7 +200,7 @@ public sealed partial class BelteRepl : Repl {
     private protected override void EvaluateSubmission(string text) {
         // ONLY use this when evaluating previous submissions, where incremental compilation would do nothing
         // Otherwise, this is much slower than the 0 arity overload
-        var syntaxTree = SyntaxTree.Parse(text, SourceCodeKind.Script);
+        var syntaxTree = SyntaxTree.Parse(text, null, SourceCodeKind.Script);
         EvaluateSubmissionInternal(syntaxTree);
     }
 
@@ -289,7 +289,7 @@ public sealed partial class BelteRepl : Repl {
     }
 
     private void ClearTree() {
-        state.tree = SyntaxTree.Parse("", SourceCodeKind.Script);
+        state.tree = SyntaxTree.Parse("", null, SourceCodeKind.Script);
         // This should always be empty by now, but just in case there was a race condition
         _changes.Clear();
     }

--- a/src/Buckle/SourceGenerators/SyntaxGenerator/SourceWriter.cs
+++ b/src/Buckle/SourceGenerators/SyntaxGenerator/SourceWriter.cs
@@ -238,11 +238,17 @@ internal sealed class SourceWriter {
 
             CloseBlock();
 
+            var valueFields = GetValueFields(abstractNode);
             var nodeFields = GetNodeOrNodeListFields(abstractNode);
 
             foreach (var field in nodeFields) {
                 WriteLine();
                 WriteLine($"internal abstract {field.Type} {field.Name} {{ get; }}");
+            }
+
+            foreach (var field in valueFields) {
+                WriteLine();
+                WriteLine($"internal abstract {OverrideModifier(field)}{field.Type} {field.Name} {{ get; }}");
             }
 
             CloseBlock();
@@ -525,7 +531,9 @@ internal sealed class SourceWriter {
             Write("=> node.Update(");
             Write(CommaJoin(nd.fields.Select(f => IsAnyNodeList(f.Type)
                     ? $"VisitList(node.{f.Name})"
-                    : $"({f.Type})Visit(node.{f.Name})"
+                    : IsNode(f.Type)
+                        ? $"({f.Type})Visit(node.{f.Name})"
+                        : $"node.{f.Name}"
                 )));
             WriteLine(");");
             Unindent();
@@ -590,12 +598,19 @@ internal sealed class SourceWriter {
             WriteLine($"internal {node.Name}(SyntaxNode parent, GreenNode green, int position)");
             WriteLine("  : base(parent, green, position) { }");
 
+            var valueFields = GetValueFields(abstractNode);
             var nodeFields = GetNodeOrNodeListFields(abstractNode);
 
             foreach (var field in nodeFields) {
                 var fieldType = GetRedFieldType(field);
                 WriteLine();
                 WriteLine($"public abstract {fieldType} {field.Name} {{ get; }}");
+            }
+            
+            foreach (var field in valueFields) {
+                var fieldType = GetRedFieldType(field);
+                WriteLine($"public abstract {OverrideModifier(field)}{fieldType} {field.Name} {{ get; }}");
+                WriteLine();
             }
 
             CloseBlock();
@@ -762,10 +777,15 @@ internal sealed class SourceWriter {
     private List<Field> GetNodeOrNodeListFields(TreeType node)
         => node is AbstractNode an
             ? an.fields.Where(n => IsNodeOrNodeList(n.Type)).ToList()
-
             : node is Node nd
                 ? nd.fields.Where(n => IsNodeOrNodeList(n.Type)).ToList()
+                : new List<Field>();
 
+    private List<Field> GetValueFields(TreeType node)
+        => node is AbstractNode an
+            ? an.fields.Where(n => !IsNodeOrNodeList(n.Type)).ToList()
+            : node is Node nd
+                ? nd.fields.Where(n => !IsNodeOrNodeList(n.Type)).ToList()
                 : new List<Field>();
 
     private string GetChildPosition(int i) => i == 0 ? "this.position" : $"GetChildPosition({i})";
@@ -787,12 +807,20 @@ internal sealed class SourceWriter {
         CloseBlock();
     }
 
+    private bool IsValueField(Field field) {
+        return !IsNodeOrNodeList(field.Type);
+    }
+
     private void WriteRedFactoryMethods(Node node) {
+        var valueFields = node.fields.Where(n => IsValueField(n)).ToList();
+        var nodeFields = node.fields.Where(n => !IsValueField(n)).ToList();
+
         var allArguments = CommaJoin(node.fields.Select(f => $"{GetRedFieldType(f)} {f.Name}"));
         var requiredArguments = CommaJoin(
             node.fields.Where(f => !IsOptional(f)).Select(f => $"{GetRedFieldType(f)} {f.Name}")
         );
-        var allParameters = CommaJoin(node.fields.Select(f =>
+        
+        var allParameters = CommaJoin(nodeFields.Select(f =>
             IsNodeList(f.Type)
                 ? $"{f.Name}?.node?.ToGreenList<Syntax.InternalSyntax.{GetElementType(f.Type)}>()" :
             IsSeparatedNodeList(f.Type)
@@ -800,8 +828,9 @@ internal sealed class SourceWriter {
             (!IsNode(f.Type) || f.Type == "SyntaxToken")
                 ? $"(Syntax.InternalSyntax.{f.Type}){f.Name}.node" :
             $"(Syntax.InternalSyntax.{f.Type}){f.Name}.green"
-        ));
-        var requiredParameters = CommaJoin(node.fields.Select(f => IsOptional(f) ? "null" :
+        ), valueFields.Select(f => f.Name));
+
+        var requiredParameters = CommaJoin(nodeFields.Select(f => IsOptional(f) ? "null" :
             IsNodeList(f.Type)
                 ? $"{f.Name}?.node?.ToGreenList<Syntax.InternalSyntax.{GetElementType(f.Type)}>()" :
             IsSeparatedNodeList(f.Type)
@@ -809,7 +838,7 @@ internal sealed class SourceWriter {
             (!IsNode(f.Type) || f.Type == "SyntaxToken")
                 ? $"(Syntax.InternalSyntax.{f.Type}){f.Name}.node" :
             $"(Syntax.InternalSyntax.{f.Type}){f.Name}.green"
-        ));
+        ), valueFields.Select(f => IsOptional(f) ? "null" : f.Name));
 
         var fullDeclaration = $"public static {node.Name} {StripPost(node.Name, "Syntax")}({allArguments}";
         var fullBody = $"=> ({node.Name})Syntax.InternalSyntax.SyntaxFactory." +


### PR DESCRIPTION
# Description

Not perfect, but good enough for now. Diagnostic reporting locations a little messed up...

Added basic `#if`, `#elif`, `#else`, `#endif`, `#define`, `#undef` preprocessor statements to allow for checking if the code is in debug or release mode.

The `--debug` flag defines a `DEBUG` preprocessor symbol, otherwise `RELEASE` is defined.