### PR TITLE
Rw/betterenums

### DIFF
--- a/docs/Current/ClassesAndObjects.md
+++ b/docs/Current/ClassesAndObjects.md
@@ -336,7 +336,50 @@ enum MyEnum {
 }
 ```
 
-### 4.6.1 Experimental Underlying Types
+### 4.6.1 Flags
+
+The `flags` keyword can be used to signal to other developers that the enum is meant to be used with multiple fields
+at the same time. For example:
+
+```belte
+var myLocal = MyEnum.Field1 | MyEnum.Field2;
+
+enum flags MyEnum {
+  None,
+  Field1,
+  Field2,
+}
+```
+
+Beyond documentation, the `flags` keyword also changes the default value behavior of enum fields. Instead of
+incrementally counting up from 0, enum fields will count up in powers of 2 (0, 1, 2, 4, 8, etc.) so that when the fields
+are combined their bits do not conflict. You can still give fields explicit values like normal.
+
+Additionally, flags enums string cast will display each field component of the value. For example:
+
+```belte
+var myLocal = MyEnum.Field1 | MyEnum.Field2;
+var myString = (string)myLocal;
+// myString = "Field1, Field2"
+
+enum flags MyEnum {
+  None,
+  Field1,
+  Field2,
+}
+```
+
+### 4.6.2 Implicit Enum Fields
+
+In target typed expressions, an implicit enum field expression can be used which
+omits the enum type name. The following are equivalent:
+
+```belte
+var myLocal = MyEnum.Field1;
+MyEnum myLocal = .Field1;
+```
+
+### 4.6.3 Experimental Underlying Types
 
 When using the Evaluator, enums can additional represent the `string` and `char` primitives:
 

--- a/extensions/belte-nolsp/belte.tmLanguage.json
+++ b/extensions/belte-nolsp/belte.tmLanguage.json
@@ -95,7 +95,7 @@
                 },
                 {
                     "name": "storage.type.class.belte",
-                    "match": "\\b(class|struct|constructor|extends|where|namespace|using|enum)\\b"
+                    "match": "\\b(class|struct|constructor|extends|where|namespace|using|enum|flags)\\b"
                 },
                 {
                     "name": "storage.type.number.belte",

--- a/src/Buckle/Compiler.Tests/CodeAnalysis/Evaluating/EvaluatorTests.cs
+++ b/src/Buckle/Compiler.Tests/CodeAnalysis/Evaluating/EvaluatorTests.cs
@@ -434,6 +434,9 @@ public sealed class EvaluatorTests {
     [InlineData("T Test<type T>() { return null; } return Test<int>();", null)]
     // Misc for coverage
     [InlineData("using H = int; H myVar = 3; return myVar;", 3)]
+    [InlineData("enum A { q, w, e, r, t } return A.t;", 4)]
+    [InlineData("enum flags A { q, w, e, r, t } return A.t;", 8)]
+    [InlineData("enum A { q, w, e, r, t } A a = .t; return (int)a;", 4)]
     [InlineData("class P { int a = 3; public int M(int a) { return a; } } var myP = new P(); return myP.M(4);", 4)]
     [InlineData("class P { public int M(int a, int b) { return a + b; } public int M(int a) { return a; } } var myP = new P(); return myP.M(4, 5);", 9)]
     [InlineData("class P { public static T M<type T>() { T a = null; return a; } } return P.M<int>();", null)]

--- a/src/Buckle/Compiler.Tests/Diagnostics/DiagnosticTests.cs
+++ b/src/Buckle/Compiler.Tests/Diagnostics/DiagnosticTests.cs
@@ -4592,4 +4592,45 @@ public sealed class DiagnosticTests {
 
     //     AssertDiagnostics(text, diagnostics, _writer);
     // }
+
+    [Fact]
+    public void Reports_Error_BU0379_InvalidImplicitEnum() {
+        var text = @"
+            enum A extends string {
+                [F]
+            }
+        ";
+
+        var diagnostics = @"
+            enum members with a string underlying type must have explicit values
+        ";
+
+        AssertDiagnostics(text, diagnostics, _writer);
+    }
+
+    [Fact]
+    public void Reports_Error_BU0380_EnumFieldNoTargetType() {
+        var text = @"
+            var a = [.A];
+        ";
+
+        var diagnostics = @"
+            there is no target type for the implicit enum field
+        ";
+
+        AssertDiagnostics(text, diagnostics, _writer);
+    }
+
+    [Fact]
+    public void Reports_Error_BU0381_WrongEnumTargetType() {
+        var text = @"
+            int32 a = [.A];
+        ";
+
+        var diagnostics = @"
+            cannot infer enum type from implicit enum field
+        ";
+
+        AssertDiagnostics(text, diagnostics, _writer);
+    }
 }

--- a/src/Buckle/Compiler/CodeAnalysis/Binding/Binder.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Binding/Binder.cs
@@ -1365,6 +1365,12 @@ internal partial class Binder {
 
                 result = new BoundLiteralExpression(expression.syntax, null, CreateErrorType());
                 break;
+            case BoundUnconvertedImplicitEnumFieldExpression:
+                if (reportNoTargetType && !expression.hasAnyErrors)
+                    diagnostics.Push(Error.EnumFieldNoTargetType(expression.syntax.location));
+
+                result = ErrorExpression(expression.syntax, expression);
+                break;
             default:
                 result = expression;
                 break;
@@ -2902,6 +2908,8 @@ internal partial class Binder {
                 return BindCascadeListExpression((CascadeListExpressionSyntax)node, diagnostics);
             case SyntaxKind.StackAllocExpression:
                 return BindStackAllocExpression((StackAllocExpressionSyntax)node, diagnostics);
+            case SyntaxKind.ImplicitEnumFieldExpression:
+                return BindImplicitEnumFieldExpression((ImplicitEnumFieldExpressionSyntax)node, diagnostics);
             default:
                 throw ExceptionUtilities.UnexpectedValue(node.kind);
         }
@@ -2989,6 +2997,12 @@ internal partial class Binder {
                 true
             );
         }
+    }
+
+    private BoundExpression BindImplicitEnumFieldExpression(
+        ImplicitEnumFieldExpressionSyntax node,
+        BelteDiagnosticQueue diagnostics) {
+        return new BoundUnconvertedImplicitEnumFieldExpression(node, node.identifier.text);
     }
 
     private BoundExpression BindStackAllocExpression(
@@ -11934,7 +11948,9 @@ symIsHidden:;
                     );
                 }
 
-                diagnostics = BelteDiagnosticQueue.Discarded;
+                // Implicit enum field errors are handled separately
+                if (expression.kind != BoundKind.UnconvertedImplicitEnumFieldExpression)
+                    diagnostics = BelteDiagnosticQueue.Discarded;
             }
         }
 
@@ -12122,6 +12138,23 @@ symIsHidden:;
             );
         }
 
+        if (source.kind == BoundKind.UnconvertedImplicitEnumFieldExpression) {
+            var fieldExpression = ConvertImplicitEnumFieldExpression(
+                (BoundUnconvertedImplicitEnumFieldExpression)source,
+                destination,
+                conversion,
+                diagnostics
+            );
+
+            return new BoundCastExpression(
+                node,
+                fieldExpression,
+                conversion,
+                null,
+                destination
+            );
+        }
+
         ConstantValue constantValue = null;
 
         if (conversion.exists && conversion.kind is not ConversionKind.ImplicitNullToPointer and not
@@ -12160,6 +12193,32 @@ symIsHidden:;
             destination: destination,
             diagnostics: diagnostics
         );
+    }
+
+    private BoundExpression ConvertImplicitEnumFieldExpression(
+        BoundUnconvertedImplicitEnumFieldExpression node,
+        TypeSymbol targetType,
+        Conversion conversion,
+        BelteDiagnosticQueue diagnostics) {
+        if (!targetType.StrippedType().IsEnumType()) {
+            diagnostics.Push(Error.WrongEnumTargetType(node.syntax.location));
+            return ErrorExpression(node.syntax, node);
+        }
+
+        var enumType = targetType.StrippedType();
+        var symbols = enumType.GetMembers(node.name).Where(s => s.kind == SymbolKind.Field).ToArray();
+
+        if (symbols.Length == 0) {
+            diagnostics.Push(Error.NoSuchMember(node.syntax.location, enumType, node.name));
+            return ErrorExpression(node.syntax, node);
+        } else if (symbols.Length == 1) {
+            var field = symbols[0] as FieldSymbol;
+            var constantValue = field.GetConstantValue(constantFieldsInProgress);
+            var fieldAccess = new BoundFieldAccessExpression(node.syntax, null, field, constantValue, enumType);
+            return CreateConversion(fieldAccess, conversion, targetType, diagnostics);
+        } else {
+            throw ExceptionUtilities.Unreachable();
+        }
     }
 
     private BoundExpression ConvertNullptrExpression(

--- a/src/Buckle/Compiler/CodeAnalysis/Binding/BoundTree/BoundExpression.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Binding/BoundTree/BoundExpression.cs
@@ -43,6 +43,7 @@ internal abstract partial class BoundExpression : BoundNode {
     internal bool NeedsToBeConverted() {
         switch (kind) {
             case BoundKind.UnconvertedInitializerList:
+            case BoundKind.UnconvertedImplicitEnumFieldExpression:
                 return true;
             default:
                 return false;

--- a/src/Buckle/Compiler/CodeAnalysis/Binding/BoundTree/BoundNodes.xml
+++ b/src/Buckle/Compiler/CodeAnalysis/Binding/BoundTree/BoundNodes.xml
@@ -93,6 +93,10 @@
   <Node Name="BoundUnconvertedNullptrExpression" Base="BoundExpression">
     <Field Name="type" Type="TypeSymbol?" Override="true" Null="always"/>
   </Node>
+  <Node Name="BoundUnconvertedImplicitEnumFieldExpression" Base="BoundExpression">
+    <Field Name="name" Type="string"/>
+    <Field Name="type" Type="TypeSymbol?" Override="true" Null="always"/>
+  </Node>
   <Node Name="BoundArrayCreationExpression" Base="BoundExpression">
     <Field Name="sizes" Type="ImmutableArray&lt;BoundExpression&gt;"/>
     <Field Name="initializer" Type="BoundInitializerList?"/>

--- a/src/Buckle/Compiler/CodeAnalysis/Binding/Conversions/Conversion.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Binding/Conversions/Conversion.cs
@@ -202,6 +202,9 @@ internal readonly partial struct Conversion : IEquatable<Conversion> {
         }
 
         if (source.IsEnumType()) {
+            if (target.specialType == SpecialType.Any)
+                return Implicit;
+
             var underlying = (source as NamedTypeSymbol).enumUnderlyingType;
             var underlyingConversion = CollapseConversion(Classify(underlying, target));
 

--- a/src/Buckle/Compiler/CodeAnalysis/Binding/Conversions/Conversions.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Binding/Conversions/Conversions.cs
@@ -45,6 +45,17 @@ internal sealed partial class Conversions {
         return Conversion.None;
     }
 
+    private Conversion GetImplicitEnumFieldExpressionConversion(
+        BoundUnconvertedImplicitEnumFieldExpression fieldAccess,
+        TypeSymbol destination) {
+        var fieldAccessConversion = GetEnumFieldExpressionConversion(fieldAccess, destination);
+
+        if (fieldAccessConversion.exists)
+            return fieldAccessConversion;
+
+        return Conversion.None;
+    }
+
     private Conversion GetImplicitListExpressionConversion(
         BoundUnconvertedInitializerList listExpression,
         TypeSymbol destination) {
@@ -66,6 +77,19 @@ internal sealed partial class Conversions {
     internal Conversion GetNullptrExpressionConversion(BoundUnconvertedNullptrExpression node, TypeSymbol targetType) {
         if (targetType.IsPointerOrFunctionPointer())
             return Conversion.ImplicitNullToPointer;
+
+        return Conversion.None;
+    }
+
+    internal Conversion GetEnumFieldExpressionConversion(
+        BoundUnconvertedImplicitEnumFieldExpression node,
+        TypeSymbol targetType) {
+        if (targetType.StrippedType().IsEnumType()) {
+            if (targetType.IsNullableType())
+                return new Conversion(ConversionKind.ImplicitNullable, [Conversion.ImplicitEnum]);
+
+            return Conversion.ImplicitEnum;
+        }
 
         return Conversion.None;
     }
@@ -120,9 +144,11 @@ internal sealed partial class Conversions {
     internal Conversion ClassifyConversionFromExpression(BoundExpression sourceExpression, TypeSymbol target) {
         var result = ClassifyImplicitConversionFromExpression(sourceExpression, target);
 
-        if (result.exists || sourceExpression is BoundUnconvertedInitializerList || sourceExpression.IsLiteralNull())
+        if (result.exists || sourceExpression is BoundUnconvertedInitializerList ||
+            sourceExpression.IsLiteralNull() || sourceExpression is BoundUnconvertedImplicitEnumFieldExpression) {
             // We tried our best. There are no built-in conversions for lists.
             return result;
+        }
 
         sourceExpression = Binder.ReduceNumericIfApplicable(target, sourceExpression);
         return Conversion.Classify(sourceExpression.Type(), target);
@@ -185,25 +211,20 @@ internal sealed partial class Conversions {
     }
 
     internal Conversion ClassifyImplicitConversionFromExpression(BoundExpression sourceExpression, TypeSymbol target) {
-        if (sourceExpression is BoundUnconvertedInitializerList list) {
-            var listExpressionConversion = GetImplicitListExpressionConversion(list, target);
+        switch (sourceExpression) {
+            case BoundUnconvertedInitializerList list:
+                var listExpressionConversion = GetImplicitListExpressionConversion(list, target);
 
-            if (listExpressionConversion.exists)
+                if (listExpressionConversion.exists)
+                    return listExpressionConversion;
+
+                // TODO Eventually we will handle user conversions, but right now if we can't immediately convert this
+                // we won't be able to
                 return listExpressionConversion;
-
-            // TODO Eventually we will handle user conversions, but right now if we can't immediately convert this
-            // we won't be able to
-            return listExpressionConversion;
-        }
-
-        if (sourceExpression is BoundUnconvertedNullptrExpression nullptr) {
-            var ptrExpressionConversion = GetImplicitNullptrExpressionConversion(nullptr, target);
-
-            if (ptrExpressionConversion.exists)
-                return ptrExpressionConversion;
-
-            // TODO See above todo
-            return ptrExpressionConversion;
+            case BoundUnconvertedNullptrExpression nullptr:
+                return GetImplicitNullptrExpressionConversion(nullptr, target); ;
+            case BoundUnconvertedImplicitEnumFieldExpression fieldAccess:
+                return GetImplicitEnumFieldExpressionConversion(fieldAccess, target);
         }
 
         if (sourceExpression.IsLiteralNull()) {

--- a/src/Buckle/Compiler/CodeAnalysis/Display/DisplayText.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Display/DisplayText.cs
@@ -315,6 +315,9 @@ public sealed class DisplayText {
             case BoundKind.ConvertedStackAllocExpression:
                 DisplayStackAllocExpression(text, (BoundStackAllocExpressionBase)node);
                 break;
+            case BoundKind.UnconvertedImplicitEnumFieldExpression:
+                DisplayUnconvertedImplicitEnumFieldExpression(text, (BoundUnconvertedImplicitEnumFieldExpression)node);
+                break;
             default:
                 throw ExceptionUtilities.UnexpectedValue(node.kind);
         }
@@ -871,6 +874,13 @@ public sealed class DisplayText {
         text.Write(CreatePunctuation(SyntaxKind.OpenParenToken));
         SymbolDisplay.AppendToDisplayText(text, node.sourceType.type);
         text.Write(CreatePunctuation(SyntaxKind.CloseParenToken));
+    }
+
+    private static void DisplayUnconvertedImplicitEnumFieldExpression(
+        DisplayText text,
+        BoundUnconvertedImplicitEnumFieldExpression node) {
+        text.Write(CreatePunctuation(SyntaxKind.PeriodToken));
+        text.Write(CreateIdentifier(node.name));
     }
 
     private static void DisplayStackAllocExpression(DisplayText text, BoundStackAllocExpressionBase node) {

--- a/src/Buckle/Compiler/CodeAnalysis/Display/SymbolDisplay.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Display/SymbolDisplay.cs
@@ -174,6 +174,11 @@ public static class SymbolDisplay {
             }
 
             text.Write(CreateSpace());
+
+            if (namedType.enumFlagsAttribute) {
+                text.Write(CreateKeyword(SyntaxKind.FlagsKeyword));
+                text.Write(CreateSpace());
+            }
         }
 
         DisplayContainedNames(text, namedType, format);

--- a/src/Buckle/Compiler/CodeAnalysis/Emitting/ILEmitter.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Emitting/ILEmitter.cs
@@ -587,6 +587,15 @@ internal sealed partial class ILEmitter : ModuleBuilder {
             GetBaseType(type)
         );
 
+        if (type.enumFlagsAttribute) {
+            var flagsCtor = _assemblyDefinition.MainModule.ImportReference(
+                typeof(FlagsAttribute).GetConstructor(Type.EmptyTypes)
+            );
+
+            var flagsAttr = new CustomAttribute(flagsCtor);
+            typeDefinition.CustomAttributes.Add(flagsAttr);
+        }
+
         GenericParameter[] workingParams = [];
 
         if (type.arity > 0) {

--- a/src/Buckle/Compiler/CodeAnalysis/Evaluating/Executor.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Evaluating/Executor.cs
@@ -523,6 +523,12 @@ internal sealed partial class Executor : ModuleBuilder {
                 underlyingType
             );
 
+            if (type.enumFlagsAttribute) {
+                var flagsCtor = typeof(FlagsAttribute).GetConstructor(Type.EmptyTypes);
+                var flagsAttr = new CustomAttributeBuilder(flagsCtor, []);
+                enumBuilder.SetCustomAttribute(flagsAttr);
+            }
+
             _workingEnums.Add(type, enumBuilder);
 
             CreateEnumMemberDefinitions(type);

--- a/src/Buckle/Compiler/CodeAnalysis/LiteralUtilities.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/LiteralUtilities.cs
@@ -358,6 +358,7 @@ internal static class LiteralUtilities {
             SpecialType.Float64 => 0D,
             SpecialType.Bool => false,
             SpecialType.Char => '\0',
+            SpecialType.String => "",
             _ => throw ExceptionUtilities.UnexpectedValue(type)
         };
     }

--- a/src/Buckle/Compiler/CodeAnalysis/Parser/LanguageParser.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Parser/LanguageParser.cs
@@ -473,6 +473,7 @@ internal sealed partial class LanguageParser : SyntaxParser {
         SyntaxList<AttributeListSyntax> attributeLists,
         SyntaxList<SyntaxToken> modifiers) {
         var keyword = EatToken();
+        var flagsKeyword = currentToken.kind == SyntaxKind.FlagsKeyword ? EatToken() : null;
         var identifier = Match(SyntaxKind.IdentifierToken, SyntaxKind.OpenBraceToken);
         var baseType = currentToken.kind == SyntaxKind.ExtendsKeyword
             ? ParseBaseType()
@@ -486,6 +487,7 @@ internal sealed partial class LanguageParser : SyntaxParser {
             attributeLists,
             modifiers,
             keyword,
+            flagsKeyword,
             identifier,
             null,
             baseType,
@@ -1608,11 +1610,19 @@ internal sealed partial class LanguageParser : SyntaxParser {
                 return AddDiagnostic(ParseReferenceExpression(), Error.InvalidExpressionTerm(SyntaxKind.RefKeyword));
             case SyntaxKind.ColonColonToken:
                 return ParseAliasQualifiedName();
+            case SyntaxKind.PeriodToken:
+                return ParseImplicitEnumFieldExpression();
             case SyntaxKind.IdentifierToken:
             case SyntaxKind.GlobalKeyword:
             default:
                 return ParseLastCaseName();
         }
+    }
+
+    private ExpressionSyntax ParseImplicitEnumFieldExpression() {
+        var period = EatToken();
+        var identifier = Match(SyntaxKind.IdentifierToken);
+        return SyntaxFactory.ImplicitEnumFieldExpression(period, identifier);
     }
 
     private ExpressionSyntax ParsePrimaryExpression(int parentPrecedence = 0, ExpressionSyntax left = null) {

--- a/src/Buckle/Compiler/CodeAnalysis/Symbols/NamedTypeSymbol.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Symbols/NamedTypeSymbol.cs
@@ -79,6 +79,8 @@ internal abstract class NamedTypeSymbol : TypeSymbol, INamedTypeSymbol, ISymbolW
 
     internal virtual NamedTypeSymbol enumUnderlyingType => null;
 
+    internal virtual bool enumFlagsAttribute => false;
+
     internal override void Accept(SymbolVisitor visitor) {
         visitor.VisitNamedType(this);
     }

--- a/src/Buckle/Compiler/CodeAnalysis/Symbols/Source/SourceEnumConstantSymbol.ZeroValuedEnumConstantSymbol.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Symbols/Source/SourceEnumConstantSymbol.ZeroValuedEnumConstantSymbol.cs
@@ -11,6 +11,8 @@ internal abstract partial class SourceEnumConstantSymbol {
             EnumMemberDeclarationSyntax syntax,
             BelteDiagnosticQueue diagnostics)
             : base(containingEnum, syntax, diagnostics) {
+            if (containingEnum.enumUnderlyingType.specialType == SpecialType.String)
+                diagnostics.Push(Error.InvalidImplicitEnum(syntax.location));
         }
 
         private protected override ConstantValue MakeConstantValue(

--- a/src/Buckle/Compiler/CodeAnalysis/Symbols/Source/SourceEnumConstantSymbol.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Symbols/Source/SourceEnumConstantSymbol.cs
@@ -19,7 +19,7 @@ internal abstract partial class SourceEnumConstantSymbol : SourceFieldSymbolWith
         SourceEnumConstantSymbol otherConstant,
         int otherConstantOffset,
         BelteDiagnosticQueue diagnostics) {
-        if ((object)otherConstant == null) {
+        if (otherConstant is null) {
             return new ZeroValuedEnumConstantSymbol(containingEnum, syntax, diagnostics);
         } else {
             return new ImplicitValuedEnumConstantSymbol(

--- a/src/Buckle/Compiler/CodeAnalysis/Symbols/Source/SourceMemberContainerTypeSymbol.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Symbols/Source/SourceMemberContainerTypeSymbol.cs
@@ -93,6 +93,8 @@ internal abstract partial class SourceMemberContainerTypeSymbol : NamedTypeSymbo
             diagnostics.Push(Warning.ProtectedInSealed(location, this));
 
         _state.NotePartComplete(CompletionParts.TemplateArguments);
+
+        enumFlagsAttribute = syntaxReference.node is EnumDeclarationSyntax e && e.flagsKeyword is not null;
     }
 
     public override string name => _declaration.name;
@@ -128,6 +130,8 @@ internal abstract partial class SourceMemberContainerTypeSymbol : NamedTypeSymbo
     internal override IEnumerable<string> memberNames => GetMembers().Select(m => m.name);
 
     internal sealed override bool isRefLikeType => HasFlag(DeclarationModifiers.Ref);
+
+    internal override bool enumFlagsAttribute { get; }
 
     internal bool anyMemberHasAttributes {
         get {
@@ -1473,11 +1477,17 @@ internal abstract partial class SourceMemberContainerTypeSymbol : NamedTypeSymbo
                 otherSymbol = symbol;
                 otherSymbolOffset = 1;
             } else {
-                otherSymbolOffset++;
+                otherSymbolOffset = Next(otherSymbolOffset);
             }
         }
-    }
 
+        int Next(int offset) {
+            if (enumFlagsAttribute && (offset & (offset - 1)) == 0)
+                return offset << 1;
+
+            return offset + 1;
+        }
+    }
 
     private void AddNonTypeMembers(
         DeclaredMembersAndInitializersBuilder builder,

--- a/src/Buckle/Compiler/CodeAnalysis/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -426,6 +426,11 @@ internal sealed class SourceNamedTypeSymbol : SourceMemberContainerTypeSymbol, I
                 type = CorLibrary.GetSpecialType(SpecialType.Int);
             }
 
+            if (type.specialType is SpecialType.Char or SpecialType.String &&
+                declaringCompilation.options.buildMode is BuildMode.CSharpTranspile or BuildMode.Execute or BuildMode.Dotnet) {
+                diagnostics.Push(Error.Unsupported.NonIntegralEnum(typeSyntax.location));
+            }
+
             return (NamedTypeSymbol)type;
         }
 

--- a/src/Buckle/Compiler/CodeAnalysis/Symbols/Source/SourceNamedTypeSymbol.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Symbols/Source/SourceNamedTypeSymbol.cs
@@ -419,9 +419,9 @@ internal sealed class SourceNamedTypeSymbol : SourceMemberContainerTypeSymbol, I
             var typeSyntax = bases.type;
 
             var baseBinder = compilation.GetBinder(bases);
-            var type = baseBinder.BindType(typeSyntax, diagnostics).type;
+            var type = baseBinder.BindType(typeSyntax, diagnostics).type.StrippedType();
 
-            if (!type.StrippedType().specialType.IsValidEnumUnderlyingType()) {
+            if (!type.specialType.IsValidEnumUnderlyingType()) {
                 diagnostics.Push(Error.InvalidEnumType(typeSyntax.location));
                 type = CorLibrary.GetSpecialType(SpecialType.Int);
             }

--- a/src/Buckle/Compiler/CodeAnalysis/Syntax/Syntax.xml
+++ b/src/Buckle/Compiler/CodeAnalysis/Syntax/Syntax.xml
@@ -547,6 +547,9 @@
     <Field Name="keyword" Type="SyntaxToken" Override="true">
       <Kind Name="EnumKeyword"/>
     </Field>
+    <Field Name="flagsKeyword" Type="SyntaxToken" Optional="true">
+      <Kind Name="FlagsKeyword"/>
+    </Field>
     <Field Name="identifier" Type="SyntaxToken" Override="true">
       <Kind Name="IdentifierToken"/>
     </Field>
@@ -960,6 +963,15 @@
     <Field Name="expression" Type="ExpressionSyntax"/>
     <Field Name="operatorToken" Type="SyntaxToken"/>
     <Field Name="name" Type="SimpleNameSyntax"/>
+  </Node>
+  <Node Name="ImplicitEnumFieldExpressionSyntax" Base="ExpressionSyntax">
+    <Kind Name="ImplicitEnumFieldExpression"/>
+    <Field Name="period" Type="SyntaxToken">
+      <Kind Name="PeriodToken"/>
+    </Field>
+    <Field Name="identifier" Type="SyntaxToken">
+      <Kind Name="IdentifierToken"/>
+    </Field>
   </Node>
   <Node Name="CascadeListExpressionSyntax" Base="ExpressionSyntax">
     <Kind Name="CascadeListExpression"/>

--- a/src/Buckle/Compiler/CodeAnalysis/Syntax/SyntaxFacts.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Syntax/SyntaxFacts.cs
@@ -211,6 +211,7 @@ public static class SyntaxFacts {
             "endif" => SyntaxKind.EndifKeyword,
             "define" => SyntaxKind.DefineKeyword,
             "undef" => SyntaxKind.UndefKeyword,
+            "flags" => SyntaxKind.FlagsKeyword,
             _ => SyntaxKind.IdentifierToken,
         };
     }
@@ -343,6 +344,7 @@ public static class SyntaxFacts {
             SyntaxKind.EndifKeyword => "endif",
             SyntaxKind.DefineKeyword => "define",
             SyntaxKind.UndefKeyword => "undef",
+            SyntaxKind.FlagsKeyword => "flags",
             _ => null,
         };
     }

--- a/src/Buckle/Compiler/CodeAnalysis/Syntax/SyntaxKind.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Syntax/SyntaxKind.cs
@@ -134,6 +134,7 @@ public enum SyntaxKind : ushort {
     EndifKeyword,
     DefineKeyword,
     UndefKeyword,
+    FlagsKeyword,
 
     // Tokens with text
     BadToken,
@@ -186,6 +187,7 @@ public enum SyntaxKind : ushort {
     CascadeListExpression,
     CascadeExpression,
     StackAllocExpression,
+    ImplicitEnumFieldExpression,
 
     // Statements
     EmptyStatement,

--- a/src/Buckle/Compiler/Diagnostics/DiagnosticCode.cs
+++ b/src/Buckle/Compiler/Diagnostics/DiagnosticCode.cs
@@ -387,11 +387,14 @@ public enum DiagnosticCode : ushort {
     ERR_UnexpectedDirective = 376,
     ERR_DirectiveFollowsToken = 377,
     ERR_InvalidDirectiveExpression = 378,
+    ERR_InvalidImplicitEnum = 379,
+    ERR_EnumFieldNoTargetType = 380,
+    ERR_WrongEnumTargetType = 381,
 
     // Carving out >=9000 for unsupported errors
     UNS_IndependentCompilation = 9000,
     UNS_NonTypeTemplate = 9001,
     UNS_ILOpCode = 9002,
-    UNS_ILOperand = 9003,
+    UNS_NonIntegralEnum = 9003,
     UNS_GraphicsDll = 9004,
 }

--- a/src/Buckle/Compiler/Diagnostics/Error.cs
+++ b/src/Buckle/Compiler/Diagnostics/Error.cs
@@ -35,9 +35,9 @@ internal static class Error {
             return CreateError(DiagnosticCode.UNS_ILOpCode, location, message);
         }
 
-        internal static BelteDiagnostic ILOperand(TextLocation location, string operandKind) {
-            var message = $"unsupported: inline IL instruction operand kind '{operandKind.ToLower()}' not supported";
-            return CreateError(DiagnosticCode.UNS_ILOperand, location, message);
+        internal static BelteDiagnostic NonIntegralEnum(TextLocation location) {
+            var message = $"unsupported: cannot use non-integral enums when building for .NET, transpiling to C#, or executing";
+            return CreateError(DiagnosticCode.UNS_NonIntegralEnum, location, message);
         }
     }
 
@@ -821,6 +821,10 @@ internal static class Error {
         return CreateError(DiagnosticCode.ERR_NullptrNoTargetType, location, message);
     }
 
+    internal static BelteDiagnostic EnumFieldNoTargetType(TextLocation location) {
+        var message = $"there is no target type for the implicit enum field";
+        return CreateError(DiagnosticCode.ERR_EnumFieldNoTargetType, location, message);
+    }
     internal static BelteDiagnostic InstanceRequiredInFieldInitializer(TextLocation location, Symbol symbol) {
         var message = $"a field initializer cannot reference non-static member '{symbol}'";
         return CreateError(DiagnosticCode.ERR_InstanceRequiredInFieldInitializer, location, message);
@@ -1846,6 +1850,16 @@ internal static class Error {
     internal static Diagnostic InvalidDirectiveExpression() {
         var message = $"invalid preprocessor expression";
         return CreateError(DiagnosticCode.ERR_InvalidDirectiveExpression, message);
+    }
+
+    internal static BelteDiagnostic InvalidImplicitEnum(TextLocation location) {
+        var message = $"enum members with a string underlying type must have explicit values";
+        return CreateError(DiagnosticCode.ERR_InvalidImplicitEnum, location, message);
+    }
+
+    internal static BelteDiagnostic WrongEnumTargetType(TextLocation location) {
+        var message = $"cannot infer enum type from implicit enum field";
+        return CreateError(DiagnosticCode.ERR_WrongEnumTargetType, location, message);
     }
 
     private static DiagnosticInfo ErrorInfo(DiagnosticCode code) {


### PR DESCRIPTION
# Description

Flags enums and implicit enum field access:

```cs
enum flags A {
  q, // 0
  w, // 1
  e, // 2
  r, // 4
  t, // 8
}
```

```cs
A a = .field;

enum A { field }
```

String enums now require explicit values, and string and char enums now err if not evaluating.

Enum string cast is fixed.