### PR TITLE
Rw/interpolation

### DIFF
--- a/docs/Current/Data.md
+++ b/docs/Current/Data.md
@@ -26,7 +26,7 @@ To convert from one data type to another, a cast can be used. If a cast is impli
 no special syntax. If a cast is explicit, it must use a special syntax (e.g. `(int)"123"`).
 
 | From | To | Cast Type | Notes |
-|-|-|-|
+|-|-|-|-|
 | Integer | Decimal | Implicit | |
 | Integer | String | Explicit | |
 | Integer | Bool | None | |
@@ -43,9 +43,28 @@ no special syntax. If a cast is explicit, it must use a special syntax (e.g. `(i
 In addition, nullability affects casting:
 
 | From | To | Cast Type | Notes |
-|-|-|-|
+|-|-|-|-|
 | type | type! | Explicit | Can throw |
 | type! | type | Implicit | |
+
+### 3.1.2 String Interpolation
+
+Prefixing a string literal with `f` allows expressions to be embedded into the string, denoted by enclosing brace pairs.
+
+The expressions within a string will automatically be casted to a string if they are a primitive. Otherwise
+`Object.ToString()` is called on the expression.
+
+For example:
+
+```belte
+var a = 3;
+var b = f"A equals {a}"; // b = "A equals 3"
+```
+
+```belte
+var a = new List<int>({ 1, 2, 3 });
+var b = f"A equals {a}"; // b = "A equals { 1, 2, 3 }"
+```
 
 ## 3.2 Operators
 

--- a/extensions/belte/server/SemanticTokensProvider.cs
+++ b/extensions/belte/server/SemanticTokensProvider.cs
@@ -66,7 +66,7 @@ internal class SemanticTokensHandler : SemanticTokensHandlerBase {
                 tokenType = SemanticTokenType.Keyword;
             else if (kind == SyntaxKind.NumericLiteralToken)
                 tokenType = SemanticTokenType.Number;
-            else if (kind is SyntaxKind.StringLiteralToken or SyntaxKind.CharacterLiteralToken)
+            else if (kind is SyntaxKind.StringLiteralToken or SyntaxKind.CharacterLiteralToken or SyntaxKind.InterpolatedStringLiteralToken)
                 tokenType = SemanticTokenType.String;
             else if (kind.IsComment())
                 tokenType = SemanticTokenType.Comment;

--- a/src/Buckle/Compiler.Tests/CodeAnalysis/Evaluating/EvaluatorTests.cs
+++ b/src/Buckle/Compiler.Tests/CodeAnalysis/Evaluating/EvaluatorTests.cs
@@ -425,6 +425,12 @@ public sealed class EvaluatorTests {
     [InlineData("var a = 3; int b = 1; switch (a) { case 4: b = 5; } return b;", 1)]
     [InlineData("var a = 3; int b = 1; switch (a) { case 3: goto case 5; case 5: goto default; default: b = 6; } return b;", 6)]
     [InlineData("var a = 3; int b = 1; switch (a) { case 1: case 2: case 3: case 4: b = 6; } return b;", 6)]
+    // String interpolation
+    [InlineData("var a = 3; return f\"a is {a}\";", "a is 3")]
+    [InlineData("int a = null; return f\"a is {a}\";", "a is ")]
+    [InlineData("return f\"a is {null}\";", "a is ")]
+    [InlineData("List<int> a = null; return f\"a is {a}\";", "a is ")]
+    [InlineData("class A { public override string ToString() { return \"text\"; } } A a = new A(); return f\"a is {a}\";", "a is text")]
     // Templates
     // TODO Is it worth testing non-type templates even though only the Evaluator supports them?
     // [InlineData("class A<int a, int b> { public static int Test() { return a + b; } } return A<2,3>.Test();", 5)]

--- a/src/Buckle/Compiler.Tests/CodeAnalysis/Parser/LexerTests.cs
+++ b/src/Buckle/Compiler.Tests/CodeAnalysis/Parser/LexerTests.cs
@@ -44,6 +44,9 @@ public sealed class LexerTests {
         untestedTokenTypes.Remove(SyntaxKind.HashToken);
         untestedTokenTypes.Remove(SyntaxKind.EndOfDirectiveToken);
         untestedTokenTypes.Remove(SyntaxKind.OmittedArgumentToken);
+        untestedTokenTypes.Remove(SyntaxKind.InterpolatedStringLiteralToken);
+        untestedTokenTypes.Remove(SyntaxKind.InterpolatedStringStartToken);
+        untestedTokenTypes.Remove(SyntaxKind.InterpolatedStringEndToken);
         untestedTokenTypes.ExceptWith(testedTokenTypes);
 
         Assert.Empty(untestedTokenTypes);

--- a/src/Buckle/Compiler/CodeAnalysis/Authoring/Classifier.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Authoring/Classifier.cs
@@ -102,7 +102,9 @@ public static class Classifier {
             SyntaxKind.NullKeyword or
             SyntaxKind.NullptrKeyword;
         var isIdentifier = kind == SyntaxKind.IdentifierToken;
-        var isString = kind is SyntaxKind.StringLiteralToken or SyntaxKind.CharacterLiteralToken;
+        var isString = kind is SyntaxKind.StringLiteralToken or
+                               SyntaxKind.CharacterLiteralToken or
+                               SyntaxKind.InterpolatedStringLiteralToken;
         var isComment = kind.IsComment();
 
         if (isTypeName)

--- a/src/Buckle/Compiler/CodeAnalysis/Authoring/Classifier.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Authoring/Classifier.cs
@@ -104,7 +104,9 @@ public static class Classifier {
         var isIdentifier = kind == SyntaxKind.IdentifierToken;
         var isString = kind is SyntaxKind.StringLiteralToken or
                                SyntaxKind.CharacterLiteralToken or
-                               SyntaxKind.InterpolatedStringLiteralToken;
+                               SyntaxKind.InterpolatedStringLiteralToken or
+                               SyntaxKind.InterpolatedStringStartToken or
+                               SyntaxKind.InterpolatedStringEndToken;
         var isComment = kind.IsComment();
 
         if (isTypeName)

--- a/src/Buckle/Compiler/CodeAnalysis/Binding/Binder.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Binding/Binder.cs
@@ -2920,6 +2920,8 @@ internal partial class Binder {
                 return BindStackAllocExpression((StackAllocExpressionSyntax)node, diagnostics);
             case SyntaxKind.ImplicitEnumFieldExpression:
                 return BindImplicitEnumFieldExpression((ImplicitEnumFieldExpressionSyntax)node, diagnostics);
+            case SyntaxKind.InterpolatedStringExpression:
+                return BindInterpolatedString((InterpolatedStringExpressionSyntax)node, diagnostics);
             default:
                 throw ExceptionUtilities.UnexpectedValue(node.kind);
         }
@@ -7087,6 +7089,89 @@ internal partial class Binder {
 
     private BoundStatement BindEmptyStatement(EmptyStatementSyntax node, BelteDiagnosticQueue diagnostics) {
         return new BoundNopStatement(node);
+    }
+
+    private BoundExpression BindInterpolatedString(
+        InterpolatedStringExpressionSyntax expression,
+        BelteDiagnosticQueue diagnostics) {
+        var builder = ArrayBuilder<BoundExpression>.GetInstance();
+        var stringType = CorLibrary.GetSpecialType(SpecialType.String);
+        ConstantValue resultConstant = null;
+        var isResultConstant = true;
+
+        if (expression.contents.Count == 0) {
+            resultConstant = new ConstantValue(string.Empty, SpecialType.String);
+            return new BoundInterpolatedStringExpression(
+                expression,
+                builder.ToImmutableAndFree(),
+                resultConstant,
+                stringType
+            );
+        }
+
+        foreach (var content in expression.contents) {
+            switch (content.kind) {
+                case SyntaxKind.Interpolation: {
+                        var interpolation = (InterpolationSyntax)content;
+                        var value = BindValue(interpolation.expression, diagnostics, BindValueKind.RValue);
+
+                        builder.Add(value);
+
+                        if (!isResultConstant ||
+                            value.constantValue is null ||
+                            interpolation is null ||
+                            !(value.constantValue is { specialType: SpecialType.String })) {
+                            isResultConstant = false;
+                            continue;
+                        }
+
+                        resultConstant = (resultConstant is null)
+                            ? value.constantValue
+                            : FoldStringConcatenation(resultConstant, value.constantValue);
+
+                        continue;
+                    }
+                case SyntaxKind.InterpolatedStringText: {
+                        var text = ((InterpolatedStringTextSyntax)content).token.value;
+
+                        var constantValue = new ConstantValue(text, SpecialType.String);
+                        builder.Add(new BoundLiteralExpression(content, constantValue, stringType));
+
+                        if (isResultConstant) {
+                            resultConstant = resultConstant is null
+                                ? constantValue
+                                : FoldStringConcatenation(resultConstant, constantValue);
+                        }
+
+                        continue;
+                    }
+                default:
+                    throw ExceptionUtilities.UnexpectedValue(content.kind);
+            }
+        }
+
+        if (!isResultConstant)
+            resultConstant = null;
+
+        return new BoundInterpolatedStringExpression(
+            expression,
+            builder.ToImmutableAndFree(),
+            resultConstant,
+            stringType
+        );
+
+        static ConstantValue FoldStringConcatenation(ConstantValue left, ConstantValue right) {
+            if (left is null || right is null)
+                return null;
+
+            if (left.specialType != SpecialType.String || right.specialType != SpecialType.String)
+                return null;
+
+            return new ConstantValue(
+                (string)left.value + (string)right.value,
+                SpecialType.String
+            );
+        }
     }
 
     private BoundExpression BindLiteralExpression(

--- a/src/Buckle/Compiler/CodeAnalysis/Binding/Binder.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Binding/Binder.cs
@@ -7113,6 +7113,10 @@ internal partial class Binder {
             switch (content.kind) {
                 case SyntaxKind.Interpolation: {
                         var interpolation = (InterpolationSyntax)content;
+
+                        if (interpolation.expression is null)
+                            continue;
+
                         var value = BindValue(interpolation.expression, diagnostics, BindValueKind.RValue);
 
                         builder.Add(value);

--- a/src/Buckle/Compiler/CodeAnalysis/Binding/BoundTree/BoundNodes.xml
+++ b/src/Buckle/Compiler/CodeAnalysis/Binding/BoundTree/BoundNodes.xml
@@ -215,6 +215,10 @@
   <Node Name="BoundLiteralExpression" Base="BoundExpression">
     <Field Name="constantValue" Type="ConstantValue" PropertyOverrides="true"/>
   </Node>
+  <Node Name="BoundInterpolatedStringExpression" Base="BoundExpression">
+    <Field Name="contents" Type="ImmutableArray&lt;BoundExpression&gt;"/>
+    <Field Name="constantValue" Type="ConstantValue?" PropertyOverrides="true"/>
+  </Node>
   <Node Name="BoundMethodGroup" Base="BoundExpression">
     <Field Name="name" Type="string"/>
     <Field Name="methods" Type="ImmutableArray&lt;MethodSymbol&gt;"/>

--- a/src/Buckle/Compiler/CodeAnalysis/Binding/BoundTree/BoundTreeExpander.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Binding/BoundTree/BoundTreeExpander.cs
@@ -336,8 +336,24 @@ internal abstract class BoundTreeExpander {
             BoundKind.FieldSlotExpression => ExpandFieldSlotExpression((BoundFieldSlotExpression)expression, out replacement),
             BoundKind.StackAllocExpression => ExpandStackAllocExpression((BoundStackAllocExpression)expression, out replacement),
             BoundKind.ConvertedStackAllocExpression => ExpandConvertedStackAllocExpression((BoundConvertedStackAllocExpression)expression, out replacement),
+            BoundKind.InterpolatedStringExpression => ExpandInterpolatedStringExpression((BoundInterpolatedStringExpression)expression, out replacement),
             _ => throw ExceptionUtilities.UnexpectedValue(expression.kind),
         };
+    }
+
+    private protected virtual List<BoundStatement> ExpandInterpolatedStringExpression(
+        BoundInterpolatedStringExpression expression,
+        out BoundExpression replacement) {
+        List<BoundStatement> statements = [];
+        var newContents = ArrayBuilder<BoundExpression>.GetInstance();
+
+        foreach (var content in expression.contents) {
+            statements.AddRange(ExpandExpression(content, out var replacementContent));
+            newContents.Add(replacementContent);
+        }
+
+        replacement = expression.Update(newContents.ToImmutableAndFree(), expression.constantValue, expression.type);
+        return statements;
     }
 
     private protected virtual List<BoundStatement> ExpandCascadeListExpression(

--- a/src/Buckle/Compiler/CodeAnalysis/Display/DisplayText.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Display/DisplayText.cs
@@ -321,6 +321,9 @@ public sealed class DisplayText {
             case BoundKind.SwitchDispatch:
                 DisplaySwitchDispatch(text, (BoundSwitchDispatch)node);
                 break;
+            case BoundKind.InterpolatedStringExpression:
+                DisplayInterpolatedStringExpression(text, (BoundInterpolatedStringExpression)node);
+                break;
             default:
                 throw ExceptionUtilities.UnexpectedValue(node.kind);
         }
@@ -462,6 +465,18 @@ public sealed class DisplayText {
         text.Write(CreateSpace());
         text.Write(CreatePunctuation(SyntaxKind.CloseBracketToken));
         text.WriteLine();
+    }
+
+    private static void DisplayInterpolatedStringExpression(DisplayText text, BoundInterpolatedStringExpression node) {
+        foreach (var expression in node.contents) {
+            if (expression.constantValue?.specialType == SpecialType.String) {
+                DisplayNode(expression);
+            } else {
+                text.Write(CreatePunctuation(SyntaxKind.OpenBraceToken));
+                DisplayNode(expression);
+                text.Write(CreatePunctuation(SyntaxKind.CloseBraceToken));
+            }
+        }
     }
 
     private static void DisplayMethodGroup(DisplayText text, BoundMethodGroup node) {

--- a/src/Buckle/Compiler/CodeAnalysis/Emitting/ILEmitter.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Emitting/ILEmitter.cs
@@ -602,6 +602,7 @@ internal sealed partial class ILEmitter : ModuleBuilder {
     }
 
     private void CreateStaticEntryPoint(MethodSymbol entryPoint) {
+        var hasArgs = entryPoint.parameterCount > 0;
         var instanceEntry = _methods[entryPoint];
 
         var staticClass = new TypeDefinition(
@@ -617,12 +618,24 @@ internal sealed partial class ILEmitter : ModuleBuilder {
             GetType(entryPoint.returnType)
         );
 
+        if (hasArgs) {
+            staticEntry.Parameters.Add(new Mono.Cecil.ParameterDefinition(
+                "args",
+                ParameterAttributes.None,
+                GetType(entryPoint.parameters[0].type)
+            ));
+        }
+
         staticClass.Methods.Add(staticEntry);
 
         var staticBuilder = new CecilILBuilder(null, this, staticEntry);
         var il = staticBuilder.iLProcessor;
 
         il.Emit(OpCodes.Newobj, GetMethod(entryPoint.containingType.instanceConstructors[0]));
+
+        if (hasArgs)
+            il.Emit(OpCodes.Ldarg_0);
+
         il.Emit(OpCodes.Callvirt, instanceEntry);
         il.Emit(OpCodes.Ret);
 

--- a/src/Buckle/Compiler/CodeAnalysis/Evaluating/Evaluator.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Evaluating/Evaluator.cs
@@ -484,12 +484,16 @@ internal sealed class Evaluator {
                             index = labelToIndex[dispatch.defaultLabel];
 
                             foreach (var (value, label) in dispatch.cases) {
+                                var op = RelationalOperatorType(
+                                    dispatch.expression.StrippedType().EnumUnderlyingTypeOrSelf().StrippedType()
+                                );
+
                                 var comparison = EvaluateEqualityOperator(
                                     false,
                                     true,
                                     expression,
                                     EvaluatorValue.Literal(value.value, value.specialType),
-                                    RelationalOperatorType(dispatch.expression.StrippedType())
+                                    op
                                 );
 
                                 if (comparison.@bool) {
@@ -848,6 +852,27 @@ internal sealed class Evaluator {
     }
 
     private EvaluatorValue EvaluateConvertCallOrNumericConversion(BoundCastExpression node, EvaluatorValue value) {
+        if (node.operand.StrippedType().IsEnumType()) {
+            if (node.type.specialType == SpecialType.String) {
+                var type = node.operand.StrippedType();
+                var underlyingType = type.GetEnumUnderlyingType().StrippedType();
+                var op = RelationalOperatorType(underlyingType);
+
+                foreach (var member in type.GetMembers()) {
+                    if (member is FieldSymbol f && f.isStatic) {
+                        if (EvaluateEqualityOperator(
+                            false,
+                            true,
+                            value,
+                            EvaluatorValue.Literal(f.constantValue, underlyingType.specialType),
+                            op).@bool) {
+                            return EvaluatorValue.Literal(f.name);
+                        }
+                    }
+                }
+            }
+        }
+
         var fromTypeSymbol = node.operand.Type();
 
         if (fromTypeSymbol.IsEnumType())
@@ -1395,13 +1420,20 @@ internal sealed class Evaluator {
             return EvaluatorValue.None;
 
         if (value.kind == ValueKind.Null)
-            return value;
+            return EvaluatorValue.Null;
 
-        var operandType = operand.Type();
-        var targetType = node.Type();
+        var operandType = operand.StrippedType();
+        var targetType = node.StrippedType();
 
         if (operandType.InheritsFromIgnoringConstruction((NamedTypeSymbol)targetType))
             return value;
+
+        if (value.kind == ValueKind.HeapPtr) {
+            var type = _context.heap[value.ptr].type;
+
+            if (type.InheritsFromIgnoringConstruction((NamedTypeSymbol)targetType))
+                return value;
+        }
 
         return EvaluatorValue.Null;
     }
@@ -2085,6 +2117,9 @@ internal sealed class Evaluator {
                 break;
             case BinaryOperatorKind.String:
                 left.@bool = left.@string == right.@string;
+                break;
+            case BinaryOperatorKind.Char:
+                left.@bool = left.@char == right.@char;
                 break;
             case BinaryOperatorKind.Object:
                 left.@bool = left.ptr == right.ptr;

--- a/src/Buckle/Compiler/CodeAnalysis/Lowering/Expander.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Lowering/Expander.cs
@@ -4,6 +4,7 @@ using Buckle.CodeAnalysis.Binding;
 using Buckle.CodeAnalysis.CodeGeneration;
 using Buckle.CodeAnalysis.Symbols;
 using Buckle.CodeAnalysis.Syntax;
+using Buckle.Libraries;
 using Buckle.Utilities;
 using static Buckle.CodeAnalysis.Binding.BoundFactory;
 
@@ -620,6 +621,121 @@ internal sealed class Expander : BoundTreeExpander {
             null,
             access.Type()
         );
+
+        return statements;
+    }
+
+    private protected override List<BoundStatement> ExpandInterpolatedStringExpression(
+        BoundInterpolatedStringExpression expression,
+        out BoundExpression replacement) {
+        var syntax = expression.syntax;
+        var stringType = CorLibrary.GetSpecialType(SpecialType.String);
+        var nullableStringType = CorLibrary.GetNullableType(SpecialType.String);
+        var statements = new List<BoundStatement>();
+        var tempLocal = GenerateTempLocal(stringType);
+        replacement = Local(syntax, tempLocal);
+        statements.Add(new BoundLocalDeclarationStatement(syntax, new BoundDataContainerDeclaration(syntax,
+            tempLocal,
+            Literal(syntax, string.Empty, stringType)
+        )));
+
+        // ? Null turns into empty strings instead of nulling the entire result
+
+        foreach (var content in expression.contents) {
+            BoundExpression right;
+
+            if (content.constantValue?.specialType == SpecialType.String) {
+                right = Literal(syntax, content.constantValue.value, stringType);
+            } else {
+                statements.AddRange(ExpandExpression(content, out var replacementContent));
+
+                if (replacementContent.IsLiteralNull())
+                    continue;
+
+                if (replacementContent.StrippedType().specialType == SpecialType.String) {
+                    right = replacementContent;
+                } else if (replacementContent.Type().IsVerifierValue()) {
+                    if (!replacementContent.Type().IsNullableType()) {
+                        right = CreateCast(syntax, stringType, replacementContent);
+                    } else {
+                        var conversion = Conversion.Classify(replacementContent.StrippedType(), stringType);
+                        right = new BoundConditionalOperator(syntax,
+                            new BoundIsOperator(syntax,
+                                replacementContent,
+                                Literal(syntax, null, nullableStringType),
+                                false,
+                                null,
+                                CorLibrary.GetSpecialType(SpecialType.Bool)
+                            ),
+                            false,
+                            Literal(syntax, string.Empty, stringType),
+                            Cast(syntax,
+                                stringType,
+                                Lowerer.CreateNullableGetValueCall(syntax, replacementContent, replacementContent.StrippedType()),
+                                conversion,
+                                null
+                            ),
+                            null,
+                            stringType
+                        );
+                    }
+                } else {
+                    var toString = (MethodSymbol)CorLibrary.GetSpecialType(SpecialType.Object)
+                        .GetMembers("ToString").Single(m => m is MethodSymbol);
+
+                    var toStringTemp = GenerateTempLocal(nullableStringType);
+                    right = Local(syntax, toStringTemp);
+
+                    statements.Add(new BoundLocalDeclarationStatement(syntax, new BoundDataContainerDeclaration(syntax,
+                        toStringTemp,
+                        new BoundConditionalOperator(syntax,
+                            new BoundIsOperator(syntax,
+                                replacementContent,
+                                Literal(syntax, null, nullableStringType),
+                                false,
+                                null,
+                                CorLibrary.GetSpecialType(SpecialType.Bool)
+                            ),
+                            false,
+                            Literal(syntax, null, nullableStringType),
+                            new BoundCallExpression(syntax,
+                                replacementContent,
+                                toString,
+                                [],
+                                [],
+                                BitVector.Empty,
+                                LookupResultKind.Viable,
+                                nullableStringType
+                            ),
+                            null,
+                            nullableStringType
+                        )
+                    )));
+                }
+            }
+
+            if (right.Type().IsNullableType()) {
+                right = new BoundNullCoalescingOperator(syntax,
+                    right,
+                    Literal(syntax, string.Empty, stringType),
+                    false,
+                    null,
+                    stringType
+                );
+            }
+
+            statements.Add(new BoundExpressionStatement(syntax, Assignment(syntax,
+                replacement,
+                Binary(syntax,
+                    replacement,
+                    BinaryOperatorKind.StringConcatenation,
+                    right,
+                    stringType
+                ),
+                false,
+                stringType
+            )));
+        }
 
         return statements;
     }

--- a/src/Buckle/Compiler/CodeAnalysis/Parser/Blender.Cursor.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Parser/Blender.Cursor.cs
@@ -42,6 +42,12 @@ internal sealed partial class Blender {
         internal Cursor MoveToFirstChild() {
             var node = currentNodeOrToken.AsNode();
 
+            if (node.kind == SyntaxKind.InterpolatedStringExpression) {
+                var greenToken = Lexer.DereadInterpolatedString((InterpolatedStringExpressionSyntax)node.green);
+                var redToken = new Syntax.SyntaxToken(node.parent, greenToken, node.position, _indexInParent);
+                return new Cursor(redToken, _indexInParent);
+            }
+
             if (node.slotCount > 0) {
                 var child = Syntax.ChildSyntaxList.ItemInternal(node, 0);
 

--- a/src/Buckle/Compiler/CodeAnalysis/Parser/Blender.Reader.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Parser/Blender.Reader.cs
@@ -95,7 +95,7 @@ internal sealed partial class Blender {
 
             blendedNode = CreateBlendedNode(
                 currentNodeOrToken.AsNode(),
-                (SyntaxToken)currentNodeOrToken.AsToken().node
+                (SyntaxToken)currentNodeOrToken.AsToken()?.node
             );
 
             return true;

--- a/src/Buckle/Compiler/CodeAnalysis/Parser/LanguageParser.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Parser/LanguageParser.cs
@@ -321,6 +321,9 @@ internal sealed partial class LanguageParser : SyntaxParser {
     }
 
     private UsingDirectiveSyntax ParseUsingDirective() {
+        if (_isIncrementalAndFactoryContextMatches && _currentNodeKind == SyntaxKind.UsingDirective)
+            return (UsingDirectiveSyntax)EatNode();
+
         var globalKeyword = currentToken.kind == SyntaxKind.GlobalKeyword ? EatToken() : null;
         var keyword = Match(SyntaxKind.UsingKeyword);
         var staticKeyword = currentToken.kind == SyntaxKind.StaticKeyword ? EatToken() : null;
@@ -370,6 +373,11 @@ internal sealed partial class LanguageParser : SyntaxParser {
     }
 
     private MemberDeclarationSyntax ParseMember(bool allowGlobalStatements = false) {
+        if (_isIncrementalAndFactoryContextMatches &&
+            CanReuseMemberDeclaration(_currentNodeKind, allowGlobalStatements)) {
+            return (MemberDeclarationSyntax)EatNode();
+        }
+
         var attributeLists = ParseAttributeLists();
         var modifiers = ParseModifiers();
 
@@ -402,6 +410,29 @@ internal sealed partial class LanguageParser : SyntaxParser {
                     return ParseGlobalStatement(attributeLists, modifiers);
                 else
                     return ParseFieldDeclaration(attributeLists, modifiers);
+        }
+    }
+
+    private bool CanReuseMemberDeclaration(SyntaxKind kind, bool isGlobal) {
+        switch (kind) {
+            case SyntaxKind.ClassDeclaration:
+            case SyntaxKind.StructDeclaration:
+            case SyntaxKind.EnumDeclaration:
+            case SyntaxKind.OperatorDeclaration:
+            case SyntaxKind.ConstructorDeclaration:
+            case SyntaxKind.NamespaceDeclaration:
+            case SyntaxKind.FileScopedNamespaceDeclaration:
+                return true;
+            case SyntaxKind.FieldDeclaration:
+            case SyntaxKind.MethodDeclaration:
+                if (!isGlobal)
+                    return true;
+
+                return currentNode?.parent is Syntax.CompilationUnitSyntax;
+            case SyntaxKind.GlobalStatement:
+                return isGlobal;
+            default:
+                return false;
         }
     }
 
@@ -531,6 +562,9 @@ internal sealed partial class LanguageParser : SyntaxParser {
     }
 
     private EnumMemberDeclarationSyntax ParseEnumMember() {
+        if (_isIncrementalAndFactoryContextMatches && _currentNodeKind == SyntaxKind.EnumMemberDeclaration)
+            return (EnumMemberDeclarationSyntax)EatNode();
+
         var attributeLists = ParseAttributeLists();
         var modifiers = ParseModifiers();
         var identifier = Match(SyntaxKind.IdentifierToken);
@@ -881,11 +915,60 @@ internal sealed partial class LanguageParser : SyntaxParser {
     }
 
     private ParameterListSyntax ParseParameterList() {
+        if (_isIncrementalAndFactoryContextMatches && CanReuseParameterList(currentNode as Syntax.ParameterListSyntax))
+            return (ParameterListSyntax)EatNode();
+
         var openParenthesis = Match(SyntaxKind.OpenParenToken);
         var parameters = ParseParameters();
         var closeParenthesis = Match(SyntaxKind.CloseParenToken);
 
         return SyntaxFactory.ParameterList(openParenthesis, parameters, closeParenthesis);
+    }
+
+    private static bool CanReuseParameterList(Syntax.ParameterListSyntax list) {
+        if (list is null)
+            return false;
+
+        if (list.openParenthesis.isFabricated)
+            return false;
+
+        if (list.closeParenthesis.isFabricated)
+            return false;
+
+        foreach (var parameter in list.parameters) {
+            if (!CanReuseParameter(parameter))
+                return false;
+        }
+
+        return true;
+    }
+
+    private static bool CanReuseParameter(Syntax.ParameterSyntax parameter) {
+        if (parameter is null)
+            return false;
+
+        if (parameter.defaultValue is not null)
+            return false;
+
+        return true;
+    }
+
+    private static bool CanReuseBracketedParameterList(Syntax.TemplateParameterListSyntax list) {
+        if (list is null)
+            return false;
+
+        if (list.openAngleBracket.isFabricated)
+            return false;
+
+        if (list.closeAngleBracket.isFabricated)
+            return false;
+
+        foreach (var parameter in list.parameters) {
+            if (!CanReuseParameter(parameter))
+                return false;
+        }
+
+        return true;
     }
 
     private FunctionPointerParameterListSyntax ParseFunctionPointerParameterList() {
@@ -897,6 +980,11 @@ internal sealed partial class LanguageParser : SyntaxParser {
     }
 
     private TemplateParameterListSyntax ParseTemplateParameterList() {
+        if (_isIncrementalAndFactoryContextMatches &&
+            CanReuseBracketedParameterList(currentNode as Syntax.TemplateParameterListSyntax)) {
+            return (TemplateParameterListSyntax)EatNode();
+        }
+
         var openAngleBracket = Match(SyntaxKind.LessThanToken);
 
         _bracketStack.Push(SyntaxKind.GreaterThanToken);
@@ -962,6 +1050,9 @@ internal sealed partial class LanguageParser : SyntaxParser {
     }
 
     private ParameterSyntax ParseParameter() {
+        if (_isIncrementalAndFactoryContextMatches && CanReuseParameter(currentNode as Syntax.ParameterSyntax))
+            return (ParameterSyntax)EatNode();
+
         var attributes = ParseAttributeLists();
         var modifiers = ParseParameterModifiers();
         var type = ParseType(false);
@@ -1560,6 +1651,9 @@ internal sealed partial class LanguageParser : SyntaxParser {
     }
 
     private StatementSyntax ParseBlockStatement(SyntaxList<SyntaxToken> modifiers = null) {
+        if (_isIncrementalAndFactoryContextMatches && _currentNodeKind == SyntaxKind.BlockStatement)
+            return (BlockStatementSyntax)EatNode();
+
         var openBrace = Match(SyntaxKind.OpenBraceToken);
         var statements = ParseStatements(SyntaxKind.CloseBraceToken);
         var closeBrace = Match(SyntaxKind.CloseBraceToken);
@@ -2375,6 +2469,9 @@ done:
     }
 
     private BracketedArgumentListSyntax ParseBracketedArgumentList() {
+        if (_isIncrementalAndFactoryContextMatches && _currentNodeKind == SyntaxKind.BracketedArgumentList)
+            return (BracketedArgumentListSyntax)EatNode();
+
         var openBracket = MatchTwo(SyntaxKind.OpenBracketToken, SyntaxKind.QuestionOpenBracketToken);
         _bracketStack.Push(SyntaxKind.CloseBracketToken);
         var arguments = ParseArguments(SyntaxKind.CloseBracketToken);
@@ -2385,6 +2482,9 @@ done:
     }
 
     private ArgumentListSyntax ParseArgumentList() {
+        if (_isIncrementalAndFactoryContextMatches && _currentNodeKind == SyntaxKind.ArgumentList)
+            return (ArgumentListSyntax)EatNode();
+
         var openParenthesis = Match(SyntaxKind.OpenParenToken);
         var arguments = ParseArguments(SyntaxKind.CloseParenToken);
         var closeParenthesis = Match(SyntaxKind.CloseParenToken);
@@ -2452,6 +2552,12 @@ done:
     }
 
     private AttributeListSyntax ParseAttributeList() {
+        if (_isIncrementalAndFactoryContextMatches &&
+            _currentNodeKind == SyntaxKind.AttributeList &&
+            (_context & ParserContext.InExpression) == 0) {
+            return (AttributeListSyntax)EatNode();
+        }
+
         var openBracket = EatToken();
 
         var nodesAndSeparators = SyntaxListBuilder<BelteSyntaxNode>.Create();
@@ -2481,6 +2587,9 @@ done:
     }
 
     private AttributeSyntax ParseAttribute() {
+        if (_isIncrementalAndFactoryContextMatches && _currentNodeKind == SyntaxKind.Attribute)
+            return (AttributeSyntax)EatNode();
+
         var name = ParseQualifiedName();
         var arguments = currentToken.kind == SyntaxKind.OpenParenToken ? ParseArgumentList() : null;
         return SyntaxFactory.Attribute(name, arguments);
@@ -2650,6 +2759,9 @@ done:
     }
 
     private IdentifierNameSyntax ParseIdentifierName(bool allowGlobal = false) {
+        if (_isIncrementalAndFactoryContextMatches && _currentNodeKind == SyntaxKind.IdentifierName)
+            return (IdentifierNameSyntax)EatNode();
+
         var identifier = (allowGlobal && currentToken.kind == SyntaxKind.GlobalKeyword)
             ? EatToken()
             : Match(SyntaxKind.IdentifierToken);

--- a/src/Buckle/Compiler/CodeAnalysis/Parser/LanguageParser.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Parser/LanguageParser.cs
@@ -34,6 +34,16 @@ internal sealed partial class LanguageParser : SyntaxParser {
         _bracketStack.Push(SyntaxKind.None);
     }
 
+    private bool _isIncrementalAndFactoryContextMatches {
+        get {
+            if (!_isIncremental)
+                return false;
+
+            var current = currentNode;
+            return current is not null;
+        }
+    }
+
     /// <summary>
     /// Parses the entirety of a single file.
     /// </summary>
@@ -1073,6 +1083,13 @@ internal sealed partial class LanguageParser : SyntaxParser {
         SyntaxList<SyntaxToken> modifiers,
         out bool consumedAttributeLists,
         out bool consumedModifiers) {
+        if (CanReuseStatement(attributeLists)) {
+            var reused = (StatementSyntax)EatNode();
+            consumedAttributeLists = true;
+            consumedModifiers = reused.kind == SyntaxKind.BlockStatement;
+            return reused;
+        }
+
         var saved = _context;
         _context |= ParserContext.InStatement;
 
@@ -1086,6 +1103,12 @@ internal sealed partial class LanguageParser : SyntaxParser {
         _context = saved;
 
         return statement;
+
+        bool CanReuseStatement(SyntaxList<AttributeListSyntax> attributes) {
+            return _isIncrementalAndFactoryContextMatches &&
+                   currentNode is Syntax.StatementSyntax &&
+                   attributes.Count == 0;
+        }
     }
 
     private StatementSyntax ParseStatementInternal(
@@ -1705,6 +1728,9 @@ internal sealed partial class LanguageParser : SyntaxParser {
                 return ParseStringLiteral();
             case SyntaxKind.InterpolatedStringLiteralToken:
                 return ParseInterpolatedStringLiteral();
+            case SyntaxKind.InterpolatedStringStartToken:
+            case SyntaxKind.InterpolatedStringEndToken:
+                throw ExceptionUtilities.UnexpectedValue(currentToken.kind);
             case SyntaxKind.CharacterLiteralToken:
                 return ParseCharacterLiteral();
             case SyntaxKind.NullKeyword:
@@ -2492,60 +2518,86 @@ done:
         var interpolations = SyntaxListBuilder<InterpolatedStringContentSyntax>.Create();
 
         var tempLexer = new Lexer(SourceText.From(originalText), options, allowPreprocessorDirectives: false);
-        var groups = tempLexer.RereadInterpolatedString();
+        var groups = tempLexer.RereadInterpolatedString(out var hasCloseQuote);
 
         foreach (var group in groups) {
-            if (group.Length == 1 && group[0].kind == SyntaxKind.InterpolatedStringLiteralToken)
+            if (group.Length == 1 && group[0].kind == SyntaxKind.StringLiteralToken)
                 interpolations.Add(SyntaxFactory.InterpolatedStringText(group[0]));
             else
                 interpolations.Add(ParseInterpolation(group));
         }
 
-        return SyntaxFactory.InterpolatedStringExpression(interpolations.ToList());
+        var openQuote = SyntaxFactory.Token(
+            SyntaxKind.InterpolatedStringStartToken,
+            2,
+            originalText[0..2],
+            null,
+            originalToken.GetLeadingTrivia(),
+            null
+        );
+
+        var closeQuote = hasCloseQuote
+            ? SyntaxFactory.Token(
+                SyntaxKind.InterpolatedStringEndToken,
+                1,
+                originalText[^1].ToString(),
+                null,
+                null,
+                originalToken.GetTrailingTrivia())
+            : SyntaxFactory.Missing(
+                SyntaxKind.InterpolatedStringEndToken,
+                null,
+                originalToken.GetTrailingTrivia());
+
+        return SyntaxFactory.InterpolatedStringExpression(openQuote, interpolations.ToList(), closeQuote);
     }
 
     private InterpolationSyntax ParseInterpolation(SyntaxToken[] tokens) {
         var openBrace = tokens[0];
-
         ExpressionSyntax expression = null;
-
-        if (tokens.Length > 1) {
-            var tempLexer = new Lexer(SourceText.From(tokens[1].text), options, allowPreprocessorDirectives: false);
-            var tempParser = new LanguageParser(tempLexer, oldTree: null, changes: null);
-
-            expression = tempParser.ParseExpression(true);
-            var report = true;
-
-            while (tempParser._currentToken.kind != SyntaxKind.EndOfFileToken) {
-                var unexpected = tempParser.EatToken(stallDiagnostics: true);
-
-                if (report) {
-                    report = false;
-                    expression = tempParser.AddDiagnostic(
-                        tempParser.WithFutureDiagnostics(tempParser.AddTrailingSkippedSyntax(expression, unexpected)),
-                        Error.UnexpectedToken(unexpected.kind),
-                        unexpected.GetLeadingTriviaWidth(),
-                        unexpected.width
-                    );
-                } else {
-                    expression = tempParser.WithFutureDiagnostics(tempParser.AddTrailingSkippedSyntax(expression, unexpected));
-                }
-            }
-        }
-
         SyntaxToken closeBrace;
 
-        if (tokens.Length == 3) {
-            closeBrace = tokens[2];
+        if (tokens.Length == 2 && tokens[1].kind == SyntaxKind.CloseBraceToken) {
+            closeBrace = tokens[1];
         } else {
-            var unexpectedToken = EatToken();
+            if (tokens.Length > 1) {
+                var tempLexer = new Lexer(SourceText.From(tokens[1].text), options, allowPreprocessorDirectives: false);
+                var tempParser = new LanguageParser(tempLexer, oldTree: null, changes: null);
 
-            closeBrace = AddDiagnostic(
-                AddLeadingSkippedSyntax(SyntaxFactory.Missing(SyntaxKind.CloseBraceToken), unexpectedToken),
-                GetUnexpectedTokenError(unexpectedToken.kind, SyntaxKind.CloseBraceToken),
-                unexpectedToken.GetLeadingTriviaWidth(),
-                unexpectedToken.width
-            );
+                expression = tempParser.ParseExpression(true);
+                var report = true;
+
+                while (tempParser._currentToken.kind != SyntaxKind.EndOfFileToken) {
+                    var unexpected = tempParser.EatToken(stallDiagnostics: true);
+
+                    if (report) {
+                        report = false;
+                        expression = tempParser.AddDiagnostic(
+                            tempParser.WithFutureDiagnostics(tempParser.AddTrailingSkippedSyntax(expression, unexpected)),
+                            Error.UnexpectedToken(unexpected.kind),
+                            unexpected.GetLeadingTriviaWidth(),
+                            unexpected.width
+                        );
+                    } else {
+                        expression = tempParser.WithFutureDiagnostics(
+                            tempParser.AddTrailingSkippedSyntax(expression, unexpected)
+                        );
+                    }
+                }
+            }
+
+            if (tokens.Length == 3) {
+                closeBrace = tokens[2];
+            } else {
+                var unexpectedToken = EatToken();
+
+                closeBrace = AddDiagnostic(
+                    AddLeadingSkippedSyntax(SyntaxFactory.Missing(SyntaxKind.CloseBraceToken), unexpectedToken),
+                    GetUnexpectedTokenError(unexpectedToken.kind, SyntaxKind.CloseBraceToken),
+                    unexpectedToken.GetLeadingTriviaWidth(),
+                    unexpectedToken.width
+                );
+            }
         }
 
         return SyntaxFactory.Interpolation(openBrace, expression, closeBrace);

--- a/src/Buckle/Compiler/CodeAnalysis/Parser/LanguageParser.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Parser/LanguageParser.cs
@@ -1703,6 +1703,8 @@ internal sealed partial class LanguageParser : SyntaxParser {
                 return ParseNumericLiteral();
             case SyntaxKind.StringLiteralToken:
                 return ParseStringLiteral();
+            case SyntaxKind.InterpolatedStringLiteralToken:
+                return ParseInterpolatedStringLiteral();
             case SyntaxKind.CharacterLiteralToken:
                 return ParseCharacterLiteral();
             case SyntaxKind.NullKeyword:
@@ -2482,6 +2484,71 @@ done:
     private ExpressionSyntax ParseStringLiteral() {
         var stringToken = Match(SyntaxKind.StringLiteralToken);
         return SyntaxFactory.Literal(stringToken);
+    }
+
+    private ExpressionSyntax ParseInterpolatedStringLiteral() {
+        var originalToken = EatToken();
+        var originalText = originalToken.text;
+        var interpolations = SyntaxListBuilder<InterpolatedStringContentSyntax>.Create();
+
+        var tempLexer = new Lexer(SourceText.From(originalText), options, allowPreprocessorDirectives: false);
+        var groups = tempLexer.RereadInterpolatedString();
+
+        foreach (var group in groups) {
+            if (group.Length == 1 && group[0].kind == SyntaxKind.InterpolatedStringLiteralToken)
+                interpolations.Add(SyntaxFactory.InterpolatedStringText(group[0]));
+            else
+                interpolations.Add(ParseInterpolation(group));
+        }
+
+        return SyntaxFactory.InterpolatedStringExpression(interpolations.ToList());
+    }
+
+    private InterpolationSyntax ParseInterpolation(SyntaxToken[] tokens) {
+        var openBrace = tokens[0];
+
+        ExpressionSyntax expression = null;
+
+        if (tokens.Length > 1) {
+            var tempLexer = new Lexer(SourceText.From(tokens[1].text), options, allowPreprocessorDirectives: false);
+            var tempParser = new LanguageParser(tempLexer, oldTree: null, changes: null);
+
+            expression = tempParser.ParseExpression(true);
+            var report = true;
+
+            while (tempParser._currentToken.kind != SyntaxKind.EndOfFileToken) {
+                var unexpected = tempParser.EatToken(stallDiagnostics: true);
+
+                if (report) {
+                    report = false;
+                    expression = tempParser.AddDiagnostic(
+                        tempParser.WithFutureDiagnostics(tempParser.AddTrailingSkippedSyntax(expression, unexpected)),
+                        Error.UnexpectedToken(unexpected.kind),
+                        unexpected.GetLeadingTriviaWidth(),
+                        unexpected.width
+                    );
+                } else {
+                    expression = tempParser.WithFutureDiagnostics(tempParser.AddTrailingSkippedSyntax(expression, unexpected));
+                }
+            }
+        }
+
+        SyntaxToken closeBrace;
+
+        if (tokens.Length == 3) {
+            closeBrace = tokens[2];
+        } else {
+            var unexpectedToken = EatToken();
+
+            closeBrace = AddDiagnostic(
+                AddLeadingSkippedSyntax(SyntaxFactory.Missing(SyntaxKind.CloseBraceToken), unexpectedToken),
+                GetUnexpectedTokenError(unexpectedToken.kind, SyntaxKind.CloseBraceToken),
+                unexpectedToken.GetLeadingTriviaWidth(),
+                unexpectedToken.width
+            );
+        }
+
+        return SyntaxFactory.Interpolation(openBrace, expression, closeBrace);
     }
 
     private ExpressionSyntax ParseCharacterLiteral() {

--- a/src/Buckle/Compiler/CodeAnalysis/Parser/Lexer.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Parser/Lexer.cs
@@ -771,7 +771,7 @@ internal sealed class Lexer : IDisposable {
 
         _position += 2;
 
-        while (true) {
+        while (_current != '\0') {
             var inner = ReadStringContent(false, true, out var normalEnd);
             var tokenWidth = _position - _start;
             var tokenValue = inner.ToString();

--- a/src/Buckle/Compiler/CodeAnalysis/Parser/Lexer.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Parser/Lexer.cs
@@ -594,7 +594,7 @@ internal sealed class Lexer : IDisposable {
         var saved = _position;
         _position++;
 
-        var sb = ReadStringContent(isCharacter, false, out _);
+        var sb = ReadStringContent(isCharacter, false, true, out _);
 
         _kind = isCharacter ? SyntaxKind.CharacterLiteralToken : SyntaxKind.StringLiteralToken;
 
@@ -613,7 +613,11 @@ internal sealed class Lexer : IDisposable {
         }
     }
 
-    private StringBuilder ReadStringContent(bool isCharacter, bool isInterpolation, out bool normalEnd) {
+    private StringBuilder ReadStringContent(
+        bool isCharacter,
+        bool isInterpolation,
+        bool consumeEndQuote,
+        out bool normalEnd) {
         var sb = new StringBuilder();
         var done = false;
         normalEnd = false;
@@ -631,7 +635,9 @@ internal sealed class Lexer : IDisposable {
                         sb.Append(_current);
                         _position += 2;
                     } else {
-                        _position++;
+                        if (consumeEndQuote)
+                            _position++;
+
                         done = true;
                         normalEnd = true;
                     }
@@ -736,7 +742,7 @@ internal sealed class Lexer : IDisposable {
         var sb = new StringBuilder();
 
         while (true) {
-            var inner = ReadStringContent(false, true, out var normalEnd);
+            var inner = ReadStringContent(false, true, true, out var normalEnd);
             sb.Append(inner);
 
             if (normalEnd || _current != '{')
@@ -765,20 +771,39 @@ internal sealed class Lexer : IDisposable {
         _value = sb.ToString();
     }
 
-    internal SyntaxToken[][] RereadInterpolatedString() {
+    internal static SyntaxToken DereadInterpolatedString(InterpolatedStringExpressionSyntax interpolatedString) {
+        var text = interpolatedString.ToString();
+
+        return SyntaxFactory.Token(
+            SyntaxKind.InterpolatedStringLiteralToken,
+            text,
+            text,
+            interpolatedString.GetFirstToken().GetLeadingTrivia(),
+            interpolatedString.GetLastToken().GetTrailingTrivia()
+        );
+    }
+
+    internal SyntaxToken[][] RereadInterpolatedString(out bool hasCloseQuote) {
+        hasCloseQuote = false;
         var groups = ArrayBuilder<SyntaxToken[]>.GetInstance();
-        var startPosition = _position;
 
         _position += 2;
+        var startPosition = _position;
+        _start = _position;
 
         while (_current != '\0') {
-            var inner = ReadStringContent(false, true, out var normalEnd);
+            var inner = ReadStringContent(false, true, false, out var normalEnd);
+            hasCloseQuote = normalEnd;
             var tokenWidth = _position - _start;
+
+            if (normalEnd && tokenWidth == 0)
+                break;
+
             var tokenValue = inner.ToString();
             var diagnostics = GetDiagnostics(GetFullWidth(_leadingTriviaCache));
             _trailingTriviaCache.Clear();
             var tokenText = text.ToString(new TextSpan(startPosition, tokenWidth));
-            groups.Add([Create(SyntaxKind.InterpolatedStringLiteralToken, tokenText, tokenValue, diagnostics)]);
+            groups.Add([Create(SyntaxKind.StringLiteralToken, tokenText, tokenValue, diagnostics)]);
 
             if (normalEnd || _current != '{')
                 break;
@@ -806,11 +831,14 @@ internal sealed class Lexer : IDisposable {
 
                 if (earlyEof || (_current == '}' && bracketStack == 0)) {
                     var sbWidth = _position - sbStart;
-                    var sbValue = sb.ToString();
-                    var diag = GetDiagnostics(GetFullWidth(_leadingTriviaCache));
-                    _trailingTriviaCache.Clear();
-                    var sbText = text.ToString(new TextSpan(sbStart, sbWidth));
-                    groupBuilder.Add(Create(SyntaxKind.StringLiteralToken, sbText, sbValue, diag));
+
+                    if (sbWidth > 0) {
+                        var sbValue = sb.ToString();
+                        var diag = GetDiagnostics(GetFullWidth(_leadingTriviaCache));
+                        _trailingTriviaCache.Clear();
+                        var sbText = text.ToString(new TextSpan(sbStart, sbWidth));
+                        groupBuilder.Add(Create(SyntaxKind.StringLiteralToken, sbText, sbValue, diag));
+                    }
 
                     if (!earlyEof) {
                         var token = LexNext(LexerMode.Syntax);

--- a/src/Buckle/Compiler/CodeAnalysis/Parser/Lexer.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Parser/Lexer.cs
@@ -7,6 +7,7 @@ using Buckle.Diagnostics;
 using Buckle.Libraries;
 using Buckle.Utilities;
 using Diagnostics;
+using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Buckle.CodeAnalysis.Syntax.InternalSyntax;
 
@@ -500,6 +501,11 @@ internal sealed class Lexer : IDisposable {
             case '\'':
                 ReadStringLiteral(true);
                 break;
+            case 'f':
+                if (TryReadInterpolatedString())
+                    break;
+
+                goto default;
             case '0':
             case '1':
             case '2':
@@ -587,8 +593,30 @@ internal sealed class Lexer : IDisposable {
     private void ReadStringLiteral(bool isCharacter) {
         var saved = _position;
         _position++;
+
+        var sb = ReadStringContent(isCharacter, false, out _);
+
+        _kind = isCharacter ? SyntaxKind.CharacterLiteralToken : SyntaxKind.StringLiteralToken;
+
+        if (isCharacter) {
+            if (isCharacter && sb.Length == 0) {
+                AddDiagnostic(Error.EmptyCharacterLiteral(), saved, 2);
+                _value = null;
+            } else if (isCharacter && sb.Length > 1) {
+                AddDiagnostic(Error.CharacterLiteralTooLong(), saved, sb.Length + 2);
+                _value = sb[0];
+            } else {
+                _value = sb[0];
+            }
+        } else {
+            _value = sb.ToString();
+        }
+    }
+
+    private StringBuilder ReadStringContent(bool isCharacter, bool isInterpolation, out bool normalEnd) {
         var sb = new StringBuilder();
         var done = false;
+        normalEnd = false;
 
         while (!done) {
             switch (_current) {
@@ -605,9 +633,24 @@ internal sealed class Lexer : IDisposable {
                     } else {
                         _position++;
                         done = true;
+                        normalEnd = true;
                     }
 
                     break;
+                case '{':
+                case '}':
+                    if (isInterpolation) {
+                        if (_lookahead == _current) {
+                            sb.Append(_current);
+                            _position += 2;
+                        } else {
+                            done = true;
+                        }
+
+                        break;
+                    }
+
+                    goto default;
                 case '\'' when isCharacter:
                     _position++;
                     done = true;
@@ -675,22 +718,117 @@ internal sealed class Lexer : IDisposable {
             }
         }
 
-        _kind = isCharacter ? SyntaxKind.CharacterLiteralToken : SyntaxKind.StringLiteralToken;
+        return sb;
+    }
 
-        if (isCharacter) {
-            if (isCharacter && sb.Length == 0) {
-                AddDiagnostic(Error.EmptyCharacterLiteral(), saved, 2);
-                _value = null;
-            } else if (isCharacter && sb.Length > 1) {
-                AddDiagnostic(Error.CharacterLiteralTooLong(), saved, sb.Length + 2);
-                _value = sb[0];
-            } else {
-                _value = sb[0];
-            }
-        } else {
-            _value = sb.ToString();
+    private bool TryReadInterpolatedString() {
+        if (Peek(1) == '"') {
+            ReadInterpolatedString();
+            return true;
         }
 
+        return false;
+    }
+
+    private void ReadInterpolatedString() {
+        _position += 2;
+
+        var sb = new StringBuilder();
+
+        while (true) {
+            var inner = ReadStringContent(false, true, out var normalEnd);
+            sb.Append(inner);
+
+            if (normalEnd || _current != '{')
+                break;
+
+            var bracketStack = 0;
+
+            while (_current != '\0') {
+                if (_current == '{')
+                    bracketStack++;
+                else if (_current == '}')
+                    bracketStack--;
+
+                sb.Append(_current);
+
+                if (_current == '}' && bracketStack == 0) {
+                    _position++;
+                    break;
+                } else {
+                    _position++;
+                }
+            }
+        }
+
+        _kind = SyntaxKind.InterpolatedStringLiteralToken;
+        _value = sb.ToString();
+    }
+
+    internal SyntaxToken[][] RereadInterpolatedString() {
+        var groups = ArrayBuilder<SyntaxToken[]>.GetInstance();
+        var startPosition = _position;
+
+        _position += 2;
+
+        while (true) {
+            var inner = ReadStringContent(false, true, out var normalEnd);
+            var tokenWidth = _position - _start;
+            var tokenValue = inner.ToString();
+            var diagnostics = GetDiagnostics(GetFullWidth(_leadingTriviaCache));
+            _trailingTriviaCache.Clear();
+            var tokenText = text.ToString(new TextSpan(startPosition, tokenWidth));
+            groups.Add([Create(SyntaxKind.InterpolatedStringLiteralToken, tokenText, tokenValue, diagnostics)]);
+
+            if (normalEnd || _current != '{')
+                break;
+
+            var groupBuilder = ArrayBuilder<SyntaxToken>.GetInstance();
+            var bracketStack = 0;
+            var sb = new StringBuilder();
+            var sbStart = _position;
+
+            while (_current != '\0') {
+                if (bracketStack == 0 && _current == '{') {
+                    bracketStack++;
+                    var token = LexNext(LexerMode.Syntax);
+                    groupBuilder.Add(token);
+                    sbStart = _position;
+                    continue;
+                }
+
+                if (_current == '{')
+                    bracketStack++;
+                else if (_current == '}')
+                    bracketStack--;
+
+                var earlyEof = _current == '\0';
+
+                if (earlyEof || (_current == '}' && bracketStack == 0)) {
+                    var sbWidth = _position - sbStart;
+                    var sbValue = sb.ToString();
+                    var diag = GetDiagnostics(GetFullWidth(_leadingTriviaCache));
+                    _trailingTriviaCache.Clear();
+                    var sbText = text.ToString(new TextSpan(sbStart, sbWidth));
+                    groupBuilder.Add(Create(SyntaxKind.StringLiteralToken, sbText, sbValue, diag));
+
+                    if (!earlyEof) {
+                        var token = LexNext(LexerMode.Syntax);
+                        groupBuilder.Add(token);
+                    }
+
+                    break;
+                } else {
+                    sb.Append(_current);
+                    _position++;
+                }
+            }
+
+            groups.Add(groupBuilder.ToArrayAndFree());
+            startPosition = _position;
+        }
+
+        return groups.ToArrayAndFree();
     }
 
     private void ReadNumericLiteral() {

--- a/src/Buckle/Compiler/CodeAnalysis/Parser/SyntaxParser.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Parser/SyntaxParser.cs
@@ -474,7 +474,7 @@ internal abstract partial class SyntaxParser : IDisposable {
             : Error.UnexpectedTokenExpectedOthers(unexpected, kind1, kind2);
     }
 
-    private static Diagnostic GetUnexpectedTokenError(SyntaxKind unexpected, SyntaxKind expected) {
+    private protected static Diagnostic GetUnexpectedTokenError(SyntaxKind unexpected, SyntaxKind expected) {
         return unexpected == SyntaxKind.EndOfFileToken
             ? Error.ExpectedTokenAtEOF(expected)
             : Error.UnexpectedTokenExpectedAnother(unexpected, expected);

--- a/src/Buckle/Compiler/CodeAnalysis/Parser/SyntaxParser.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Parser/SyntaxParser.cs
@@ -69,6 +69,13 @@ internal abstract partial class SyntaxParser : IDisposable {
         }
     }
 
+    private protected SyntaxKind _currentNodeKind {
+        get {
+            var cn = currentNode;
+            return cn is not null ? cn.kind : SyntaxKind.None;
+        }
+    }
+
     internal DirectiveStack directives => _lexer.directives;
 
     internal ParseOptions options => _lexer.options;

--- a/src/Buckle/Compiler/CodeAnalysis/Parser/SyntaxParser.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Parser/SyntaxParser.cs
@@ -13,8 +13,8 @@ internal abstract partial class SyntaxParser : IDisposable {
         new ObjectPool<BlendedNode[]>(() => new BlendedNode[32], 2);
 
     private protected readonly Lexer _lexer;
+    private protected readonly bool _isIncremental;
     private readonly LexerMode _mode;
-    private readonly bool _isIncremental;
     private readonly Blender _firstBlender;
     private readonly List<Diagnostic> _futureDiagnostics;
 
@@ -59,13 +59,13 @@ internal abstract partial class SyntaxParser : IDisposable {
     // Used for reusing nodes from the old tree. Just validate and call EatNode to reuse an old node.
     internal SyntaxNode currentNode {
         get {
-            var node = _currentNode.node;
+            var node = _currentNode?.node;
 
             if (node is not null)
                 return node;
 
             ReadCurrentNode();
-            return _currentNode.node;
+            return _currentNode?.node;
         }
     }
 
@@ -303,8 +303,8 @@ internal abstract partial class SyntaxParser : IDisposable {
         _futureDiagnostics.Add(diagnostic);
     }
 
-    private protected SyntaxNode EatNode() {
-        var saved = currentNode;
+    private protected GreenNode EatNode() {
+        var saved = currentNode.green;
 
         if (_tokenOffset >= _blendedTokens.Length)
             AddTokenSlot();

--- a/src/Buckle/Compiler/CodeAnalysis/Syntax/InternalSyntax/SyntaxFactory.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Syntax/InternalSyntax/SyntaxFactory.cs
@@ -52,6 +52,15 @@ internal static partial class SyntaxFactory {
     }
 
     /// <summary>
+    /// Creates a <see cref="SyntaxToken" /> with a text, a value, and trivia.
+    /// </summary>
+    internal static SyntaxToken Token(
+        SyntaxKind kind, string text, object value,
+        GreenNode leading, GreenNode trailing) {
+        return new SyntaxToken(kind, text, value, leading, trailing);
+    }
+
+    /// <summary>
     /// Creates a <see cref="SyntaxTrivia" /> with text and diagnostics.
     /// </summary>
     internal static SyntaxTrivia Trivia(SyntaxKind kind, string text, Diagnostic[] diagnostics) {
@@ -70,6 +79,13 @@ internal static partial class SyntaxFactory {
     /// </summary>
     internal static SyntaxToken Missing(SyntaxKind kind) {
         return SyntaxToken.CreateMissing(kind, null, null);
+    }
+
+    /// <summary>
+    /// Creates a missing <see cref="SyntaxToken" /> with trivia.
+    /// </summary>
+    internal static SyntaxToken Missing(SyntaxKind kind, GreenNode leading, GreenNode trailing) {
+        return SyntaxToken.CreateMissing(kind, leading, trailing);
     }
 
     /// <summary>

--- a/src/Buckle/Compiler/CodeAnalysis/Syntax/Syntax.xml
+++ b/src/Buckle/Compiler/CodeAnalysis/Syntax/Syntax.xml
@@ -1029,6 +1029,27 @@
     <Kind Name="LiteralExpression"/>
     <Field Name="token" Type="SyntaxToken"/>
   </Node>
+  <Node Name="InterpolatedStringExpressionSyntax" Base="ExpressionSyntax">
+    <Kind Name="InterpolatedStringExpression"/>
+    <Field Name="contents" Type="SyntaxList&lt;InterpolatedStringContentSyntax&gt;"/>
+  </Node>
+  <AbstractNode Name="InterpolatedStringContentSyntax" Base="SyntaxNode"/>
+  <Node Name="InterpolatedStringTextSyntax" Base="InterpolatedStringContentSyntax">
+    <Kind Name="InterpolatedStringText"/>
+    <Field Name="token" Type="SyntaxToken">
+      <Kind Name="InterpolatedStringLiteralToken"/>
+    </Field>
+  </Node>
+  <Node Name="InterpolationSyntax" Base="InterpolatedStringContentSyntax">
+    <Kind Name="Interpolation"/>
+    <Field Name="openBrace" Type="SyntaxToken">
+      <Kind Name="OpenBraceToken"/>
+    </Field>
+    <Field Name="expression" Type="ExpressionSyntax" Optional="true"/>
+    <Field Name="closeBrace" Type="SyntaxToken">
+      <Kind Name="CloseBraceToken"/>
+    </Field>
+  </Node>
   <Node Name="MemberAccessExpressionSyntax" Base="ExpressionSyntax">
     <Kind Name="MemberAccessExpression"/>
     <Field Name="expression" Type="ExpressionSyntax"/>

--- a/src/Buckle/Compiler/CodeAnalysis/Syntax/Syntax.xml
+++ b/src/Buckle/Compiler/CodeAnalysis/Syntax/Syntax.xml
@@ -1031,13 +1031,19 @@
   </Node>
   <Node Name="InterpolatedStringExpressionSyntax" Base="ExpressionSyntax">
     <Kind Name="InterpolatedStringExpression"/>
+    <Field Name="stringStart" Type="SyntaxToken">
+      <Kind Name="InterpolatedStringStartToken"/>
+    </Field>
     <Field Name="contents" Type="SyntaxList&lt;InterpolatedStringContentSyntax&gt;"/>
+    <Field Name="stringEnd" Type="SyntaxToken">
+      <Kind Name="InterpolatedStringEndToken"/>
+    </Field>
   </Node>
   <AbstractNode Name="InterpolatedStringContentSyntax" Base="SyntaxNode"/>
   <Node Name="InterpolatedStringTextSyntax" Base="InterpolatedStringContentSyntax">
     <Kind Name="InterpolatedStringText"/>
     <Field Name="token" Type="SyntaxToken">
-      <Kind Name="InterpolatedStringLiteralToken"/>
+      <Kind Name="StringLiteralToken"/>
     </Field>
   </Node>
   <Node Name="InterpolationSyntax" Base="InterpolatedStringContentSyntax">

--- a/src/Buckle/Compiler/CodeAnalysis/Syntax/SyntaxKind.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Syntax/SyntaxKind.cs
@@ -146,6 +146,7 @@ public enum SyntaxKind : ushort {
     NumericLiteralToken,
     StringLiteralToken,
     CharacterLiteralToken,
+    InterpolatedStringLiteralToken,
 
     // Trivia
     EndOfLineTrivia,
@@ -192,6 +193,9 @@ public enum SyntaxKind : ushort {
     CascadeExpression,
     StackAllocExpression,
     ImplicitEnumFieldExpression,
+    InterpolatedStringExpression,
+    InterpolatedStringText,
+    Interpolation,
 
     // Statements
     EmptyStatement,

--- a/src/Buckle/Compiler/CodeAnalysis/Syntax/SyntaxKind.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Syntax/SyntaxKind.cs
@@ -196,6 +196,8 @@ public enum SyntaxKind : ushort {
     InterpolatedStringExpression,
     InterpolatedStringText,
     Interpolation,
+    InterpolatedStringStartToken,
+    InterpolatedStringEndToken,
 
     // Statements
     EmptyStatement,

--- a/src/Buckle/Compiler/Libraries/Standard/StandardLibrary.cs
+++ b/src/Buckle/Compiler/Libraries/Standard/StandardLibrary.cs
@@ -526,9 +526,9 @@ internal static class StandardLibrary {
             { "Console_ResetColor", new Func<object, object, object, object>((a, b, c)
                 => { if (!System.Console.IsOutputRedirected) System.Console.ResetColor(); return null; }) },
             { "Console_SetForegroundColor_I", new Func<object, object, object, object>((a, b, c)
-                => { if (!System.Console.IsOutputRedirected) System.Console.ForegroundColor = (ConsoleColor)a; return null; }) },
+                => { if (!System.Console.IsOutputRedirected) System.Console.ForegroundColor = (ConsoleColor)(long)a; return null; }) },
             { "Console_SetBackgroundColor_I", new Func<object, object, object, object>((a, b, c)
-                => { if (!System.Console.IsOutputRedirected) System.Console.BackgroundColor = (ConsoleColor)a; return null; }) },
+                => { if (!System.Console.IsOutputRedirected) System.Console.BackgroundColor = (ConsoleColor)(long)a; return null; }) },
             { "Console_SetCursorPosition_I?I?", new Func<object, object, object, object>((a, b, c)
                 => { if (!System.Console.IsOutputRedirected) { System.Console.SetCursorPosition(a is null ? System.Console.CursorLeft : Convert.ToInt32(a), b is null ? System.Console.CursorTop : Convert.ToInt32(b)); } return null; }) },
             { "Console_SetCursorVisibility_B", new Func<object, object, object, object>((a, b, c)
@@ -709,6 +709,8 @@ internal static class StandardLibrary {
                 => { return a is null || char.IsWhiteSpace((char)a); }) },
             { "String_IsDigit_C?", new Func<object, object, object, object>((a, b, c)
                 => { return a is not null && char.IsDigit((char)a); }) },
+            { "String_Length_S", new Func<object, object, object, object>((a, b, c)
+                => { return ((string)a).Length; }) },
             { "String_Substring_S?I?I?", new Func<object, object, object, object>((a, b, c)
                 => { if (a is null) return null;
                      if (c is null) return ((string)a).Substring(b is null ? 0 : unchecked((int)(long)b));


### PR DESCRIPTION
# Description

Simple string interpolation (no formatting or alignment, just expressions). E.g. `f"some text {local + 3} more text";`

Also fixed some Evaluator bugs related to the `as` operator, switch dispatching, and converting enums to strings.
