### PR TITLE
Rw/expanderimprove

### DIFF
--- a/src/Belte/Native/Standard/Collections/Dictionary.blt
+++ b/src/Belte/Native/Standard/Collections/Dictionary.blt
@@ -25,7 +25,7 @@ public lowlevel sealed class Dictionary<type TKey, type TValue> {
     public constructor(Dictionary<TKey, TValue> dictionary) : this(dictionary, null) { }
 
     public constructor(Dictionary<TKey, TValue> dictionary, EqualityComparer<TKey> comparer)
-        : this(dictionary isnt null ? dictionary.Length() : 0, comparer) {
+        : this(dictionary?.Length()?, comparer) {
         if (dictionary is null)
             throw new ArgumentNullException();
 

--- a/src/Buckle/Compiler.Tests/CodeAnalysis/Evaluating/EvaluatorTests.cs
+++ b/src/Buckle/Compiler.Tests/CodeAnalysis/Evaluating/EvaluatorTests.cs
@@ -493,6 +493,53 @@ public sealed class EvaluatorTests {
     int! b = a?.Length()?;
     return b;
     ", 0)]
+    [InlineData(@"
+    class A {
+        public int a;
+    }
+
+    A a = new A();
+    a?.a = 3;
+    return a?.a;
+    ", 3)]
+    [InlineData(@"
+    class A {
+        public int a;
+        public A b;
+    }
+
+    A a = new A();
+    a?.b?.a = 3;
+    return a?.b?.a;
+    ", null)]
+    [InlineData(@"
+    class A {
+        public int a;
+        public void M() { a = 5; }
+    }
+
+    A a = new A()?..M();
+    return a.a;
+    ", 5)]
+    [InlineData(@"
+    class A {
+        public int a;
+        public void M() { a = 5; }
+    }
+
+    A a = null;
+    var b = a?..M();
+    return b?.a;
+    ", null)]
+    [InlineData(@"
+    class A {
+        public int a;
+        public A b;
+    }
+
+    var a = new A()?..b = (new A()..a = 4);
+    return a.b.a;
+    ", 4)]
     public void Evaluator_Computes_CorrectValues(string text, object? expectedValue) {
         AssertValue(text, expectedValue, evaluator: true, executor: true);
     }

--- a/src/Buckle/Compiler.Tests/CodeAnalysis/Evaluating/EvaluatorTests.cs
+++ b/src/Buckle/Compiler.Tests/CodeAnalysis/Evaluating/EvaluatorTests.cs
@@ -540,6 +540,16 @@ public sealed class EvaluatorTests {
     var a = new A()?..b = (new A()..a = 4);
     return a.b.a;
     ", 4)]
+    [InlineData(@"
+    int[][] a = null;
+    a?[0]?[0] = 5;
+    return a?[0]?[0];
+    ", null)]
+    [InlineData(@"
+    int[][] a = { { 1 } };
+    a?[0]?[0] = 5;
+    return a?[0]?[0];
+    ", 5)]
     public void Evaluator_Computes_CorrectValues(string text, object? expectedValue) {
         AssertValue(text, expectedValue, evaluator: true, executor: true);
     }

--- a/src/Buckle/Compiler.Tests/CodeAnalysis/Evaluating/EvaluatorTests.cs
+++ b/src/Buckle/Compiler.Tests/CodeAnalysis/Evaluating/EvaluatorTests.cs
@@ -251,6 +251,7 @@ public sealed class EvaluatorTests {
     [InlineData("return (string)null;", null)]
     [InlineData("return (int)null;", null)]
     [InlineData("int! a = 3; decimal! b = 3.5; return (int!)b == a;", true)]
+    [InlineData("int! a = 3; string b = \"test\" + (string)a; return b;", "test3")]
     [InlineData("lowlevel { any a = new int[] {1, 2, 3}; return ((int[])a)[1]; }", 2)]
     [InlineData("lowlevel { any a = new bool[] {true, false}; return ((bool[])a)[0]; }", true)]
     [InlineData("lowlevel { any[] a = {1, 3.5, true, \"test\"}; return a[0]; }", 1)]
@@ -465,6 +466,33 @@ public sealed class EvaluatorTests {
     // [InlineData("class P { public static T M<type T>(T b) { T a = b; L<bool>(); return a; void L<type T2>() { a = null; } } } return P.M<int>();", null)]
     [InlineData("static class P { [DllImport(\"kernel32.dll\")]static extern int64* GetModuleHandle(string lpModuleName); } return null;", null)]
     [InlineData("static class P { [DllImport(\"msvcrt.dll\", CallingConvention: CallingConvention.Cdecl)]static extern void* memcpy(void* dest, void* src, uint64 count); } return null;", null)]
+    [InlineData(@"
+    struct A { B b; }
+    struct B { int a; }
+
+    var c = new A();
+    c.b.a = 4;
+    return c.b.a;
+    ", 4)]
+    // Compound nullability operators
+    [InlineData(@"
+    class A {
+        public int! Length() { return 4; }
+    }
+
+    A a = new A();
+    int! b = a?.Length()?;
+    return b;
+    ", 4)]
+    [InlineData(@"
+    class A {
+        public int! Length() { return 4; }
+    }
+
+    A a = null;
+    int! b = a?.Length()?;
+    return b;
+    ", 0)]
     public void Evaluator_Computes_CorrectValues(string text, object? expectedValue) {
         AssertValue(text, expectedValue, evaluator: true, executor: true);
     }

--- a/src/Buckle/Compiler/CodeAnalysis/Binding/Binder.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Binding/Binder.cs
@@ -2178,6 +2178,9 @@ internal partial class Binder {
         if (expression.hasAnyErrors)
             return false;
 
+        if (expression is BoundConditionalAccessExpression c)
+            expression = c.accessExpression;
+
         if (RequiresRValueOnly(valueKind))
             return CheckNotNamespaceOrType(expression, diagnostics);
 
@@ -12112,15 +12115,21 @@ symIsHidden:;
             if (expression is BoundCompileTimeExpression cte)
                 return IsInvalidExpressionStatement(cte.expression);
 
-            return expression is not BoundCallExpression
-                          and not BoundAssignmentOperator
-                          and not BoundErrorExpression
-                          and not BoundCompoundAssignmentOperator
-                          and not BoundThrowExpression
-                          and not BoundIncrementOperator
-                          and not BoundNullCoalescingAssignmentOperator
-                          and not BoundFunctionPointerCallExpression
-                          and not BoundCompileTimeExpression;
+            switch (expression.kind) {
+                case BoundKind.AssignmentOperator:
+                case BoundKind.ErrorExpression:
+                case BoundKind.CompoundAssignmentOperator:
+                case BoundKind.ThrowExpression:
+                case BoundKind.IncrementOperator:
+                case BoundKind.NullCoalescingAssignmentOperator:
+                case BoundKind.FunctionPointerCallExpression:
+                case BoundKind.CompileTimeExpression:
+                case BoundKind.CallExpression:
+                case BoundKind.CascadeListExpression:
+                    return false;
+                default:
+                    return true;
+            }
         }
     }
 

--- a/src/Buckle/Compiler/CodeAnalysis/Binding/BoundFactory.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Binding/BoundFactory.cs
@@ -23,6 +23,21 @@ internal static partial class BoundFactory {
         );
     }
 
+    internal static BoundIsOperator IsNull(SyntaxNode syntax, BoundExpression expression) {
+        var boolType = CorLibrary.GetSpecialType(SpecialType.Bool);
+        return new BoundIsOperator(syntax, expression, Literal(syntax, null, expression.type), false, null, boolType);
+    }
+
+    internal static BoundLocalDeclarationStatement LocalDeclaration(
+        SyntaxNode syntax,
+        DataContainerSymbol local,
+        BoundExpression initializer) {
+        return new BoundLocalDeclarationStatement(
+            syntax,
+            new BoundDataContainerDeclaration(syntax, local, initializer)
+        );
+    }
+
     internal static BoundBlockStatement Block(SyntaxNode syntax, params BoundStatement[] statements) {
         return new BoundBlockStatement(syntax, ImmutableArray.Create(statements), [], []);
     }

--- a/src/Buckle/Compiler/CodeAnalysis/Binding/BoundTree/BoundTreeExpander.UseKind.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Binding/BoundTree/BoundTreeExpander.UseKind.cs
@@ -1,0 +1,10 @@
+
+namespace Buckle.CodeAnalysis.Binding;
+
+internal abstract partial class BoundTreeExpander {
+    private protected enum UseKind : byte {
+        Value,
+        StableValue,
+        Writable
+    }
+}

--- a/src/Buckle/Compiler/CodeAnalysis/Binding/BoundTree/BoundTreeExpander.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Binding/BoundTree/BoundTreeExpander.cs
@@ -615,7 +615,10 @@ internal abstract partial class BoundTreeExpander {
         out BoundExpression replacement,
         UseKind useKind) {
         var statements = ExpandExpression(expression.left, out var newLeft);
-        statements.AddRange(ExpandExpression(expression.right, out var newRight));
+        var newRight = expression.right;
+
+        if (!newRight.IsLiteralNull())
+            statements.AddRange(ExpandExpression(expression.right, out newRight));
 
         if (statements.Count != 0 || expression.left != newLeft || expression.right != newRight) {
             replacement = expression.Update(
@@ -1109,7 +1112,13 @@ internal abstract partial class BoundTreeExpander {
         out BoundExpression replacement,
         UseKind useKind) {
         if (!expression.field.isStatic) {
-            var statements = ExpandExpression(expression.receiver, out var newReceiver, UseKind.StableValue);
+            // Structs are special case because they have limited expansion ability (they are non-nullable)
+            // And because they are passed by value so in something like `a.b.c = x`, we can't hoist anything
+            var statements = ExpandExpression(
+                expression.receiver,
+                out var newReceiver,
+                expression.receiver.Type().IsStructType() ? UseKind.Writable : UseKind.StableValue
+            );
 
             if (statements.Count != 0 || expression.receiver != newReceiver) {
                 replacement = expression.Update(

--- a/src/Buckle/Compiler/CodeAnalysis/Binding/BoundTree/BoundTreeExpander.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Binding/BoundTree/BoundTreeExpander.cs
@@ -11,10 +11,11 @@ namespace Buckle.CodeAnalysis.Binding;
 /// <summary>
 /// Rewrites BoundStatements and all child BoundStatements, allowing expansion.
 /// </summary>
-internal abstract class BoundTreeExpander {
+internal abstract partial class BoundTreeExpander {
     private protected readonly List<string> _localNames = [];
 
     private protected int _tempCount = 0;
+    private protected int _labelCount = 0;
 
     private protected abstract MethodSymbol _container { get; set; }
 
@@ -23,6 +24,10 @@ internal abstract class BoundTreeExpander {
             return statements[0];
         else
             return Block(syntax, statements.ToArray());
+    }
+
+    private protected SynthesizedLabelSymbol GenerateLabel(string suffix = null) {
+        return new SynthesizedLabelSymbol($"ExpLabel{++_labelCount}{suffix}");
     }
 
     private protected SynthesizedDataContainerSymbol GenerateTempLocal(TypeSymbol type) {
@@ -150,7 +155,7 @@ internal abstract class BoundTreeExpander {
         var statements = ExpandExpression(statement.declaration.initializer, out var replacement);
         var syntax = statement.syntax;
 
-        if (statements.Count > 0) {
+        if (statements.Count > 0 || statement.declaration.initializer != replacement) {
             statements.Add(new BoundLocalDeclarationStatement(
                 syntax,
                 new BoundDataContainerDeclaration(syntax, statement.declaration.dataContainer, replacement)
@@ -267,7 +272,7 @@ internal abstract class BoundTreeExpander {
 
         var statements = ExpandExpression(statement.expression, out var replacement);
 
-        if (statements.Count != 0) {
+        if (statements.Count != 0 || statement.expression != replacement) {
             statements.Add(new BoundReturnStatement(statement.syntax, statement.refKind, replacement));
             return statements;
         }
@@ -302,68 +307,70 @@ internal abstract class BoundTreeExpander {
 
     private protected virtual List<BoundStatement> ExpandExpression(
         BoundExpression expression,
-        out BoundExpression replacement) {
+        out BoundExpression replacement,
+        UseKind useKind = UseKind.Value) {
         if (expression.constantValue is not null) {
             replacement = expression;
             return [];
         }
 
         return expression.kind switch {
-            BoundKind.LiteralExpression => ExpandLiteralExpression((BoundLiteralExpression)expression, out replacement),
-            BoundKind.InitializerList => ExpandInitializerList((BoundInitializerList)expression, out replacement),
-            BoundKind.InitializerDictionary => ExpandInitializerDictionary((BoundInitializerDictionary)expression, out replacement),
-            BoundKind.DataContainerExpression => ExpandDataContainerExpression((BoundDataContainerExpression)expression, out replacement),
-            BoundKind.AssignmentOperator => ExpandAssignmentOperator((BoundAssignmentOperator)expression, out replacement),
-            BoundKind.UnaryOperator => ExpandUnaryOperator((BoundUnaryOperator)expression, out replacement),
-            BoundKind.IncrementOperator => ExpandIncrementOperator((BoundIncrementOperator)expression, out replacement),
-            BoundKind.BinaryOperator => ExpandBinaryOperator((BoundBinaryOperator)expression, out replacement),
-            BoundKind.AsOperator => ExpandAsOperator((BoundAsOperator)expression, out replacement),
-            BoundKind.IsOperator => ExpandIsOperator((BoundIsOperator)expression, out replacement),
-            BoundKind.NullCoalescingOperator => ExpandNullCoalescingOperator((BoundNullCoalescingOperator)expression, out replacement),
-            BoundKind.NullCoalescingAssignmentOperator => ExpandNullCoalescingAssignmentOperator((BoundNullCoalescingAssignmentOperator)expression, out replacement),
-            BoundKind.NullAssertOperator => ExpandNullAssertOperator((BoundNullAssertOperator)expression, out replacement),
-            BoundKind.NullErasureOperator => ExpandNullErasureOperator((BoundNullErasureOperator)expression, out replacement),
-            BoundKind.AddressOfOperator => ExpandAddressOfOperator((BoundAddressOfOperator)expression, out replacement),
-            BoundKind.PointerIndirectionOperator => ExpandPointerIndirectionOperator((BoundPointerIndirectionOperator)expression, out replacement),
-            BoundKind.ErrorExpression => ExpandErrorExpression((BoundErrorExpression)expression, out replacement),
-            BoundKind.CallExpression => ExpandCallExpression((BoundCallExpression)expression, out replacement),
-            BoundKind.CastExpression => ExpandCastExpression((BoundCastExpression)expression, out replacement),
-            BoundKind.ArrayAccessExpression => ExpandArrayAccessExpression((BoundArrayAccessExpression)expression, out replacement),
-            BoundKind.IndexerAccessExpression => ExpandIndexerAccessExpression((BoundIndexerAccessExpression)expression, out replacement),
-            BoundKind.PointerIndexAccessExpression => ExpandPointerIndexAccessExpression((BoundPointerIndexAccessExpression)expression, out replacement),
-            BoundKind.CompoundAssignmentOperator => ExpandCompoundAssignmentOperator((BoundCompoundAssignmentOperator)expression, out replacement),
-            BoundKind.ReferenceExpression => ExpandReferenceExpression((BoundReferenceExpression)expression, out replacement),
-            BoundKind.TypeOfExpression => ExpandTypeOfExpression((BoundTypeOfExpression)expression, out replacement),
-            BoundKind.ConditionalOperator => ExpandConditionalOperator((BoundConditionalOperator)expression, out replacement),
-            BoundKind.ObjectCreationExpression => ExpandObjectCreationExpression((BoundObjectCreationExpression)expression, out replacement),
-            BoundKind.ArrayCreationExpression => ExpandArrayCreationExpression((BoundArrayCreationExpression)expression, out replacement),
-            BoundKind.FieldAccessExpression => ExpandFieldAccessExpression((BoundFieldAccessExpression)expression, out replacement),
-            BoundKind.ConditionalAccessExpression => ExpandConditionalAccessExpression((BoundConditionalAccessExpression)expression, out replacement),
-            BoundKind.ThisExpression => ExpandThisExpression((BoundThisExpression)expression, out replacement),
-            BoundKind.BaseExpression => ExpandBaseExpression((BoundBaseExpression)expression, out replacement),
-            BoundKind.ThrowExpression => ExpandThrowExpression((BoundThrowExpression)expression, out replacement),
-            BoundKind.TypeExpression => ExpandTypeExpression((BoundTypeExpression)expression, out replacement),
-            BoundKind.NamespaceExpression => ExpandNamespaceExpression((BoundNamespaceExpression)expression, out replacement),
-            BoundKind.ParameterExpression => ExpandParameterExpression((BoundParameterExpression)expression, out replacement),
-            BoundKind.MethodGroup => ExpandMethodGroup((BoundMethodGroup)expression, out replacement),
-            BoundKind.FunctionPointerLoad => ExpandFunctionPointerLoad((BoundFunctionPointerLoad)expression, out replacement),
-            BoundKind.FunctionPointerCallExpression => ExpandFunctionPointerCallExpression((BoundFunctionPointerCallExpression)expression, out replacement),
-            BoundKind.UnconvertedNullptrExpression => ExpandUnconvertedNullptrExpression((BoundUnconvertedNullptrExpression)expression, out replacement),
-            BoundKind.CompileTimeExpression => ExpandCompileTimeExpression((BoundCompileTimeExpression)expression, out replacement),
-            BoundKind.SizeOfOperator => ExpandSizeOfOperator((BoundSizeOfOperator)expression, out replacement),
-            BoundKind.CascadeListExpression => ExpandCascadeListExpression((BoundCascadeListExpression)expression, out replacement),
-            BoundKind.StackSlotExpression => ExpandStackSlotExpression((BoundStackSlotExpression)expression, out replacement),
-            BoundKind.FieldSlotExpression => ExpandFieldSlotExpression((BoundFieldSlotExpression)expression, out replacement),
-            BoundKind.StackAllocExpression => ExpandStackAllocExpression((BoundStackAllocExpression)expression, out replacement),
-            BoundKind.ConvertedStackAllocExpression => ExpandConvertedStackAllocExpression((BoundConvertedStackAllocExpression)expression, out replacement),
-            BoundKind.InterpolatedStringExpression => ExpandInterpolatedStringExpression((BoundInterpolatedStringExpression)expression, out replacement),
+            BoundKind.LiteralExpression => ExpandLiteralExpression((BoundLiteralExpression)expression, out replacement, useKind),
+            BoundKind.InitializerList => ExpandInitializerList((BoundInitializerList)expression, out replacement, useKind),
+            BoundKind.InitializerDictionary => ExpandInitializerDictionary((BoundInitializerDictionary)expression, out replacement, useKind),
+            BoundKind.DataContainerExpression => ExpandDataContainerExpression((BoundDataContainerExpression)expression, out replacement, useKind),
+            BoundKind.AssignmentOperator => ExpandAssignmentOperator((BoundAssignmentOperator)expression, out replacement, useKind),
+            BoundKind.UnaryOperator => ExpandUnaryOperator((BoundUnaryOperator)expression, out replacement, useKind),
+            BoundKind.IncrementOperator => ExpandIncrementOperator((BoundIncrementOperator)expression, out replacement, useKind),
+            BoundKind.BinaryOperator => ExpandBinaryOperator((BoundBinaryOperator)expression, out replacement, useKind),
+            BoundKind.AsOperator => ExpandAsOperator((BoundAsOperator)expression, out replacement, useKind),
+            BoundKind.IsOperator => ExpandIsOperator((BoundIsOperator)expression, out replacement, useKind),
+            BoundKind.NullCoalescingOperator => ExpandNullCoalescingOperator((BoundNullCoalescingOperator)expression, out replacement, useKind),
+            BoundKind.NullCoalescingAssignmentOperator => ExpandNullCoalescingAssignmentOperator((BoundNullCoalescingAssignmentOperator)expression, out replacement, useKind),
+            BoundKind.NullAssertOperator => ExpandNullAssertOperator((BoundNullAssertOperator)expression, out replacement, useKind),
+            BoundKind.NullErasureOperator => ExpandNullErasureOperator((BoundNullErasureOperator)expression, out replacement, useKind),
+            BoundKind.AddressOfOperator => ExpandAddressOfOperator((BoundAddressOfOperator)expression, out replacement, useKind),
+            BoundKind.PointerIndirectionOperator => ExpandPointerIndirectionOperator((BoundPointerIndirectionOperator)expression, out replacement, useKind),
+            BoundKind.ErrorExpression => ExpandErrorExpression((BoundErrorExpression)expression, out replacement, useKind),
+            BoundKind.CallExpression => ExpandCallExpression((BoundCallExpression)expression, out replacement, useKind),
+            BoundKind.CastExpression => ExpandCastExpression((BoundCastExpression)expression, out replacement, useKind),
+            BoundKind.ArrayAccessExpression => ExpandArrayAccessExpression((BoundArrayAccessExpression)expression, out replacement, useKind),
+            BoundKind.IndexerAccessExpression => ExpandIndexerAccessExpression((BoundIndexerAccessExpression)expression, out replacement, useKind),
+            BoundKind.PointerIndexAccessExpression => ExpandPointerIndexAccessExpression((BoundPointerIndexAccessExpression)expression, out replacement, useKind),
+            BoundKind.CompoundAssignmentOperator => ExpandCompoundAssignmentOperator((BoundCompoundAssignmentOperator)expression, out replacement, useKind),
+            BoundKind.ReferenceExpression => ExpandReferenceExpression((BoundReferenceExpression)expression, out replacement, useKind),
+            BoundKind.TypeOfExpression => ExpandTypeOfExpression((BoundTypeOfExpression)expression, out replacement, useKind),
+            BoundKind.ConditionalOperator => ExpandConditionalOperator((BoundConditionalOperator)expression, out replacement, useKind),
+            BoundKind.ObjectCreationExpression => ExpandObjectCreationExpression((BoundObjectCreationExpression)expression, out replacement, useKind),
+            BoundKind.ArrayCreationExpression => ExpandArrayCreationExpression((BoundArrayCreationExpression)expression, out replacement, useKind),
+            BoundKind.FieldAccessExpression => ExpandFieldAccessExpression((BoundFieldAccessExpression)expression, out replacement, useKind),
+            BoundKind.ConditionalAccessExpression => ExpandConditionalAccessExpression((BoundConditionalAccessExpression)expression, out replacement, useKind),
+            BoundKind.ThisExpression => ExpandThisExpression((BoundThisExpression)expression, out replacement, useKind),
+            BoundKind.BaseExpression => ExpandBaseExpression((BoundBaseExpression)expression, out replacement, useKind),
+            BoundKind.ThrowExpression => ExpandThrowExpression((BoundThrowExpression)expression, out replacement, useKind),
+            BoundKind.TypeExpression => ExpandTypeExpression((BoundTypeExpression)expression, out replacement, useKind),
+            BoundKind.NamespaceExpression => ExpandNamespaceExpression((BoundNamespaceExpression)expression, out replacement, useKind),
+            BoundKind.ParameterExpression => ExpandParameterExpression((BoundParameterExpression)expression, out replacement, useKind),
+            BoundKind.MethodGroup => ExpandMethodGroup((BoundMethodGroup)expression, out replacement, useKind),
+            BoundKind.FunctionPointerLoad => ExpandFunctionPointerLoad((BoundFunctionPointerLoad)expression, out replacement, useKind),
+            BoundKind.FunctionPointerCallExpression => ExpandFunctionPointerCallExpression((BoundFunctionPointerCallExpression)expression, out replacement, useKind),
+            BoundKind.UnconvertedNullptrExpression => ExpandUnconvertedNullptrExpression((BoundUnconvertedNullptrExpression)expression, out replacement, useKind),
+            BoundKind.CompileTimeExpression => ExpandCompileTimeExpression((BoundCompileTimeExpression)expression, out replacement, useKind),
+            BoundKind.SizeOfOperator => ExpandSizeOfOperator((BoundSizeOfOperator)expression, out replacement, useKind),
+            BoundKind.CascadeListExpression => ExpandCascadeListExpression((BoundCascadeListExpression)expression, out replacement, useKind),
+            BoundKind.StackSlotExpression => ExpandStackSlotExpression((BoundStackSlotExpression)expression, out replacement, useKind),
+            BoundKind.FieldSlotExpression => ExpandFieldSlotExpression((BoundFieldSlotExpression)expression, out replacement, useKind),
+            BoundKind.StackAllocExpression => ExpandStackAllocExpression((BoundStackAllocExpression)expression, out replacement, useKind),
+            BoundKind.ConvertedStackAllocExpression => ExpandConvertedStackAllocExpression((BoundConvertedStackAllocExpression)expression, out replacement, useKind),
+            BoundKind.InterpolatedStringExpression => ExpandInterpolatedStringExpression((BoundInterpolatedStringExpression)expression, out replacement, useKind),
             _ => throw ExceptionUtilities.UnexpectedValue(expression.kind),
         };
     }
 
     private protected virtual List<BoundStatement> ExpandInterpolatedStringExpression(
         BoundInterpolatedStringExpression expression,
-        out BoundExpression replacement) {
+        out BoundExpression replacement,
+        UseKind useKind) {
         List<BoundStatement> statements = [];
         var newContents = ArrayBuilder<BoundExpression>.GetInstance();
 
@@ -378,7 +385,8 @@ internal abstract class BoundTreeExpander {
 
     private protected virtual List<BoundStatement> ExpandCascadeListExpression(
         BoundCascadeListExpression expression,
-        out BoundExpression replacement) {
+        out BoundExpression replacement,
+        UseKind useKind) {
         List<BoundStatement> statements;
         BoundExpression newReceiver = null;
 
@@ -401,70 +409,80 @@ internal abstract class BoundTreeExpander {
 
     private protected virtual List<BoundStatement> ExpandSizeOfOperator(
         BoundSizeOfOperator expression,
-        out BoundExpression replacement) {
+        out BoundExpression replacement,
+        UseKind useKind) {
         replacement = expression;
         return [];
     }
 
     private protected virtual List<BoundStatement> ExpandStackSlotExpression(
         BoundStackSlotExpression expression,
-        out BoundExpression replacement) {
+        out BoundExpression replacement,
+        UseKind useKind) {
         replacement = expression;
         return [];
     }
 
     private protected virtual List<BoundStatement> ExpandFieldSlotExpression(
         BoundFieldSlotExpression expression,
-        out BoundExpression replacement) {
+        out BoundExpression replacement,
+        UseKind useKind) {
         replacement = expression;
         return [];
     }
 
     private protected virtual List<BoundStatement> ExpandStackAllocExpression(
         BoundStackAllocExpression expression,
-        out BoundExpression replacement) {
+        out BoundExpression replacement,
+        UseKind useKind) {
         replacement = expression;
         return [];
     }
 
     private protected virtual List<BoundStatement> ExpandConvertedStackAllocExpression(
         BoundConvertedStackAllocExpression expression,
-        out BoundExpression replacement) {
+        out BoundExpression replacement,
+        UseKind useKind) {
         replacement = expression;
         return [];
     }
 
     private protected virtual List<BoundStatement> ExpandMethodGroup(
         BoundMethodGroup expression,
-        out BoundExpression replacement) {
+        out BoundExpression replacement,
+        UseKind useKind) {
         replacement = expression;
         return [];
     }
 
     private protected virtual List<BoundStatement> ExpandCompileTimeExpression(
         BoundCompileTimeExpression expression,
-        out BoundExpression replacement) {
+        out BoundExpression replacement,
+        UseKind useKind) {
         replacement = expression;
         return [];
     }
 
     private protected virtual List<BoundStatement> ExpandUnconvertedNullptrExpression(
         BoundUnconvertedNullptrExpression expression,
-        out BoundExpression replacement) {
+        out BoundExpression replacement,
+        UseKind useKind) {
         replacement = expression;
         return [];
     }
 
     private protected virtual List<BoundStatement> ExpandFunctionPointerLoad(
         BoundFunctionPointerLoad expression,
-        out BoundExpression replacement) {
+        out BoundExpression replacement,
+        UseKind useKind) {
         replacement = expression;
         return [];
     }
 
     private protected virtual List<BoundStatement> ExpandFunctionPointerCallExpression(
         BoundFunctionPointerCallExpression expression,
-        out BoundExpression replacement) {
+        out BoundExpression replacement,
+        UseKind useKind) {
         List<BoundStatement> statements;
         BoundExpression newInvokedExpression = null;
 
@@ -488,42 +506,48 @@ internal abstract class BoundTreeExpander {
 
     private protected virtual List<BoundStatement> ExpandParameterExpression(
         BoundParameterExpression expression,
-        out BoundExpression replacement) {
+        out BoundExpression replacement,
+        UseKind useKind) {
         replacement = expression;
         return [];
     }
 
     private protected virtual List<BoundStatement> ExpandTypeExpression(
         BoundTypeExpression expression,
-        out BoundExpression replacement) {
+        out BoundExpression replacement,
+        UseKind useKind) {
         replacement = expression;
         return [];
     }
 
     private protected virtual List<BoundStatement> ExpandNamespaceExpression(
         BoundNamespaceExpression expression,
-        out BoundExpression replacement) {
+        out BoundExpression replacement,
+        UseKind useKind) {
         replacement = expression;
         return [];
     }
 
     private protected virtual List<BoundStatement> ExpandThisExpression(
         BoundThisExpression expression,
-        out BoundExpression replacement) {
+        out BoundExpression replacement,
+        UseKind useKind) {
         replacement = expression;
         return [];
     }
 
     private protected virtual List<BoundStatement> ExpandBaseExpression(
         BoundBaseExpression expression,
-        out BoundExpression replacement) {
+        out BoundExpression replacement,
+        UseKind useKind) {
         replacement = expression;
         return [];
     }
 
     private protected virtual List<BoundStatement> ExpandThrowExpression(
         BoundThrowExpression expression,
-        out BoundExpression replacement) {
+        out BoundExpression replacement,
+        UseKind useKind) {
         var statements = ExpandExpression(expression.expression, out var newExpression);
 
         if (statements.Count != 0 || newExpression != expression.expression) {
@@ -541,7 +565,8 @@ internal abstract class BoundTreeExpander {
 
     private protected virtual List<BoundStatement> ExpandBinaryOperator(
         BoundBinaryOperator expression,
-        out BoundExpression replacement) {
+        out BoundExpression replacement,
+        UseKind useKind) {
         var statements = ExpandExpression(expression.left, out var newLeft);
         statements.AddRange(ExpandExpression(expression.right, out var newRight));
 
@@ -564,7 +589,8 @@ internal abstract class BoundTreeExpander {
 
     private protected virtual List<BoundStatement> ExpandAsOperator(
         BoundAsOperator expression,
-        out BoundExpression replacement) {
+        out BoundExpression replacement,
+        UseKind useKind) {
         var statements = ExpandExpression(expression.left, out var newLeft);
         statements.AddRange(ExpandExpression(expression.right, out var newRight));
 
@@ -586,7 +612,8 @@ internal abstract class BoundTreeExpander {
 
     private protected virtual List<BoundStatement> ExpandIsOperator(
         BoundIsOperator expression,
-        out BoundExpression replacement) {
+        out BoundExpression replacement,
+        UseKind useKind) {
         var statements = ExpandExpression(expression.left, out var newLeft);
         statements.AddRange(ExpandExpression(expression.right, out var newRight));
 
@@ -608,7 +635,8 @@ internal abstract class BoundTreeExpander {
 
     private protected virtual List<BoundStatement> ExpandNullCoalescingOperator(
         BoundNullCoalescingOperator expression,
-        out BoundExpression replacement) {
+        out BoundExpression replacement,
+        UseKind useKind) {
         var statements = ExpandExpression(expression.left, out var newLeft);
         statements.AddRange(ExpandExpression(expression.right, out var newRight));
 
@@ -630,8 +658,9 @@ internal abstract class BoundTreeExpander {
 
     private protected virtual List<BoundStatement> ExpandNullCoalescingAssignmentOperator(
         BoundNullCoalescingAssignmentOperator expression,
-        out BoundExpression replacement) {
-        var statements = ExpandExpression(expression.left, out var newLeft);
+        out BoundExpression replacement,
+        UseKind useKind) {
+        var statements = ExpandExpression(expression.left, out var newLeft, UseKind.Writable);
         statements.AddRange(ExpandExpression(expression.right, out var newRight));
 
         if (statements.Count != 0 || expression.left != newLeft || expression.right != newRight) {
@@ -645,7 +674,8 @@ internal abstract class BoundTreeExpander {
 
     private protected virtual List<BoundStatement> ExpandInitializerList(
         BoundInitializerList expression,
-        out BoundExpression replacement) {
+        out BoundExpression replacement,
+        UseKind useKind) {
         var statements = new List<BoundStatement>();
         var replacementItems = ArrayBuilder<BoundExpression>.GetInstance();
 
@@ -660,7 +690,8 @@ internal abstract class BoundTreeExpander {
 
     private protected virtual List<BoundStatement> ExpandInitializerDictionary(
         BoundInitializerDictionary expression,
-        out BoundExpression replacement) {
+        out BoundExpression replacement,
+        UseKind useKind) {
         var statements = new List<BoundStatement>();
         var replacementItems = ArrayBuilder<(BoundExpression, BoundExpression)>.GetInstance();
 
@@ -676,22 +707,25 @@ internal abstract class BoundTreeExpander {
 
     private protected virtual List<BoundStatement> ExpandLiteralExpression(
         BoundLiteralExpression expression,
-        out BoundExpression replacement) {
+        out BoundExpression replacement,
+        UseKind useKind) {
         replacement = expression;
         return [];
     }
 
     private protected virtual List<BoundStatement> ExpandDataContainerExpression(
         BoundDataContainerExpression expression,
-        out BoundExpression replacement) {
+        out BoundExpression replacement,
+        UseKind useKind) {
         replacement = expression;
         return [];
     }
 
     private protected virtual List<BoundStatement> ExpandAssignmentOperator(
         BoundAssignmentOperator expression,
-        out BoundExpression replacement) {
-        var statements = ExpandExpression(expression.left, out var newLeft);
+        out BoundExpression replacement,
+        UseKind useKind) {
+        var statements = ExpandExpression(expression.left, out var newLeft, UseKind.Writable);
         statements.AddRange(ExpandExpression(expression.right, out var newRight));
 
         if (statements.Count != 0 || expression.left != newLeft || expression.right != newRight) {
@@ -705,7 +739,8 @@ internal abstract class BoundTreeExpander {
 
     private protected virtual List<BoundStatement> ExpandUnaryOperator(
         BoundUnaryOperator expression,
-        out BoundExpression replacement) {
+        out BoundExpression replacement,
+        UseKind useKind) {
         var statements = ExpandExpression(expression.operand, out var newOperand);
 
         if (statements.Count != 0 || expression.operand != newOperand) {
@@ -726,8 +761,9 @@ internal abstract class BoundTreeExpander {
 
     private protected virtual List<BoundStatement> ExpandIncrementOperator(
         BoundIncrementOperator expression,
-        out BoundExpression replacement) {
-        var statements = ExpandExpression(expression.operand, out var newOperand);
+        out BoundExpression replacement,
+        UseKind useKind) {
+        var statements = ExpandExpression(expression.operand, out var newOperand, UseKind.Writable);
 
         if (statements.Count != 0 || expression.operand != newOperand) {
             replacement = expression.Update(
@@ -752,7 +788,8 @@ internal abstract class BoundTreeExpander {
 
     private protected virtual List<BoundStatement> ExpandNullAssertOperator(
         BoundNullAssertOperator expression,
-        out BoundExpression replacement) {
+        out BoundExpression replacement,
+        UseKind useKind) {
         var statements = ExpandExpression(expression.operand, out var newOperand);
 
         if (statements.Count != 0 || expression.operand != newOperand) {
@@ -772,7 +809,8 @@ internal abstract class BoundTreeExpander {
 
     private protected virtual List<BoundStatement> ExpandNullErasureOperator(
         BoundNullErasureOperator expression,
-        out BoundExpression replacement) {
+        out BoundExpression replacement,
+        UseKind useKind) {
         var statements = ExpandExpression(expression.operand, out var newOperand);
 
         if (statements.Count != 0 || expression.operand != newOperand) {
@@ -792,7 +830,8 @@ internal abstract class BoundTreeExpander {
 
     private protected virtual List<BoundStatement> ExpandAddressOfOperator(
         BoundAddressOfOperator expression,
-        out BoundExpression replacement) {
+        out BoundExpression replacement,
+        UseKind useKind) {
         var statements = ExpandExpression(expression.operand, out var newOperand);
 
         if (statements.Count != 0 || expression.operand != newOperand) {
@@ -811,7 +850,8 @@ internal abstract class BoundTreeExpander {
 
     private protected virtual List<BoundStatement> ExpandPointerIndirectionOperator(
         BoundPointerIndirectionOperator expression,
-        out BoundExpression replacement) {
+        out BoundExpression replacement,
+        UseKind useKind) {
         var statements = ExpandExpression(expression.operand, out var newOperand);
 
         if (statements.Count != 0 || expression.operand != newOperand) {
@@ -830,14 +870,16 @@ internal abstract class BoundTreeExpander {
 
     private protected virtual List<BoundStatement> ExpandErrorExpression(
         BoundErrorExpression expression,
-        out BoundExpression replacement) {
+        out BoundExpression replacement,
+        UseKind useKind) {
         replacement = expression;
         return [];
     }
 
     private protected virtual List<BoundStatement> ExpandCallExpression(
         BoundCallExpression expression,
-        out BoundExpression replacement) {
+        out BoundExpression replacement,
+        UseKind useKind) {
         List<BoundStatement> statements;
         BoundExpression newReceiver = null;
 
@@ -863,7 +905,8 @@ internal abstract class BoundTreeExpander {
 
     private protected List<BoundStatement> ExpandExpressionList(
         ImmutableArray<BoundExpression> expressions,
-        out ImmutableArray<BoundExpression> replacement) {
+        out ImmutableArray<BoundExpression> replacement,
+        UseKind useKind = UseKind.Value) {
         var statements = new List<BoundStatement>();
         var replacementExpressions = ArrayBuilder<BoundExpression>.GetInstance();
 
@@ -878,7 +921,8 @@ internal abstract class BoundTreeExpander {
 
     private protected virtual List<BoundStatement> ExpandCastExpression(
         BoundCastExpression expression,
-        out BoundExpression replacement) {
+        out BoundExpression replacement,
+        UseKind useKind) {
         var statements = ExpandExpression(expression.operand, out var newOperand);
 
         if (statements.Count != 0 || expression.operand != newOperand) {
@@ -898,7 +942,8 @@ internal abstract class BoundTreeExpander {
 
     private protected virtual List<BoundStatement> ExpandArrayAccessExpression(
         BoundArrayAccessExpression expression,
-        out BoundExpression replacement) {
+        out BoundExpression replacement,
+        UseKind useKind) {
         var statements = ExpandExpression(expression.receiver, out var newOperand);
         statements.AddRange(ExpandExpression(expression.index, out var newIndex));
 
@@ -913,7 +958,8 @@ internal abstract class BoundTreeExpander {
 
     private protected virtual List<BoundStatement> ExpandIndexerAccessExpression(
         BoundIndexerAccessExpression expression,
-        out BoundExpression replacement) {
+        out BoundExpression replacement,
+        UseKind useKind) {
         var statements = ExpandExpression(expression.receiver, out var newOperand);
         statements.AddRange(ExpandExpression(expression.index, out var newIndex));
 
@@ -935,7 +981,8 @@ internal abstract class BoundTreeExpander {
 
     private protected virtual List<BoundStatement> ExpandPointerIndexAccessExpression(
         BoundPointerIndexAccessExpression expression,
-        out BoundExpression replacement) {
+        out BoundExpression replacement,
+        UseKind useKind) {
         var statements = ExpandExpression(expression.receiver, out var newOperand);
         statements.AddRange(ExpandExpression(expression.index, out var newIndex));
 
@@ -956,8 +1003,9 @@ internal abstract class BoundTreeExpander {
 
     private protected virtual List<BoundStatement> ExpandCompoundAssignmentOperator(
         BoundCompoundAssignmentOperator expression,
-        out BoundExpression replacement) {
-        var statements = ExpandExpression(expression.left, out var newLeft);
+        out BoundExpression replacement,
+        UseKind useKind) {
+        var statements = ExpandExpression(expression.left, out var newLeft, UseKind.Writable);
         statements.AddRange(ExpandExpression(expression.right, out var newRight));
 
         if (statements.Count != 0 || expression.left != newLeft || expression.right != newRight) {
@@ -983,21 +1031,24 @@ internal abstract class BoundTreeExpander {
 
     private protected virtual List<BoundStatement> ExpandReferenceExpression(
         BoundReferenceExpression expression,
-        out BoundExpression replacement) {
+        out BoundExpression replacement,
+        UseKind useKind) {
         replacement = expression;
         return [];
     }
 
     private protected virtual List<BoundStatement> ExpandTypeOfExpression(
         BoundTypeOfExpression expression,
-        out BoundExpression replacement) {
+        out BoundExpression replacement,
+        UseKind useKind) {
         replacement = expression;
         return [];
     }
 
     private protected virtual List<BoundStatement> ExpandConditionalOperator(
         BoundConditionalOperator expression,
-        out BoundExpression replacement) {
+        out BoundExpression replacement,
+        UseKind useKind) {
         var statements = ExpandExpression(expression.condition, out var newCondition);
         statements.AddRange(ExpandExpression(expression.trueExpression, out var newTrueExpression));
         statements.AddRange(ExpandExpression(expression.falseExpression, out var newFalseExpression));
@@ -1022,7 +1073,8 @@ internal abstract class BoundTreeExpander {
 
     private protected virtual List<BoundStatement> ExpandObjectCreationExpression(
         BoundObjectCreationExpression expression,
-        out BoundExpression replacement) {
+        out BoundExpression replacement,
+        UseKind useKind) {
         var statements = ExpandExpressionList(expression.arguments, out var newArguments);
 
         replacement = expression.Update(
@@ -1040,7 +1092,8 @@ internal abstract class BoundTreeExpander {
 
     private protected virtual List<BoundStatement> ExpandArrayCreationExpression(
         BoundArrayCreationExpression expression,
-        out BoundExpression replacement) {
+        out BoundExpression replacement,
+        UseKind useKind) {
         if (expression.initializer is null) {
             replacement = expression;
             return [];
@@ -1053,9 +1106,10 @@ internal abstract class BoundTreeExpander {
 
     private protected virtual List<BoundStatement> ExpandFieldAccessExpression(
         BoundFieldAccessExpression expression,
-        out BoundExpression replacement) {
+        out BoundExpression replacement,
+        UseKind useKind) {
         if (!expression.field.isStatic) {
-            var statements = ExpandExpression(expression.receiver, out var newReceiver);
+            var statements = ExpandExpression(expression.receiver, out var newReceiver, UseKind.StableValue);
 
             if (statements.Count != 0 || expression.receiver != newReceiver) {
                 replacement = expression.Update(
@@ -1075,8 +1129,9 @@ internal abstract class BoundTreeExpander {
 
     private protected virtual List<BoundStatement> ExpandConditionalAccessExpression(
         BoundConditionalAccessExpression expression,
-        out BoundExpression replacement) {
-        var statements = ExpandExpression(expression.receiver, out var newReceiver);
+        out BoundExpression replacement,
+        UseKind useKind) {
+        var statements = ExpandExpression(expression.receiver, out var newReceiver, UseKind.StableValue);
         statements.AddRange(ExpandExpression(expression.accessExpression, out var newAccess));
 
         if (statements.Count != 0 || expression.receiver != newReceiver || expression.accessExpression != newAccess) {

--- a/src/Buckle/Compiler/CodeAnalysis/Display/DisplayText.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Display/DisplayText.cs
@@ -873,7 +873,6 @@ public sealed class DisplayText {
     }
 
     private static void DisplayConditionalAccessExpression(DisplayText text, BoundConditionalAccessExpression node) {
-        DisplayNode(text, node.receiver);
         var accessExpression = node.accessExpression;
 
         switch (accessExpression) {
@@ -1035,9 +1034,7 @@ public sealed class DisplayText {
 
     private static void DisplayCallExpression(DisplayText text, BoundCallExpression node, bool conditional = false) {
         if (node.receiver is not null) {
-            if (!conditional)
-                DisplayNode(text, node.receiver);
-
+            DisplayNode(text, node.receiver);
             text.Write(CreatePunctuation(conditional ? SyntaxKind.QuestionPeriodToken : SyntaxKind.PeriodToken));
             text.Write(CreateIdentifier(node.method.name));
         } else {

--- a/src/Buckle/Compiler/CodeAnalysis/Display/DisplayText.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Display/DisplayText.cs
@@ -883,6 +883,9 @@ public sealed class DisplayText {
             case BoundFieldAccessExpression f:
                 DisplayFieldAccessExpression(text, f, true);
                 break;
+            case BoundCallExpression c:
+                DisplayCallExpression(text, c, true);
+                break;
             default:
                 throw ExceptionUtilities.UnexpectedValue(accessExpression.kind);
         }
@@ -1030,10 +1033,12 @@ public sealed class DisplayText {
         DisplayNode(text, node.operand);
     }
 
-    private static void DisplayCallExpression(DisplayText text, BoundCallExpression node) {
+    private static void DisplayCallExpression(DisplayText text, BoundCallExpression node, bool conditional = false) {
         if (node.receiver is not null) {
-            DisplayNode(text, node.receiver);
-            text.Write(CreatePunctuation(SyntaxKind.PeriodToken));
+            if (!conditional)
+                DisplayNode(text, node.receiver);
+
+            text.Write(CreatePunctuation(conditional ? SyntaxKind.QuestionPeriodToken : SyntaxKind.PeriodToken));
             text.Write(CreateIdentifier(node.method.name));
         } else {
             // Static methods drop their receiver (it's functionally not used)

--- a/src/Buckle/Compiler/CodeAnalysis/Lowering/CompileTimeLowerer.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Lowering/CompileTimeLowerer.cs
@@ -51,7 +51,8 @@ internal sealed class CompileTimeLowerer : BoundTreeExpander {
 
     private protected override List<BoundStatement> ExpandCompileTimeExpression(
         BoundCompileTimeExpression node,
-        out BoundExpression replacement) {
+        out BoundExpression replacement,
+        UseKind useKind) {
         try {
             var methodLayout = _program.methodLayouts[_container.originalDefinition];
             var result = _evaluator.EvaluateExpression(node.expression, methodLayout, out var hasValue);

--- a/src/Buckle/Compiler/CodeAnalysis/Lowering/EvaluatorSlotRewriter.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Lowering/EvaluatorSlotRewriter.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using Buckle.CodeAnalysis.Binding;
 using Buckle.CodeAnalysis.CodeGeneration;
 using Buckle.CodeAnalysis.Symbols;
+using Buckle.CodeAnalysis.Syntax;
 using Buckle.Libraries;
 using Buckle.Utilities;
 using static Buckle.CodeAnalysis.Binding.BoundFactory;

--- a/src/Buckle/Compiler/CodeAnalysis/Lowering/Expander.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Lowering/Expander.cs
@@ -30,6 +30,18 @@ internal sealed class Expander : BoundTreeExpander {
         return Simplify(statement.syntax, ExpandStatement(statement));
     }
 
+    private protected override List<BoundStatement> ExpandExpression(
+        BoundExpression expression,
+        out BoundExpression replacement,
+        UseKind useKind = UseKind.Value) {
+        if (expression.constantValue is not null) {
+            replacement = Lowerer.VisitConstant(expression);
+            return [];
+        }
+
+        return base.ExpandExpression(expression, out replacement, useKind);
+    }
+
     private protected override List<BoundStatement> ExpandCascadeListExpression(
         BoundCascadeListExpression expression,
         out BoundExpression replacement,
@@ -259,7 +271,14 @@ internal sealed class Expander : BoundTreeExpander {
                 newRight,
                 expression.op.kind,
                 expression.op.method,
-                expression.constantValue,
+                ConstantFolding.FoldBinary(
+                    newLeft,
+                    newRight,
+                    expression.op.kind,
+                    expression.Type(),
+                    syntax.location,
+                    BelteDiagnosticQueue.Discarded
+                ),
                 expression.type
             ),
             false,
@@ -408,26 +427,12 @@ internal sealed class Expander : BoundTreeExpander {
         BoundCallExpression expression,
         out BoundExpression replacement,
         UseKind useKind) {
-        /*
+        var statements = base.ExpandCallExpression(expression, out replacement, UseKind.Value);
 
-        <operand>(<args>)
-
-        ----> UseKind.StableValue, UseKind.Writable
-
-        temp = <operand>(<args>)
-        temp
-
-        */
-        var syntax = expression.syntax;
-
-        var statements = base.ExpandCallExpression(expression, out var newCall, UseKind.Value);
-
-        if (useKind == UseKind.Value) {
-            replacement = newCall;
+        if (useKind == UseKind.Writable && expression.method.returnsByRef)
             return statements;
-        } else {
-            return Stabilize(syntax, statements, newCall, out replacement);
-        }
+        else
+            return StabilizeIfNecessary(expression.syntax, useKind, statements, replacement, out replacement);
     }
 
     private protected override List<BoundStatement> ExpandBinaryOperator(
@@ -468,11 +473,14 @@ internal sealed class Expander : BoundTreeExpander {
         */
         var op = expression.operatorKind;
 
-        if (op.Operator() == BinaryOperatorKind.ConditionalAnd)
-            return ExpandConditionalAndOperator(expression, out replacement);
-
-        if (op.Operator() == BinaryOperatorKind.ConditionalOr)
-            return ExpandConditionalOrOperator(expression, out replacement);
+        if (op.IsConditional()) {
+            if (op.Operator() == BinaryOperatorKind.And)
+                return ExpandConditionalAndOperator(expression, out replacement);
+            else if (op.Operator() == BinaryOperatorKind.Or)
+                return ExpandConditionalOrOperator(expression, out replacement);
+            else
+                throw ExceptionUtilities.UnexpectedValue(op);
+        }
 
         var syntax = expression.syntax;
 
@@ -534,9 +542,9 @@ internal sealed class Expander : BoundTreeExpander {
                 ),
                 @then: Lowerer.CreateNullable(syntax,
                     Binary(syntax,
-                        Value(syntax, newLeft, newLeft.Type().GetNullableUnderlyingType()),
+                        Value(syntax, newLeft, newLeft.Type().StrippedType()),
                         op,
-                        Value(syntax, newRight, newRight.Type().GetNullableUnderlyingType()),
+                        Value(syntax, newRight, newRight.Type().StrippedType()),
                         type.StrippedType()
                         ),
                     type
@@ -552,7 +560,7 @@ internal sealed class Expander : BoundTreeExpander {
                 @if: HasValue(syntax, newLeft),
                 @then: Lowerer.CreateNullable(syntax,
                     Binary(syntax,
-                        Value(syntax, newLeft, newLeft.Type().GetNullableUnderlyingType()),
+                        Value(syntax, newLeft, newLeft.Type().StrippedType()),
                         op,
                         Lowerer.DeNull(newRight),
                         type.StrippedType()
@@ -572,7 +580,7 @@ internal sealed class Expander : BoundTreeExpander {
                     Binary(syntax,
                         Lowerer.DeNull(newLeft),
                         op,
-                        Value(syntax, newRight, newRight.Type().GetNullableUnderlyingType()),
+                        Value(syntax, newRight, newRight.Type().StrippedType()),
                         type.StrippedType()
                     ),
                     type
@@ -632,6 +640,8 @@ internal sealed class Expander : BoundTreeExpander {
         var syntax = expression.syntax;
         var boolType = CorLibrary.GetSpecialType(SpecialType.Bool);
 
+        // TODO There is probably potential for short cutting if left and right are "simple" (e.g. `a && b`)
+
         if (expression.left.Type().IsNullableType() && expression.right.Type().IsNullableType()) {
             var statements = ExpandExpression(expression.left, out var newLeft, UseKind.StableValue);
             var temp = GenerateTempLocal(boolType);
@@ -640,7 +650,7 @@ internal sealed class Expander : BoundTreeExpander {
             statements.Add(GotoIf(syntax, breakLabel,
                 Binary(syntax,
                     IsNull(syntax, newLeft),
-                    BinaryOperatorKind.ConditionalOr,
+                    BinaryOperatorKind.BoolConditionalOr,
                     Binary(syntax,
                         new BoundNullAssertOperator(syntax, newLeft, false, null, newLeft.StrippedType()),
                         BinaryOperatorKind.BoolEqual,
@@ -672,7 +682,7 @@ internal sealed class Expander : BoundTreeExpander {
             statements.Add(GotoIf(syntax, breakLabel,
                 Binary(syntax,
                     IsNull(syntax, newLeft),
-                    BinaryOperatorKind.ConditionalOr,
+                    BinaryOperatorKind.BoolConditionalOr,
                     Binary(syntax,
                         new BoundNullAssertOperator(syntax, newLeft, false, null, newLeft.StrippedType()),
                         BinaryOperatorKind.BoolEqual,
@@ -812,7 +822,7 @@ internal sealed class Expander : BoundTreeExpander {
             statements.Add(GotoIfNot(syntax, breakLabel,
                 Binary(syntax,
                     IsNull(syntax, newLeft),
-                    BinaryOperatorKind.ConditionalOr,
+                    BinaryOperatorKind.BoolConditionalOr,
                     Binary(syntax,
                         new BoundNullAssertOperator(syntax, newLeft, false, null, newLeft.StrippedType()),
                         BinaryOperatorKind.BoolEqual,
@@ -854,7 +864,7 @@ internal sealed class Expander : BoundTreeExpander {
             statements.Add(GotoIfNot(syntax, breakLabel,
                 Binary(syntax,
                     IsNull(syntax, newLeft),
-                    BinaryOperatorKind.ConditionalOr,
+                    BinaryOperatorKind.BoolConditionalOr,
                     Binary(syntax,
                         new BoundNullAssertOperator(syntax, newLeft, false, null, newLeft.StrippedType()),
                         BinaryOperatorKind.BoolEqual,
@@ -1262,7 +1272,11 @@ internal sealed class Expander : BoundTreeExpander {
         out BoundExpression replacement,
         UseKind useKind) {
         var statements = base.ExpandPointerIndirectionOperator(expression, out replacement, UseKind.Value);
-        return StabilizeIfNecessary(expression.syntax, useKind, statements, replacement, out replacement);
+
+        if (useKind == UseKind.Writable)
+            return statements;
+        else
+            return StabilizeIfNecessary(expression.syntax, useKind, statements, replacement, out replacement);
     }
 
     private protected override List<BoundStatement> ExpandArrayCreationExpression(
@@ -1454,10 +1468,10 @@ internal sealed class Expander : BoundTreeExpander {
             if (content.constantValue?.specialType == SpecialType.String) {
                 right = Literal(syntax, content.constantValue.value, stringType);
             } else {
-                statements.AddRange(ExpandExpression(content, out var replacementContent, UseKind.StableValue));
-
-                if (replacementContent.IsLiteralNull())
+                if (content.IsLiteralNull())
                     continue;
+
+                statements.AddRange(ExpandExpression(content, out var replacementContent, UseKind.StableValue));
 
                 if (replacementContent.StrippedType().specialType == SpecialType.String) {
                     right = replacementContent;

--- a/src/Buckle/Compiler/CodeAnalysis/Lowering/Expander.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Lowering/Expander.cs
@@ -63,6 +63,21 @@ internal sealed class Expander : BoundTreeExpander {
             var isConditional = expression.conditionals[i];
 
             switch (cascade.kind) {
+                case BoundKind.ConditionalAccessExpression: {
+                        var condAccess = (BoundConditionalAccessExpression)cascade;
+
+                        statements.AddRange(
+                            ExpandStatement(new BoundExpressionStatement(syntax,
+                                condAccess.Update(
+                                    Local(syntax, tempLocal),
+                                    condAccess.accessExpression,
+                                    condAccess.type
+                                )
+                            ))
+                        );
+                    }
+
+                    break;
                 case BoundKind.CallExpression: {
                         // TODO Conditional cascade
                         var call = (BoundCallExpression)cascade;
@@ -87,7 +102,10 @@ internal sealed class Expander : BoundTreeExpander {
                     break;
                 case BoundKind.CompoundAssignmentOperator: {
                         var assignment = (BoundCompoundAssignmentOperator)cascade;
-                        var leftAccess = (BoundFieldAccessExpression)assignment.left;
+                        var leftAccess = isConditional
+                            ? (BoundFieldAccessExpression)(assignment.left as BoundConditionalAccessExpression)
+                                .accessExpression
+                            : (BoundFieldAccessExpression)assignment.left;
 
                         statements.AddRange(
                             ExpandStatement(new BoundExpressionStatement(syntax,
@@ -110,7 +128,10 @@ internal sealed class Expander : BoundTreeExpander {
                     break;
                 case BoundKind.NullCoalescingAssignmentOperator: {
                         var assignment = (BoundNullCoalescingAssignmentOperator)cascade;
-                        var leftAccess = (BoundFieldAccessExpression)assignment.left;
+                        var leftAccess = isConditional
+                            ? (BoundFieldAccessExpression)(assignment.left as BoundConditionalAccessExpression)
+                                .accessExpression
+                            : (BoundFieldAccessExpression)assignment.left;
 
                         statements.AddRange(
                             ExpandStatement(new BoundExpressionStatement(syntax,
@@ -127,18 +148,20 @@ internal sealed class Expander : BoundTreeExpander {
                     break;
                 case BoundKind.AssignmentOperator: {
                         var assignment = (BoundAssignmentOperator)cascade;
-                        var leftAccess = (BoundFieldAccessExpression)assignment.left;
-                        statements.AddRange(ExpandExpression(assignment.right, out var right));
+                        var leftAccess = isConditional
+                            ? (BoundFieldAccessExpression)(assignment.left as BoundConditionalAccessExpression)
+                                .accessExpression
+                            : (BoundFieldAccessExpression)assignment.left;
 
-                        statements.Add(
-                            new BoundExpressionStatement(syntax,
+                        statements.AddRange(
+                            ExpandStatement(new BoundExpressionStatement(syntax,
                                 assignment.Update(
                                     MakeReplacementReceiver(syntax, isConditional, tempLocal, leftAccess),
-                                    right,
+                                    assignment.right,
                                     assignment.isRef,
                                     assignment.type
                                 )
-                            )
+                            ))
                         );
                     }
 
@@ -1323,8 +1346,137 @@ internal sealed class Expander : BoundTreeExpander {
         BoundAssignmentOperator expression,
         out BoundExpression replacement,
         UseKind useKind) {
-        var statements = base.ExpandAssignmentOperator(expression, out replacement, useKind);
-        return StabilizeIfNecessary(expression.syntax, useKind, statements, replacement, out replacement);
+        /*
+
+        <left> = <right>
+
+        ----> <left> is conditional access <cond>
+
+        temp = null
+        goto break if <cond.receiver> is null
+        temp = <cond.access> = <right>
+        break:
+        temp
+
+
+        ----> <left> is conditional access <cond> and is isolated
+
+        goto break if <cond.receiver> is null
+        <cond.access> = <right>
+        break:
+
+        */
+        if (expression.left is BoundConditionalAccessExpression condAccess) {
+            var syntax = expression.syntax;
+            List<BoundStatement> statements = [];
+            var isIsolated = expression.syntax.parent.kind is SyntaxKind.ExpressionStatement or SyntaxKind.CascadeExpression;
+            var breakLabel = GenerateLabel();
+            var temp = GenerateTempLocal(expression.Type());
+
+            if (!isIsolated)
+                statements.Add(LocalDeclaration(syntax, temp, Literal(syntax, null, temp.type)));
+
+            var linearChain = new List<BoundConditionalAccessExpression>();
+            var current = condAccess;
+
+            while (current is not null) {
+                linearChain.Add(current);
+                current = current.receiver as BoundConditionalAccessExpression;
+            }
+
+            ExpandExpression(linearChain.Last().receiver, out var newReceiver, UseKind.StableValue);
+            statements.Add(GotoIf(syntax, breakLabel, IsNull(syntax, newReceiver)));
+
+            for (var i = linearChain.Count - 1; i > 0; i--) {
+                var cur = linearChain[i];
+                var innerTemp = GenerateTempLocal(cur.Type());
+                statements.AddRange(CreateConditionalAccess(cur, newReceiver, out var conditionalAccess));
+                statements.Add(LocalDeclaration(syntax, innerTemp, conditionalAccess));
+                newReceiver = Local(syntax, innerTemp);
+                statements.Add(GotoIf(syntax, breakLabel, IsNull(syntax, newReceiver)));
+            }
+
+            statements.AddRange(ExpandExpression(expression.right, out var newRight));
+            statements.AddRange(CreateConditionalAccess(linearChain[0], newReceiver, out var finalReceiver));
+            var assignment = Assignment(
+                syntax,
+                finalReceiver,
+                newRight,
+                false,
+                newReceiver.type
+            );
+
+            if (isIsolated) {
+                statements.Add(new BoundExpressionStatement(syntax, assignment));
+                statements.Add(Label(syntax, breakLabel));
+                replacement = null;
+            } else {
+                statements.Add(new BoundExpressionStatement(syntax,
+                    Assignment(syntax,
+                        Local(syntax, temp),
+                        assignment,
+                        false,
+                        assignment.type
+                    )
+                ));
+                statements.Add(Label(syntax, breakLabel));
+                replacement = Local(syntax, temp);
+            }
+
+            return statements;
+        } else {
+            var statements = base.ExpandAssignmentOperator(expression, out replacement, UseKind.Value);
+            return StabilizeIfNecessary(expression.syntax, useKind, statements, replacement, out replacement);
+        }
+
+        List<BoundStatement> CreateConditionalAccess(
+            BoundConditionalAccessExpression expression,
+            BoundExpression currentReceiver,
+            out BoundExpression newReceiver) {
+            var access = expression.accessExpression;
+
+            switch (access.kind) {
+                case BoundKind.FieldAccessExpression:
+                    var fieldAccess = (BoundFieldAccessExpression)access;
+                    newReceiver = new BoundFieldAccessExpression(
+                        access.syntax,
+                        currentReceiver,
+                        fieldAccess.field,
+                        fieldAccess.constantValue,
+                        fieldAccess.type
+                    );
+                    return [];
+                case BoundKind.ArrayAccessExpression: {
+                        var arrayAccess = (BoundArrayAccessExpression)access;
+                        var statements = ExpandExpression(arrayAccess.index, out var newIndex);
+                        newReceiver = new BoundArrayAccessExpression(
+                            access.syntax,
+                            currentReceiver,
+                            newIndex,
+                            arrayAccess.constantValue,
+                            arrayAccess.type
+                        );
+                        return statements;
+                    }
+                case BoundKind.CallExpression: {
+                        var call = (BoundCallExpression)access;
+                        var statements = ExpandExpressionList(call.arguments, out var newArguments);
+                        newReceiver = new BoundCallExpression(
+                            access.syntax,
+                            currentReceiver,
+                            call.method,
+                            newArguments,
+                            call.argumentRefKinds,
+                            call.defaultArguments,
+                            call.resultKind,
+                            call.type
+                        );
+                        return statements;
+                    }
+                default:
+                    throw ExceptionUtilities.UnexpectedValue(access.kind);
+            }
+        }
     }
 
     private protected override List<BoundStatement> ExpandInitializerDictionary(

--- a/src/Buckle/Compiler/CodeAnalysis/Lowering/Expander.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Lowering/Expander.cs
@@ -12,15 +12,12 @@ using static Buckle.CodeAnalysis.Binding.BoundFactory;
 namespace Buckle.CodeAnalysis.Lowering;
 
 /// <summary>
-/// Expands expressions to make them simpler to handle by the <see cref="Lowerer" />.
+/// For lowering expressions into statements. Any lowering that can't produce statements should be done in a later pass.
+/// Most commonly to produce temporary locals to prevent side-effect duplication.
+/// Nodes can be revisited.
 /// </summary>
 internal sealed class Expander : BoundTreeExpander {
     private readonly BelteDiagnosticQueue _diagnostics;
-
-    private int _compoundAssignmentDepth = 0;
-    private int _operatorDepth = 0;
-    private int _conditionalDepth = 0;
-    private int _accessDepth = 0;
 
     internal Expander(MethodSymbol container, BelteDiagnosticQueue diagnostics) {
         _container = container;
@@ -35,9 +32,10 @@ internal sealed class Expander : BoundTreeExpander {
 
     private protected override List<BoundStatement> ExpandCascadeListExpression(
         BoundCascadeListExpression expression,
-        out BoundExpression replacement) {
+        out BoundExpression replacement,
+        UseKind useKind) {
         var syntax = expression.syntax;
-        var statements = ExpandExpression(expression.receiver, out var newReceiver);
+        var statements = ExpandExpression(expression.receiver, out var newReceiver, UseKind.Writable);
         var tempLocal = GenerateTempLocal(expression.Type());
 
         statements.Add(
@@ -51,10 +49,10 @@ internal sealed class Expander : BoundTreeExpander {
         for (var i = 0; i < expression.cascades.Length; i++) {
             var cascade = expression.cascades[i];
             var isConditional = expression.conditionals[i];
-            // TODO How to represent conditional receiver on call?
 
             switch (cascade.kind) {
                 case BoundKind.CallExpression: {
+                        // TODO Conditional cascade
                         var call = (BoundCallExpression)cascade;
                         var replacementReceiver = Local(syntax, tempLocal);
                         statements.AddRange(ExpandExpressionList(call.arguments, out var arguments));
@@ -78,13 +76,12 @@ internal sealed class Expander : BoundTreeExpander {
                 case BoundKind.CompoundAssignmentOperator: {
                         var assignment = (BoundCompoundAssignmentOperator)cascade;
                         var leftAccess = (BoundFieldAccessExpression)assignment.left;
-                        statements.AddRange(ExpandExpression(assignment.right, out var right));
 
-                        statements.Add(
-                            new BoundExpressionStatement(syntax,
+                        statements.AddRange(
+                            ExpandStatement(new BoundExpressionStatement(syntax,
                                 assignment.Update(
                                     MakeReplacementReceiver(syntax, isConditional, tempLocal, leftAccess),
-                                    right,
+                                    assignment.right,
                                     assignment.op,
                                     assignment.leftPlaceholder,
                                     assignment.leftConversion,
@@ -94,7 +91,7 @@ internal sealed class Expander : BoundTreeExpander {
                                     assignment.originalUserDefinedOperators,
                                     assignment.type
                                 )
-                            )
+                            ))
                         );
                     }
 
@@ -102,17 +99,16 @@ internal sealed class Expander : BoundTreeExpander {
                 case BoundKind.NullCoalescingAssignmentOperator: {
                         var assignment = (BoundNullCoalescingAssignmentOperator)cascade;
                         var leftAccess = (BoundFieldAccessExpression)assignment.left;
-                        statements.AddRange(ExpandExpression(assignment.right, out var right));
 
-                        statements.Add(
-                            new BoundExpressionStatement(syntax,
+                        statements.AddRange(
+                            ExpandStatement(new BoundExpressionStatement(syntax,
                                 assignment.Update(
                                     MakeReplacementReceiver(syntax, isConditional, tempLocal, leftAccess),
-                                    right,
+                                    assignment.right,
                                     assignment.isPropagation,
                                     assignment.type
                                 )
-                            )
+                            ))
                         );
                     }
 
@@ -181,352 +177,1146 @@ internal sealed class Expander : BoundTreeExpander {
 
     private protected override List<BoundStatement> ExpandFieldAccessExpression(
         BoundFieldAccessExpression expression,
-        out BoundExpression replacement) {
-        if (expression.field.isStatic || expression.receiver.type.IsVerifierValue())
-            return base.ExpandFieldAccessExpression(expression, out replacement);
+        out BoundExpression replacement,
+        UseKind useKind) {
+        /*
 
-        var type = expression.receiver.Type();
-        var syntax = expression.syntax;
+        <receiver>.<field>
 
-        var savedAccessDepth = _accessDepth;
-        _accessDepth++;
+        ----> UseKind.Value, UseKind.Writable
 
-        if (type.IsNullableType() && type.GetNullableUnderlyingType().IsStructType()) {
-            var underlyingType = type.GetNullableUnderlyingType();
+        <receiver>.<field>
 
-            var statements = ExpandExpression(expression.receiver, out var newReceiver);
+        ----> UseKind.StableValue
 
-            newReceiver = Lowerer.CreateNullableGetValueCall(syntax, newReceiver, underlyingType);
-            var tempLocal = GenerateTempLocal(type);
+        temp = <receiver>.<field>
+        temp
 
-            statements.AddRange(
-                new BoundLocalDeclarationStatement(syntax,
-                    new BoundDataContainerDeclaration(syntax, tempLocal, newReceiver)
-                )
-            );
+        */
+        var statements = base.ExpandFieldAccessExpression(expression, out replacement, UseKind.Value);
 
-            replacement = new BoundFieldAccessExpression(syntax,
-                Local(syntax, tempLocal),
-                expression.field,
-                expression.constantValue,
-                expression.field.type
-            );
+        if (expression.type.IsNullableType() && expression.type.GetNullableUnderlyingType().IsStructType()) {
+            // TODO Just need to make sure this is actually unreachable then can remove
+            throw ExceptionUtilities.Unreachable();
+            // var syntax = expression.syntax;
+            // var underlyingType = type.GetNullableUnderlyingType();
 
-            _accessDepth = savedAccessDepth;
-            return statements;
+            // var statements = ExpandExpression(expression.receiver, out var newReceiver, useKind);
+
+            // newReceiver = Lowerer.CreateNullableGetValueCall(syntax, newReceiver, underlyingType);
+            // var tempLocal = GenerateTempLocal(type);
+
+            // statements.AddRange(
+            //     new BoundLocalDeclarationStatement(syntax,
+            //         new BoundDataContainerDeclaration(syntax, tempLocal, newReceiver)
+            //     )
+            // );
+
+            // replacement = new BoundFieldAccessExpression(syntax,
+            //     Local(syntax, tempLocal),
+            //     expression.field,
+            //     expression.constantValue,
+            //     expression.field.type
+            // );
+
+            // _accessDepth = savedAccessDepth;
+            // return statements;
         }
 
-        _accessDepth--;
-        return base.ExpandFieldAccessExpression(expression, out replacement);
+        if (useKind == UseKind.StableValue)
+            return Stabilize(expression.syntax, statements, replacement, out replacement);
+
+        return statements;
     }
 
     private protected override List<BoundStatement> ExpandCompoundAssignmentOperator(
         BoundCompoundAssignmentOperator expression,
-        out BoundExpression replacement) {
-        _compoundAssignmentDepth++;
+        out BoundExpression replacement,
+        UseKind useKind) {
+        /*
+
+        <left> <op>= <right>
+
+        ----> UseKind.Value
+
+        <left> = <left> <op> <right>
+
+        ---> UseKind.StableValue, UseKind.Writable
+
+        <left> = <left> <op> <right>
+        <left>
+
+        */
         var syntax = expression.syntax;
 
-        if (_compoundAssignmentDepth > 1) {
-            var statements = ExpandExpression(expression.left, out var newLeft);
-            statements.AddRange(ExpandExpression(expression.right, out var newRight));
+        var statements = ExpandExpression(expression.left, out var newLeft, UseKind.Writable);
+        statements.AddRange(ExpandExpression(expression.right, out var newRight));
 
-            statements.Add(
-                new BoundExpressionStatement(
-                    syntax,
-                    new BoundCompoundAssignmentOperator(
-                        syntax,
-                        newLeft,
-                        newRight,
-                        expression.op,
-                        expression.leftPlaceholder,
-                        expression.leftConversion,
-                        expression.finalPlaceholder,
-                        expression.finalConversion,
-                        expression.resultKind,
-                        expression.originalUserDefinedOperators,
-                        expression.Type()
-                    )
-                )
-            );
+        statements.AddRange(ExpandAssignmentOperator(Assignment(syntax,
+            newLeft,
+            new BoundBinaryOperator(syntax,
+                newLeft,
+                newRight,
+                expression.op.kind,
+                expression.op.method,
+                expression.constantValue,
+                expression.type
+            ),
+            false,
+            expression.type
+        ), out var assignment, UseKind.Value));
 
+        if (useKind == UseKind.Value) {
+            replacement = assignment;
+            return statements;
+        } else {
+            statements.Add(new BoundExpressionStatement(syntax, assignment));
             replacement = newLeft;
-            _compoundAssignmentDepth--;
             return statements;
         }
-
-        var baseStatements = base.ExpandCompoundAssignmentOperator(expression, out replacement);
-        _compoundAssignmentDepth--;
-        return baseStatements;
     }
 
     private protected override List<BoundStatement> ExpandNullCoalescingOperator(
         BoundNullCoalescingOperator expression,
-        out BoundExpression replacement) {
-        _operatorDepth++;
-        _conditionalDepth++;
+        out BoundExpression replacement,
+        UseKind useKind) {
+        /*
 
-        var baseStatements = base.ExpandNullCoalescingOperator(expression, out replacement);
+        <left> <op> <right>
 
-        _operatorDepth--;
-        _conditionalDepth--;
-        return baseStatements;
+        ----> <op> is ??
+
+        temp = <left>
+        goto Break unless temp is null
+        temp = <right>
+        Break:
+        temp
+
+        ---> <op> is ?!
+
+        temp = <left>
+        goto Break if temp is null
+        temp = <right>
+        Break:
+        temp
+
+        */
+        var syntax = expression.syntax;
+
+        var statements = ExpandExpression(expression.left, out var newLeft);
+        var temp = GenerateTempLocal(newLeft.type);
+        statements.Add(LocalDeclaration(syntax, temp, newLeft));
+
+        var condition = IsNull(syntax, Local(syntax, temp));
+        var breakLabel = GenerateLabel();
+        statements.Add(
+            expression.isPropagation
+                ? GotoIf(syntax, breakLabel, condition)
+                : GotoIfNot(syntax, breakLabel, condition)
+        );
+
+        statements.AddRange(ExpandExpression(expression.right, out var newRight));
+        var assignment = Assignment(syntax, Local(syntax, temp), newRight, false, expression.type);
+        statements.Add(new BoundExpressionStatement(syntax, assignment));
+        statements.Add(Label(syntax, breakLabel));
+
+        replacement = Local(syntax, temp);
+        return statements;
+    }
+
+    private protected override List<BoundStatement> ExpandNullErasureOperator(
+        BoundNullErasureOperator expression,
+        out BoundExpression replacement,
+        UseKind useKind) {
+        /*
+
+        <operand>?
+
+        ---->
+
+        temp = <operand>
+        goto Break unless temp is null
+        temp = <default value>
+        Break:
+        temp!
+
+        */
+        var syntax = expression.syntax;
+
+        var statements = ExpandExpression(expression.operand, out var newOperand);
+        var temp = GenerateTempLocal(newOperand.type);
+        statements.Add(LocalDeclaration(syntax, temp, newOperand));
+
+        var condition = IsNull(syntax, Local(syntax, temp));
+        var breakLabel = GenerateLabel();
+        statements.Add(GotoIfNot(syntax, breakLabel, condition));
+
+        var defaultValue = Literal(syntax, expression.defaultValue.value, expression.type);
+        var assignment = Assignment(syntax, Local(syntax, temp), defaultValue, false, expression.type);
+        statements.Add(new BoundExpressionStatement(syntax, assignment));
+        statements.Add(Label(syntax, breakLabel));
+
+        replacement = new BoundNullAssertOperator(syntax, Local(syntax, temp), false, null, expression.type);
+        return statements;
     }
 
     private protected override List<BoundStatement> ExpandNullCoalescingAssignmentOperator(
         BoundNullCoalescingAssignmentOperator expression,
-        out BoundExpression replacement) {
-        _compoundAssignmentDepth++;
+        out BoundExpression replacement,
+        UseKind useKind) {
+        /*
+
+        <left> <op>= <right>
+
+        ----> <op> is ??
+
+        goto Break unless <left> is null
+        <left> = <right>
+        Break:
+        <left>
+
+        ---> <op> is ?!
+
+        goto Break if <left> is null
+        <left> = <right>
+        Break:
+        <left>
+
+        */
         var syntax = expression.syntax;
 
-        if (_compoundAssignmentDepth > 1) {
-            var statements = ExpandExpression(expression.left, out var newLeft);
-            statements.AddRange(ExpandExpression(expression.right, out var newRight));
+        var statements = ExpandExpression(expression.left, out var newLeft, UseKind.Writable);
 
-            statements.Add(
-                new BoundExpressionStatement(
-                    syntax,
-                    new BoundNullCoalescingAssignmentOperator(
-                        syntax,
-                        newLeft,
-                        newRight,
-                        expression.isPropagation,
-                        expression.Type()
-                    )
-                )
-            );
+        var condition = IsNull(syntax, newLeft);
+        var breakLabel = GenerateLabel();
+        statements.Add(
+            expression.isPropagation
+                ? GotoIf(syntax, breakLabel, condition)
+                : GotoIfNot(syntax, breakLabel, condition)
+        );
 
-            replacement = newLeft;
-            _compoundAssignmentDepth--;
-            return statements;
-        }
+        statements.AddRange(ExpandExpression(expression.right, out var newRight));
+        var assignment = Assignment(syntax, newLeft, newRight, false, expression.type);
+        statements.Add(new BoundExpressionStatement(syntax, assignment));
+        statements.Add(Label(syntax, breakLabel));
 
-        var baseStatements = base.ExpandNullCoalescingAssignmentOperator(expression, out replacement);
-        _compoundAssignmentDepth--;
-        return baseStatements;
+        replacement = newLeft;
+        return statements;
     }
 
     private protected override List<BoundStatement> ExpandCallExpression(
         BoundCallExpression expression,
-        out BoundExpression replacement) {
+        out BoundExpression replacement,
+        UseKind useKind) {
+        /*
+
+        <operand>(<args>)
+
+        ----> UseKind.StableValue, UseKind.Writable
+
+        temp = <operand>(<args>)
+        temp
+
+        */
         var syntax = expression.syntax;
 
-        if (_conditionalDepth > 0) {
-            var statements = ExpandCallExpressionInternal(expression, out var callReplacement);
-            var tempLocal = GenerateTempLocal(expression.Type());
+        var statements = base.ExpandCallExpression(expression, out var newCall, UseKind.Value);
 
-            statements.Add(new BoundLocalDeclarationStatement(
-                syntax,
-                new BoundDataContainerDeclaration(syntax, tempLocal, callReplacement)
-            ));
-
-            replacement = Local(syntax, tempLocal);
-
+        if (useKind == UseKind.Value) {
+            replacement = newCall;
             return statements;
+        } else {
+            return Stabilize(syntax, statements, newCall, out replacement);
         }
-
-        return ExpandCallExpressionInternal(expression, out replacement);
-    }
-
-    private List<BoundStatement> ExpandCallExpressionInternal(
-        BoundCallExpression expression,
-        out BoundExpression replacement) {
-        /*
-        TODO What did this do
-        if (_transpilerMode && expression.method.containingType.Equals(StandardLibrary.Math)) {
-            var statements = ExpandExpression(expression.expression, out var expressionReplacement);
-            var replacementArguments = ArrayBuilder<BoundExpression>.GetInstance();
-
-            foreach (var argument in expression.arguments) {
-                var tempLocal = GenerateTempLocal(argument.type);
-                statements.AddRange(ExpandExpression(argument, out var argumentReplacement));
-                statements.Add(new BoundLocalDeclarationStatement(
-                    new BoundDataContainerDeclaration(tempLocal, argumentReplacement)
-                ));
-
-                replacementArguments.Add(new BoundDataContainerExpression(tempLocal));
-            }
-
-            replacement = new BoundCallExpression(
-                expressionReplacement,
-                expression.method,
-                replacementArguments.ToImmutableAndFree()
-            );
-
-            return statements;
-        }
-        */
-
-        return base.ExpandCallExpression(expression, out replacement);
     }
 
     private protected override List<BoundStatement> ExpandBinaryOperator(
         BoundBinaryOperator expression,
-        out BoundExpression replacement) {
-        _operatorDepth++;
-        var savedConditionalDepth = _conditionalDepth;
+        out BoundExpression replacement,
+        UseKind useKind) {
+        /*
+
+        (Multiple options can happen in junction)
+
+        <left> <op> <right>
+
+        ----> UseKind.StableValue
+
+        temp = <left> <op> <right>
+        temp
+
+        ----> <op> has a method attached
+
+        <method>(<left>, <right>)
+
+        ----> <op> is **
+
+        Math.Pow(<left>, <right>)
+
+        ----> <left> is nullable and <right> is nullable
+
+        ((HasValue(<left>) && HasValue(<right>)) ? new Nullable( Value(<left>) <op> Value(<right>) ) : null)
+
+        ----> <left> is nullable
+
+        (HasValue(<left>) ? new Nullable( Value(<left>) <op> <right> ) : null)
+
+        ----> <right> is nullable
+
+        (<right> isnt null ? new Nullable( <left> <op> Value(<right>) ) : null)
+
+        */
+        var op = expression.operatorKind;
+
+        if (op.Operator() == BinaryOperatorKind.ConditionalAnd)
+            return ExpandConditionalAndOperator(expression, out replacement);
+
+        if (op.Operator() == BinaryOperatorKind.ConditionalOr)
+            return ExpandConditionalOrOperator(expression, out replacement);
+
         var syntax = expression.syntax;
 
-        if (expression.left.Type().IsNullableType() || expression.right.Type().IsNullableType())
-            _conditionalDepth++;
-
-        if (_conditionalDepth > 1) {
+        if (expression.method is not null) {
             var statements = ExpandExpression(expression.left, out var newLeft);
             statements.AddRange(ExpandExpression(expression.right, out var newRight));
-
-            var tempLocal = GenerateTempLocal(expression.Type());
-
-            statements.Add(
-                new BoundLocalDeclarationStatement(syntax, new BoundDataContainerDeclaration(
-                    syntax,
-                    tempLocal,
-                    new BoundBinaryOperator(
-                        syntax,
-                        newLeft,
-                        newRight,
-                        expression.operatorKind,
-                        expression.method,
-                        expression.constantValue,
-                        expression.Type()
-                    )
-                ))
+            replacement = Call(
+                syntax,
+                expression.method,
+                newLeft,
+                newRight
             );
 
-            replacement = Local(syntax, tempLocal);
-            _operatorDepth--;
-            _conditionalDepth = savedConditionalDepth;
-            return statements;
+            return StabilizeIfNecessary(syntax, useKind, statements, replacement, out replacement);
         }
 
-        var baseStatements = base.ExpandBinaryOperator(expression, out replacement);
-        _operatorDepth--;
-        _conditionalDepth = savedConditionalDepth;
-        return baseStatements;
+        if (op.Operator() == BinaryOperatorKind.Power) {
+            var statements = ExpandExpression(expression.left, out var newLeft);
+            statements.AddRange(ExpandExpression(expression.right, out var newRight));
+            replacement = Call(
+                syntax,
+                StandardLibrary.GetPowerMethod(op.IsLifted(), op.OperandTypes() == BinaryOperatorKind.Int),
+                newLeft,
+                newRight
+            );
+
+            return StabilizeIfNecessary(syntax, useKind, statements, replacement, out replacement);
+        }
+
+        var type = expression.Type();
+        var left = expression.left;
+        var right = expression.right;
+
+        if (op.IsLifted()) {
+            // Optimization: We don't need to check if something is nullable if it was lifted just for this operator
+            if (left is BoundCastExpression lCast &&
+                lCast.conversion.kind == ConversionKind.ImplicitNullable &&
+                lCast.conversion.underlyingConversions[0].kind == ConversionKind.Identity) {
+                left = lCast.operand;
+            }
+
+            if (right is BoundCastExpression rCast &&
+                rCast.conversion.kind == ConversionKind.ImplicitNullable &&
+                rCast.conversion.underlyingConversions[0].kind == ConversionKind.Identity) {
+                right = rCast.operand;
+            }
+        }
+
+        var leftIsNullable = left.Type().IsNullableType();
+        var rightIsNullable = right.Type().IsNullableType();
+
+        if (leftIsNullable && rightIsNullable && left.constantValue is null && right.constantValue is null) {
+            var statements = ExpandExpression(left, out var newLeft, UseKind.StableValue);
+            statements.AddRange(ExpandExpression(right, out var newRight, UseKind.StableValue));
+            replacement = Conditional(syntax,
+                @if: And(syntax,
+                    HasValue(syntax, newLeft),
+                    HasValue(syntax, newRight)
+                ),
+                @then: Lowerer.CreateNullable(syntax,
+                    Binary(syntax,
+                        Value(syntax, newLeft, newLeft.Type().GetNullableUnderlyingType()),
+                        op,
+                        Value(syntax, newRight, newRight.Type().GetNullableUnderlyingType()),
+                        type.StrippedType()
+                        ),
+                    type
+                ),
+                @else: Literal(syntax, null, type),
+                type
+            );
+            return StabilizeIfNecessary(syntax, useKind, statements, replacement, out replacement);
+        } else if (leftIsNullable && left.constantValue is null) {
+            var statements = ExpandExpression(left, out var newLeft, UseKind.StableValue);
+            statements.AddRange(ExpandExpression(right, out var newRight));
+            replacement = Conditional(syntax,
+                @if: HasValue(syntax, newLeft),
+                @then: Lowerer.CreateNullable(syntax,
+                    Binary(syntax,
+                        Value(syntax, newLeft, newLeft.Type().GetNullableUnderlyingType()),
+                        op,
+                        Lowerer.DeNull(newRight),
+                        type.StrippedType()
+                    ),
+                    type
+                ),
+                @else: Literal(syntax, null, type),
+                type
+            );
+            return StabilizeIfNecessary(syntax, useKind, statements, replacement, out replacement);
+        } else if (rightIsNullable && right.constantValue is null) {
+            var statements = ExpandExpression(left, out var newLeft);
+            statements.AddRange(ExpandExpression(right, out var newRight, UseKind.StableValue));
+            replacement = Conditional(syntax,
+                @if: HasValue(syntax, newRight),
+                @then: Lowerer.CreateNullable(syntax,
+                    Binary(syntax,
+                        Lowerer.DeNull(newLeft),
+                        op,
+                        Value(syntax, newRight, newRight.Type().GetNullableUnderlyingType()),
+                        type.StrippedType()
+                    ),
+                    type
+                ),
+                @else: Literal(syntax, null, type),
+                type
+            );
+            return StabilizeIfNecessary(syntax, useKind, statements, replacement, out replacement);
+        } else {
+            var statements = base.ExpandBinaryOperator(expression, out replacement, UseKind.Value);
+            return StabilizeIfNecessary(syntax, useKind, statements, replacement, out replacement);
+        }
+    }
+
+    private List<BoundStatement> ExpandConditionalAndOperator(
+        BoundBinaryOperator expression,
+        out BoundExpression replacement) {
+        /*
+
+        <left> && <right>
+
+        ----> <left> is nullable and <right> is nullable
+
+        result = false
+        goto break if <left> is null || <left>! == false
+        goto break if <right> is null
+        result = <right>!
+        break:
+        result
+
+        ----> <left> is nullable
+
+        result = false
+        goto break if <left> is null || <left>! == false
+        result = <right>
+        break:
+        result
+
+        ----> <right> is nullable
+
+        result = false
+        goto break if <left> == false
+        goto break if <right> is null
+        result = <right>!
+        break:
+        result
+
+        ---->
+
+        result = <left>
+        goto break if result == false
+        result = <right>
+        break:
+        result
+
+        */
+        var syntax = expression.syntax;
+        var boolType = CorLibrary.GetSpecialType(SpecialType.Bool);
+
+        if (expression.left.Type().IsNullableType() && expression.right.Type().IsNullableType()) {
+            var statements = ExpandExpression(expression.left, out var newLeft, UseKind.StableValue);
+            var temp = GenerateTempLocal(boolType);
+            var breakLabel = GenerateLabel();
+            statements.Add(LocalDeclaration(syntax, temp, Literal(syntax, false, boolType)));
+            statements.Add(GotoIf(syntax, breakLabel,
+                Binary(syntax,
+                    IsNull(syntax, newLeft),
+                    BinaryOperatorKind.ConditionalOr,
+                    Binary(syntax,
+                        new BoundNullAssertOperator(syntax, newLeft, false, null, newLeft.StrippedType()),
+                        BinaryOperatorKind.BoolEqual,
+                        Literal(syntax, false, boolType),
+                        boolType
+                    ),
+                    boolType
+                )
+            ));
+            statements.AddRange(ExpandExpression(expression.right, out var newRight, UseKind.StableValue));
+            statements.Add(GotoIf(syntax, breakLabel, IsNull(syntax, newRight)));
+            statements.Add(new BoundExpressionStatement(syntax,
+                Assignment(syntax,
+                    Local(syntax, temp),
+                    new BoundNullAssertOperator(syntax, newRight, false, null, newRight.StrippedType()),
+                    false,
+                    temp.type
+                )
+            ));
+            statements.Add(Label(syntax, breakLabel));
+
+            replacement = Local(syntax, temp);
+            return statements;
+        } else if (expression.left.Type().IsNullableType()) {
+            var statements = ExpandExpression(expression.left, out var newLeft, UseKind.StableValue);
+            var temp = GenerateTempLocal(boolType);
+            var breakLabel = GenerateLabel();
+            statements.Add(LocalDeclaration(syntax, temp, Literal(syntax, false, boolType)));
+            statements.Add(GotoIf(syntax, breakLabel,
+                Binary(syntax,
+                    IsNull(syntax, newLeft),
+                    BinaryOperatorKind.ConditionalOr,
+                    Binary(syntax,
+                        new BoundNullAssertOperator(syntax, newLeft, false, null, newLeft.StrippedType()),
+                        BinaryOperatorKind.BoolEqual,
+                        Literal(syntax, false, boolType),
+                        boolType
+                    ),
+                    boolType
+                )
+            ));
+            statements.AddRange(ExpandExpression(expression.right, out var newRight));
+            statements.Add(GotoIf(syntax, breakLabel, IsNull(syntax, newRight)));
+            statements.Add(new BoundExpressionStatement(syntax,
+                Assignment(syntax,
+                    Local(syntax, temp),
+                    newRight,
+                    false,
+                    temp.type
+                )
+            ));
+            statements.Add(Label(syntax, breakLabel));
+
+            replacement = Local(syntax, temp);
+            return statements;
+        } else if (expression.right.Type().IsNullableType()) {
+            var statements = ExpandExpression(expression.left, out var newLeft);
+            var temp = GenerateTempLocal(boolType);
+            var breakLabel = GenerateLabel();
+            statements.Add(LocalDeclaration(syntax, temp, Literal(syntax, false, boolType)));
+            statements.Add(GotoIf(syntax, breakLabel,
+                Binary(syntax,
+                    newLeft,
+                    BinaryOperatorKind.BoolEqual,
+                    Literal(syntax, false, boolType),
+                    boolType
+                )
+            ));
+            statements.AddRange(ExpandExpression(expression.right, out var newRight, UseKind.StableValue));
+            statements.Add(GotoIf(syntax, breakLabel, IsNull(syntax, newRight)));
+            statements.Add(new BoundExpressionStatement(syntax,
+                Assignment(syntax,
+                    Local(syntax, temp),
+                    new BoundNullAssertOperator(syntax, newRight, false, null, newRight.StrippedType()),
+                    false,
+                    temp.type
+                )
+            ));
+            statements.Add(Label(syntax, breakLabel));
+
+            replacement = Local(syntax, temp);
+            return statements;
+        } else {
+            var statements = ExpandExpression(expression.left, out var newLeft);
+            var temp = GenerateTempLocal(boolType);
+            var breakLabel = GenerateLabel();
+            statements.Add(LocalDeclaration(syntax, temp, newLeft));
+            statements.Add(GotoIf(syntax, breakLabel,
+                Binary(syntax,
+                    newLeft,
+                    BinaryOperatorKind.BoolEqual,
+                    Literal(syntax, false, boolType),
+                    boolType
+                )
+            ));
+            statements.AddRange(ExpandExpression(expression.right, out var newRight));
+            statements.Add(new BoundExpressionStatement(syntax,
+                Assignment(syntax,
+                    Local(syntax, temp),
+                    newRight,
+                    false,
+                    temp.type
+                )
+            ));
+            statements.Add(Label(syntax, breakLabel));
+
+            replacement = Local(syntax, temp);
+            return statements;
+        }
+    }
+
+    private List<BoundStatement> ExpandConditionalOrOperator(
+        BoundBinaryOperator expression,
+        out BoundExpression replacement) {
+        /*
+
+        <left> || <right>
+
+        ----> <left> is nullable and <right> is nullable
+
+        result = true
+        goto break unless <left> is null || <left>! == false
+        goto continue unless <right> is null
+        result = false
+        goto break
+        continue:
+        result = <right>!
+        break:
+        result
+
+        ----> <left> is nullable
+
+        result = true
+        goto break unless <left> is null || <left>! == false
+        result = <right>
+        break:
+        result
+
+        ----> <right> is nullable
+
+        result = true
+        goto break if <left> == true
+        goto continue unless <right> is null
+        result = false
+        goto break
+        continue:
+        result = <right>!
+        break:
+        result
+
+        ---->
+
+        result = <left>
+        goto break if result == true
+        result = <right>
+        break:
+        result
+
+        */
+        var syntax = expression.syntax;
+        var boolType = CorLibrary.GetSpecialType(SpecialType.Bool);
+
+        if (expression.left.Type().IsNullableType() && expression.right.Type().IsNullableType()) {
+            var statements = ExpandExpression(expression.left, out var newLeft, UseKind.StableValue);
+            var temp = GenerateTempLocal(boolType);
+            var breakLabel = GenerateLabel();
+            var continueLabel = GenerateLabel();
+            statements.Add(LocalDeclaration(syntax, temp, Literal(syntax, true, boolType)));
+            statements.Add(GotoIfNot(syntax, breakLabel,
+                Binary(syntax,
+                    IsNull(syntax, newLeft),
+                    BinaryOperatorKind.ConditionalOr,
+                    Binary(syntax,
+                        new BoundNullAssertOperator(syntax, newLeft, false, null, newLeft.StrippedType()),
+                        BinaryOperatorKind.BoolEqual,
+                        Literal(syntax, false, boolType),
+                        boolType
+                    ),
+                    boolType
+                )
+            ));
+            statements.AddRange(ExpandExpression(expression.right, out var newRight, UseKind.StableValue));
+            statements.Add(GotoIfNot(syntax, continueLabel, IsNull(syntax, newRight)));
+            statements.Add(new BoundExpressionStatement(syntax,
+                Assignment(syntax,
+                    Local(syntax, temp),
+                    Literal(syntax, false, temp.type),
+                    false,
+                    temp.type
+                )
+            ));
+            statements.Add(Goto(syntax, breakLabel));
+            statements.Add(Label(syntax, continueLabel));
+            statements.Add(new BoundExpressionStatement(syntax,
+                Assignment(syntax,
+                    Local(syntax, temp),
+                    new BoundNullAssertOperator(syntax, newRight, false, null, newRight.StrippedType()),
+                    false,
+                    temp.type
+                )
+            ));
+            statements.Add(Label(syntax, breakLabel));
+
+            replacement = Local(syntax, temp);
+            return statements;
+        } else if (expression.left.Type().IsNullableType()) {
+            var statements = ExpandExpression(expression.left, out var newLeft, UseKind.StableValue);
+            var temp = GenerateTempLocal(boolType);
+            var breakLabel = GenerateLabel();
+            statements.Add(LocalDeclaration(syntax, temp, Literal(syntax, true, boolType)));
+            statements.Add(GotoIfNot(syntax, breakLabel,
+                Binary(syntax,
+                    IsNull(syntax, newLeft),
+                    BinaryOperatorKind.ConditionalOr,
+                    Binary(syntax,
+                        new BoundNullAssertOperator(syntax, newLeft, false, null, newLeft.StrippedType()),
+                        BinaryOperatorKind.BoolEqual,
+                        Literal(syntax, false, boolType),
+                        boolType
+                    ),
+                    boolType
+                )
+            ));
+            statements.AddRange(ExpandExpression(expression.right, out var newRight));
+            statements.Add(new BoundExpressionStatement(syntax,
+                Assignment(syntax,
+                    Local(syntax, temp),
+                    newRight,
+                    false,
+                    temp.type
+                )
+            ));
+            statements.Add(Label(syntax, breakLabel));
+
+            replacement = Local(syntax, temp);
+            return statements;
+        } else if (expression.right.Type().IsNullableType()) {
+            var statements = ExpandExpression(expression.left, out var newLeft);
+            var temp = GenerateTempLocal(boolType);
+            var breakLabel = GenerateLabel();
+            var continueLabel = GenerateLabel();
+            statements.Add(LocalDeclaration(syntax, temp, Literal(syntax, true, boolType)));
+            statements.Add(GotoIf(syntax, breakLabel,
+                Binary(syntax,
+                    newLeft,
+                    BinaryOperatorKind.BoolEqual,
+                    Literal(syntax, true, boolType),
+                    boolType
+                )
+            ));
+            statements.AddRange(ExpandExpression(expression.right, out var newRight, UseKind.StableValue));
+            statements.Add(GotoIfNot(syntax, continueLabel, IsNull(syntax, newRight)));
+            statements.Add(new BoundExpressionStatement(syntax,
+                Assignment(syntax,
+                    Local(syntax, temp),
+                    Literal(syntax, false, temp.type),
+                    false,
+                    temp.type
+                )
+            ));
+            statements.Add(Goto(syntax, breakLabel));
+            statements.Add(Label(syntax, continueLabel));
+            statements.Add(new BoundExpressionStatement(syntax,
+                Assignment(syntax,
+                    Local(syntax, temp),
+                    new BoundNullAssertOperator(syntax, newRight, false, null, newRight.StrippedType()),
+                    false,
+                    temp.type
+                )
+            ));
+            statements.Add(Label(syntax, breakLabel));
+
+            replacement = Local(syntax, temp);
+            return statements;
+        } else {
+            var statements = ExpandExpression(expression.left, out var newLeft);
+            var temp = GenerateTempLocal(boolType);
+            var breakLabel = GenerateLabel();
+            statements.Add(LocalDeclaration(syntax, temp, newLeft));
+            statements.Add(GotoIf(syntax, breakLabel,
+                Binary(syntax,
+                    newLeft,
+                    BinaryOperatorKind.BoolEqual,
+                    Literal(syntax, true, boolType),
+                    boolType
+                )
+            ));
+            statements.AddRange(ExpandExpression(expression.right, out var newRight));
+            statements.Add(new BoundExpressionStatement(syntax,
+                Assignment(syntax,
+                    Local(syntax, temp),
+                    newRight,
+                    false,
+                    temp.type
+                )
+            ));
+            statements.Add(Label(syntax, breakLabel));
+
+            replacement = Local(syntax, temp);
+            return statements;
+        }
+    }
+
+    private List<BoundStatement> StabilizeIfNecessary(
+        SyntaxNode syntax,
+        UseKind useKind,
+        List<BoundStatement> statements,
+        BoundExpression tentativeReplacement,
+        out BoundExpression replacement) {
+        if (useKind == UseKind.Value) {
+            replacement = tentativeReplacement;
+            return statements;
+        } else if (useKind == UseKind.StableValue) {
+            return Stabilize(syntax, statements, tentativeReplacement, out replacement);
+        } else {
+            throw ExceptionUtilities.UnexpectedValue(useKind);
+        }
+    }
+
+    private List<BoundStatement> Stabilize(
+        SyntaxNode syntax,
+        List<BoundStatement> statements,
+        BoundExpression expression,
+        out BoundExpression replacement) {
+        var temp = GenerateTempLocal(expression.type);
+        statements.Add(LocalDeclaration(syntax, temp, expression));
+        replacement = Local(syntax, temp);
+        return statements;
     }
 
     private protected override List<BoundStatement> ExpandUnaryOperator(
         BoundUnaryOperator expression,
-        out BoundExpression replacement) {
-        _operatorDepth++;
-        var savedConditionalDepth = _conditionalDepth;
+        out BoundExpression replacement,
+        UseKind useKind) {
+        /*
 
-        if (expression.operand.Type().IsNullableType())
-            _conditionalDepth++;
+        <op> <operand>
 
-        var baseStatements = base.ExpandUnaryOperator(expression, out replacement);
-        _operatorDepth--;
-        _conditionalDepth = savedConditionalDepth;
-        return baseStatements;
+        ----> <op> has a method attached
+
+        <method>(<op>)
+
+        ----> <op> is +
+
+        <operand>
+
+        ----> <operand> is nullable
+
+        (HasValue(<operand>) ? new Nullable( <op> Value(<operand>) ) : null)
+
+        */
+        var syntax = expression.syntax;
+        var operand = expression.operand;
+
+        if (expression.method is not null) {
+            var statements = ExpandExpression(operand, out var newOperand);
+            replacement = Call(
+                syntax,
+                expression.method,
+                newOperand
+            );
+
+            return StabilizeIfNecessary(syntax, useKind, statements, replacement, out replacement);
+        }
+
+        var op = expression.operatorKind;
+
+        if (op == UnaryOperatorKind.UnaryPlus)
+            return ExpandExpression(operand, out replacement, useKind);
+
+        if (operand.Type().IsNullableType()) {
+            var statements = ExpandExpression(operand, out var newOperand);
+            replacement = Conditional(syntax,
+                @if: HasValue(syntax, newOperand),
+                @then: Lowerer.CreateNullable(syntax,
+                    Unary(syntax,
+                        op,
+                        Value(syntax, newOperand, newOperand.Type().GetNullableUnderlyingType()),
+                        expression.StrippedType()
+                    ),
+                    expression.type
+                ),
+                @else: Literal(syntax, null, expression.Type()),
+                expression.Type()
+            );
+            return StabilizeIfNecessary(syntax, useKind, statements, replacement, out replacement);
+        } else {
+            var statements = base.ExpandUnaryOperator(expression, out replacement, UseKind.Value);
+            return StabilizeIfNecessary(syntax, useKind, statements, replacement, out replacement);
+        }
     }
 
     private protected override List<BoundStatement> ExpandCastExpression(
         BoundCastExpression expression,
-        out BoundExpression replacement) {
-        _operatorDepth++;
-        var savedConditionalDepth = _conditionalDepth;
+        out BoundExpression replacement,
+        UseKind useKind) {
+        /*
 
-        if (expression.operand.Type().IsNullableType() && expression.Type().IsNullableType())
-            _conditionalDepth++;
+        (<type>)<operand>
 
-        if (_conditionalDepth > 1 &&
-            (expression.Type().IsNullableType() || expression.operand.Type().IsNullableType()) &&
-            expression.conversion.underlyingConversions != default &&
-            expression.conversion.kind is ConversionKind.ImplicitNullable or ConversionKind.ExplicitNullable &&
-            !expression.operand.Type().Equals(expression.Type())) {
-            var syntax = expression.syntax;
-            var statements = ExpandExpression(expression.operand, out var newOperand);
-            var tempLocal = GenerateTempLocal(expression.Type());
+        ----> <op> has a method attached
 
-            statements.Add(
-                new BoundLocalDeclarationStatement(syntax, new BoundDataContainerDeclaration(
-                    syntax,
-                    tempLocal,
-                    new BoundCastExpression(
-                        syntax,
-                        newOperand,
-                        expression.conversion,
-                        expression.constantValue,
-                        expression.Type()
-                    )
-                ))
+        <method>(<operand>)
+
+        ----> <operand> is nullable and <type> is nullable
+
+        (HasValue(<operand>) ? new Nullable( (<type!>)Value(<operand>) ) : null)
+
+        ----> <operand> is nullable and <type> is not nullable
+
+        (<type>)Value(<operand>)
+
+        ----> <operand> is not nullable and <type> is nullable
+
+        new Nullable( (<type!>)<operand> )
+
+        ----> <operand>.type == <type>
+
+        <operand>
+
+        */
+        var syntax = expression.syntax;
+        var operand = expression.operand;
+
+        if (expression.conversion.method is not null) {
+            var statements = ExpandExpression(operand, out var newOperand);
+            replacement = Call(
+                syntax,
+                expression.conversion.method,
+                newOperand
             );
 
-            replacement = Local(syntax, tempLocal);
-            _operatorDepth--;
-            _conditionalDepth = savedConditionalDepth;
-            return statements;
+            return StabilizeIfNecessary(syntax, useKind, statements, replacement, out replacement);
         }
 
-        var baseStatements = base.ExpandCastExpression(expression, out replacement);
-        _operatorDepth--;
-        _conditionalDepth = savedConditionalDepth;
-        return baseStatements;
+        var type = expression.Type();
+        var operandType = operand.Type();
+
+        if (operandType?.Equals(type, TypeCompareKind.ConsiderEverything) ?? false)
+            return ExpandExpression(operand, out replacement, useKind);
+
+        if (expression.conversion.underlyingConversions == default) {
+            if (expression.conversion.kind is ConversionKind.ImplicitNullToPointer)
+                return StabilizeIfNecessary(syntax, useKind, [], expression, out replacement);
+
+            var statements = base.ExpandCastExpression(expression, out replacement, UseKind.Value);
+            return StabilizeIfNecessary(syntax, useKind, statements, replacement, out replacement);
+        }
+
+        if (operandType.IsNullableType() && type.IsNullableType()) {
+            var statements = ExpandExpression(operand, out var newOperand, UseKind.StableValue);
+            statements.AddRange(ExpandExpression(Conditional(syntax,
+                @if: HasValue(syntax, newOperand),
+                @then: Lowerer.CreateNullable(syntax,
+                    Cast(syntax,
+                        type.GetNullableUnderlyingType(),
+                        Value(syntax, newOperand, operandType.GetNullableUnderlyingType()),
+                        expression.conversion.underlyingConversions[0],
+                        newOperand.constantValue
+                    ),
+                    type
+                ),
+                @else: Literal(syntax, null, type),
+                type
+            ), out replacement, UseKind.Value));
+            return StabilizeIfNecessary(syntax, useKind, statements, replacement, out replacement);
+        }
+
+        {
+            List<BoundStatement> statements;
+
+            switch (expression.conversion.kind) {
+                case ConversionKind.ImplicitNullable:
+                    statements = ExpandExpression(Lowerer.CreateNullable(
+                        syntax,
+                        Cast(
+                            syntax,
+                            type.GetNullableUnderlyingType(),
+                            operand,
+                            expression.conversion.underlyingConversions[0],
+                            operand.constantValue
+                        ),
+                        type
+                    ), out replacement, UseKind.Value);
+                    break;
+                case ConversionKind.ExplicitNullable:
+                    statements = ExpandExpression(Cast(
+                        syntax,
+                        type,
+                        Value(syntax, operand, operandType.GetNullableUnderlyingType()),
+                        expression.conversion.underlyingConversions[0],
+                        operand.constantValue
+                    ), out replacement, UseKind.Value);
+                    break;
+                default:
+                    statements = ExpandExpression(operand, out replacement, UseKind.Value);
+                    break;
+            }
+
+            return StabilizeIfNecessary(syntax, useKind, statements, replacement, out replacement);
+        }
     }
 
     private protected override List<BoundStatement> ExpandIncrementOperator(
         BoundIncrementOperator expression,
-        out BoundExpression replacement) {
-        if (expression.operatorKind.Operator() is UnaryOperatorKind.PrefixDecrement
-                                               or UnaryOperatorKind.PrefixIncrement) {
-            return base.ExpandIncrementOperator(expression, out replacement);
+        out BoundExpression replacement,
+        UseKind useKind) {
+        /*
+
+        <op> <operand>
+
+        ----> <op> has a method attached
+
+        <method>(<op>)
+
+        ----> <op> is '++'
+
+        <operand> += 1
+
+        ----> <op> is '--'
+
+        <operand> -= 1
+
+        */
+        var syntax = expression.syntax;
+        var operand = expression.operand;
+
+        if (expression.method is not null) {
+            var statements = ExpandExpression(operand, out var newOperand);
+            replacement = Call(
+                syntax,
+                expression.method,
+                newOperand
+            );
+
+            return StabilizeIfNecessary(syntax, useKind, statements, replacement, out replacement);
         }
 
-        var syntax = expression.syntax;
+        var op = expression.operatorKind.Operator();
+        var isIsolated = syntax.parent.kind == SyntaxKind.ExpressionStatement;
 
-        var statements = ExpandExpression(expression.operand, out var newOperand);
-        var tempLocal = GenerateTempLocal(expression.type);
+        if (op == UnaryOperatorKind.PrefixIncrement || (op == UnaryOperatorKind.PostfixIncrement && isIsolated))
+            return ExpandCompoundAssignmentOperator(Increment(syntax, operand), out replacement, useKind);
 
-        statements.AddRange([
-            new BoundLocalDeclarationStatement(syntax, new BoundDataContainerDeclaration(syntax, tempLocal, newOperand)),
-            new BoundExpressionStatement(syntax, expression)
-        ]);
+        if (op == UnaryOperatorKind.PrefixDecrement || (op == UnaryOperatorKind.PostfixDecrement && isIsolated))
+            return ExpandCompoundAssignmentOperator(Decrement(syntax, operand), out replacement, useKind);
 
-        replacement = Local(syntax, tempLocal);
-        return statements;
+        if (op == UnaryOperatorKind.PostfixIncrement) {
+            var statements = ExpandExpression(operand, out var newOperand, UseKind.Writable);
+            var temp = GenerateTempLocal(newOperand.type);
+            statements.Add(LocalDeclaration(syntax, temp, newOperand));
+            statements.AddRange(ExpandCompoundAssignmentOperator(Increment(syntax, newOperand), out var expr, useKind));
+            statements.Add(new BoundExpressionStatement(syntax, expr));
+            replacement = Local(syntax, temp);
+            return statements;
+        } else if (op == UnaryOperatorKind.PostfixDecrement) {
+            var statements = ExpandExpression(operand, out var newOperand, UseKind.Writable);
+            var temp = GenerateTempLocal(newOperand.type);
+            statements.Add(LocalDeclaration(syntax, temp, newOperand));
+            statements.AddRange(ExpandCompoundAssignmentOperator(Decrement(syntax, newOperand), out var expr, useKind));
+            statements.Add(new BoundExpressionStatement(syntax, expr));
+            replacement = Local(syntax, temp);
+            return statements;
+        } else {
+            throw ExceptionUtilities.UnexpectedValue(op);
+        }
     }
 
     private protected override List<BoundStatement> ExpandConditionalOperator(
         BoundConditionalOperator expression,
-        out BoundExpression replacement) {
-        _operatorDepth++;
-        var syntax = expression.syntax;
+        out BoundExpression replacement,
+        UseKind useKind) {
+        var statements = base.ExpandConditionalOperator(expression, out replacement, UseKind.Value);
+        return StabilizeIfNecessary(expression.syntax, useKind, statements, replacement, out replacement);
+    }
 
-        if (_operatorDepth > 1) {
-            var statements = ExpandExpression(expression.condition, out var newCondition);
-            statements.AddRange(ExpandExpression(expression.trueExpression, out var newTrueExpression));
-            statements.AddRange(ExpandExpression(expression.falseExpression, out var newFalseExpression));
+    private protected override List<BoundStatement> ExpandInitializerList(
+        BoundInitializerList expression,
+        out BoundExpression replacement,
+        UseKind useKind) {
+        var statements = base.ExpandInitializerList(expression, out replacement, UseKind.Value);
+        return StabilizeIfNecessary(expression.syntax, useKind, statements, replacement, out replacement);
+    }
 
-            var tempLocal = GenerateTempLocal(expression.Type());
+    private protected override List<BoundStatement> ExpandAsOperator(
+        BoundAsOperator expression,
+        out BoundExpression replacement,
+        UseKind useKind) {
+        var statements = base.ExpandAsOperator(expression, out replacement, UseKind.Value);
+        return StabilizeIfNecessary(expression.syntax, useKind, statements, replacement, out replacement);
+    }
 
-            statements.Add(
-                new BoundLocalDeclarationStatement(syntax, new BoundDataContainerDeclaration(
-                    syntax,
-                    tempLocal,
-                    new BoundConditionalOperator(
-                        syntax,
-                        newCondition,
-                        expression.isRef,
-                        newTrueExpression,
-                        newFalseExpression,
-                        null,
-                        expression.Type()
-                    )
-                ))
-            );
+    private protected override List<BoundStatement> ExpandIsOperator(
+        BoundIsOperator expression,
+        out BoundExpression replacement,
+        UseKind useKind) {
+        var statements = base.ExpandIsOperator(expression, out replacement, UseKind.Value);
+        return StabilizeIfNecessary(expression.syntax, useKind, statements, replacement, out replacement);
+    }
 
-            replacement = Local(syntax, tempLocal);
-            _operatorDepth--;
-            return statements;
-        }
+    private protected override List<BoundStatement> ExpandNullAssertOperator(
+        BoundNullAssertOperator expression,
+        out BoundExpression replacement,
+        UseKind useKind) {
+        var statements = base.ExpandNullAssertOperator(expression, out replacement, UseKind.Value);
+        return StabilizeIfNecessary(expression.syntax, useKind, statements, replacement, out replacement);
+    }
 
-        var baseStatements = base.ExpandConditionalOperator(expression, out replacement);
-        _operatorDepth--;
-        return baseStatements;
+    private protected override List<BoundStatement> ExpandAddressOfOperator(
+        BoundAddressOfOperator expression,
+        out BoundExpression replacement,
+        UseKind useKind) {
+        var statements = base.ExpandAddressOfOperator(expression, out replacement, UseKind.Value);
+        return StabilizeIfNecessary(expression.syntax, useKind, statements, replacement, out replacement);
+    }
+
+    private protected override List<BoundStatement> ExpandPointerIndirectionOperator(
+        BoundPointerIndirectionOperator expression,
+        out BoundExpression replacement,
+        UseKind useKind) {
+        var statements = base.ExpandPointerIndirectionOperator(expression, out replacement, UseKind.Value);
+        return StabilizeIfNecessary(expression.syntax, useKind, statements, replacement, out replacement);
+    }
+
+    private protected override List<BoundStatement> ExpandArrayCreationExpression(
+        BoundArrayCreationExpression expression,
+        out BoundExpression replacement,
+        UseKind useKind) {
+        var statements = base.ExpandArrayCreationExpression(expression, out replacement, UseKind.Value);
+        return StabilizeIfNecessary(expression.syntax, useKind, statements, replacement, out replacement);
+    }
+
+    private protected override List<BoundStatement> ExpandFunctionPointerLoad(
+        BoundFunctionPointerLoad expression,
+        out BoundExpression replacement,
+        UseKind useKind) {
+        var statements = base.ExpandFunctionPointerLoad(expression, out replacement, UseKind.Value);
+        return StabilizeIfNecessary(expression.syntax, useKind, statements, replacement, out replacement);
+    }
+
+    private protected override List<BoundStatement> ExpandFunctionPointerCallExpression(
+        BoundFunctionPointerCallExpression expression,
+        out BoundExpression replacement,
+        UseKind useKind) {
+        var statements = base.ExpandFunctionPointerCallExpression(expression, out replacement, UseKind.Value);
+        return StabilizeIfNecessary(expression.syntax, useKind, statements, replacement, out replacement);
+    }
+
+    private protected override List<BoundStatement> ExpandStackAllocExpression(
+        BoundStackAllocExpression expression,
+        out BoundExpression replacement,
+        UseKind useKind) {
+        var statements = base.ExpandStackAllocExpression(expression, out replacement, UseKind.Value);
+        return StabilizeIfNecessary(expression.syntax, useKind, statements, replacement, out replacement);
+    }
+
+    private protected override List<BoundStatement> ExpandConvertedStackAllocExpression(
+        BoundConvertedStackAllocExpression expression,
+        out BoundExpression replacement,
+        UseKind useKind) {
+        var statements = base.ExpandConvertedStackAllocExpression(expression, out replacement, UseKind.Value);
+        return StabilizeIfNecessary(expression.syntax, useKind, statements, replacement, out replacement);
+    }
+
+    private protected override List<BoundStatement> ExpandAssignmentOperator(
+        BoundAssignmentOperator expression,
+        out BoundExpression replacement,
+        UseKind useKind) {
+        var statements = base.ExpandAssignmentOperator(expression, out replacement, useKind);
+        return StabilizeIfNecessary(expression.syntax, useKind, statements, replacement, out replacement);
     }
 
     private protected override List<BoundStatement> ExpandInitializerDictionary(
         BoundInitializerDictionary expression,
-        out BoundExpression replacement) {
-        // TODO Add a way where if _operatorDepth == 0 a temp local isn't made if this is a variable initializer
+        out BoundExpression replacement,
+        UseKind useKind) {
         var syntax = expression.syntax;
         var dictionaryType = (NamedTypeSymbol)expression.StrippedType();
         var tempLocal = GenerateTempLocal(expression.Type());
@@ -550,7 +1340,7 @@ internal sealed class Expander : BoundTreeExpander {
         var method = dictionaryType.GetMembers("Add").Single() as MethodSymbol;
 
         foreach (var pair in expression.items) {
-            statements.Add(new BoundExpressionStatement(syntax, new BoundCallExpression(
+            statements.AddRange(ExpandStatement(new BoundExpressionStatement(syntax, new BoundCallExpression(
                 syntax,
                 Local(syntax, tempLocal),
                 method,
@@ -559,7 +1349,7 @@ internal sealed class Expander : BoundTreeExpander {
                 default,
                 LookupResultKind.Viable,
                 method.returnType
-            )));
+            ))));
         }
 
         replacement = Local(syntax, tempLocal);
@@ -568,31 +1358,52 @@ internal sealed class Expander : BoundTreeExpander {
 
     private protected override List<BoundStatement> ExpandConditionalAccessExpression(
         BoundConditionalAccessExpression expression,
-        out BoundExpression replacement) {
+        out BoundExpression replacement,
+        UseKind useKind) {
+        /*
+
+        <receiver>?.<operand>
+
+        ----> <operand> is a field
+
+        <receiver> isnt null ? <receiver>.<field> : null
+
+        ----> <operand> is an index, UseKind.Value
+
+        <receiver> isnt null ? <receiver>[<index>] : null
+
+        ----> <operand> is an index, UseKind.StableValue
+
+        temp = <receiver> isnt null ? <receiver>[<index>] : null
+        temp
+
+        ----> <operand> is a method call, UseKind.Value
+
+        <receiver> isnt null ? <receiver>.<call> : null
+
+        ----> <operand> is a method call, UseKind.StableValue
+
+        temp = <receiver> isnt null ? <receiver>.<call> : null
+        temp
+
+        */
         var syntax = expression.syntax;
-        var receiver = expression.receiver;
         var access = expression.accessExpression;
-        var tempLocal = GenerateTempLocal(receiver.Type());
-        var statements = ExpandExpression(receiver, out var receiverReplacement);
 
-        statements.Add(new BoundLocalDeclarationStatement(syntax,
-            new BoundDataContainerDeclaration(syntax, tempLocal, receiverReplacement))
-        );
+        var statements = ExpandExpression(expression.receiver, out var newReceiver, UseKind.StableValue);
 
-        var receiverLocal = Local(syntax, tempLocal);
-
-        BoundExpression newAccess;
+        BoundExpression trueExpression;
 
         if (access is BoundFieldAccessExpression f) {
-            newAccess = new BoundFieldAccessExpression(syntax, receiverLocal, f.field, f.constantValue, f.Type());
+            trueExpression = new BoundFieldAccessExpression(syntax, newReceiver, f.field, f.constantValue, f.Type());
         } else if (access is BoundArrayAccessExpression a) {
             statements.AddRange(ExpandExpression(a.index, out var indexReplacement));
-            newAccess = new BoundArrayAccessExpression(syntax, receiverLocal, indexReplacement, null, a.Type());
+            trueExpression = new BoundArrayAccessExpression(syntax, newReceiver, indexReplacement, null, a.Type());
         } else if (access is BoundCallExpression c) {
             statements.AddRange(ExpandExpressionList(c.arguments, out var replacementArguments));
-            newAccess = new BoundCallExpression(
+            trueExpression = new BoundCallExpression(
                 syntax,
-                receiverLocal,
+                newReceiver,
                 c.method,
                 replacementArguments,
                 c.argumentRefKinds,
@@ -606,21 +1417,24 @@ internal sealed class Expander : BoundTreeExpander {
 
         replacement = new BoundConditionalOperator(
             syntax,
-            HasValue(syntax, receiverLocal),
+            HasValue(syntax, newReceiver),
             false,
-            newAccess,
-            new BoundLiteralExpression(syntax, ConstantValue.Null, access.Type()),
+            trueExpression,
+            Literal(syntax, null, access.Type()),
             null,
             access.Type()
         );
 
-        statements.AddRange(ExpandExpression(replacement, out replacement));
-        return statements;
+        if (access is BoundFieldAccessExpression)
+            return statements;
+        else
+            return StabilizeIfNecessary(syntax, useKind, statements, replacement, out replacement);
     }
 
     private protected override List<BoundStatement> ExpandInterpolatedStringExpression(
         BoundInterpolatedStringExpression expression,
-        out BoundExpression replacement) {
+        out BoundExpression replacement,
+        UseKind useKind) {
         var syntax = expression.syntax;
         var stringType = CorLibrary.GetSpecialType(SpecialType.String);
         var nullableStringType = CorLibrary.GetNullableType(SpecialType.String);
@@ -640,7 +1454,7 @@ internal sealed class Expander : BoundTreeExpander {
             if (content.constantValue?.specialType == SpecialType.String) {
                 right = Literal(syntax, content.constantValue.value, stringType);
             } else {
-                statements.AddRange(ExpandExpression(content, out var replacementContent));
+                statements.AddRange(ExpandExpression(content, out var replacementContent, UseKind.StableValue));
 
                 if (replacementContent.IsLiteralNull())
                     continue;
@@ -679,7 +1493,12 @@ internal sealed class Expander : BoundTreeExpander {
                             Literal(syntax, string.Empty, stringType),
                             Cast(syntax,
                                 stringType,
-                                Lowerer.CreateNullableGetValueCall(syntax, replacementContent, replacementContent.StrippedType()),
+                                new BoundNullAssertOperator(syntax,
+                                    replacementContent,
+                                    false,
+                                    null,
+                                    replacementContent.StrippedType()
+                                ),
                                 conversion,
                                 null
                             ),
@@ -723,13 +1542,13 @@ internal sealed class Expander : BoundTreeExpander {
             }
 
             if (right.Type().IsNullableType()) {
-                right = new BoundNullCoalescingOperator(syntax,
+                statements.AddRange(ExpandExpression(new BoundNullCoalescingOperator(syntax,
                     right,
                     Literal(syntax, string.Empty, stringType),
                     false,
                     null,
                     stringType
-                );
+                ), out right, UseKind.Value));
             }
 
             statements.Add(new BoundExpressionStatement(syntax, Assignment(syntax,

--- a/src/Buckle/Compiler/CodeAnalysis/Lowering/Expander.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Lowering/Expander.cs
@@ -79,7 +79,6 @@ internal sealed class Expander : BoundTreeExpander {
 
                     break;
                 case BoundKind.CallExpression: {
-                        // TODO Conditional cascade
                         var call = (BoundCallExpression)cascade;
                         var replacementReceiver = Local(syntax, tempLocal);
                         statements.AddRange(ExpandExpressionList(call.arguments, out var arguments));

--- a/src/Buckle/Compiler/CodeAnalysis/Lowering/FlowLowerer/FlowLowerer.PatternLocalRewriter.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Lowering/FlowLowerer/FlowLowerer.PatternLocalRewriter.cs
@@ -46,7 +46,13 @@ internal sealed partial class FlowLowerer {
                             if (conversion.kind == ConversionKind.ExplicitNullable &&
                                 inputType.GetNullableUnderlyingType().Equals(output.type, TypeCompareKind.AllIgnoreOptions) &&
                                 Lowerer.ShouldBeTreatedAsNullable(inputType)) {
-                                evaluated = Lowerer.CreateNullableGetValueCall(_node, input, inputType.GetNullableUnderlyingType());
+                                evaluated = new BoundNullAssertOperator(
+                                    _node,
+                                    input,
+                                    false,
+                                    null,
+                                    inputType.GetNullableUnderlyingType()
+                                );
                             } else {
                                 evaluated = Cast(_node, type, input, conversion, null);
                             }

--- a/src/Buckle/Compiler/CodeAnalysis/Lowering/FlowLowerer/FlowLowerer.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Lowering/FlowLowerer/FlowLowerer.cs
@@ -8,6 +8,10 @@ using static Buckle.CodeAnalysis.Binding.BoundFactory;
 
 namespace Buckle.CodeAnalysis.Lowering;
 
+/// <summary>
+/// For lowering control flow structures.
+/// Runs before general lowering to simplify the number of nodes they have to cover.
+/// </summary>
 internal sealed partial class FlowLowerer : BoundTreeRewriter {
     private readonly List<string> _localNames = [];
     private int _tempCount = 0;

--- a/src/Buckle/Compiler/CodeAnalysis/Lowering/Lowerer.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Lowering/Lowerer.cs
@@ -15,6 +15,9 @@ namespace Buckle.CodeAnalysis.Lowering;
 
 /// <summary>
 /// Lowers statements to be simpler and use less language features.
+/// This lowerer directly can only lower simple expressions that do not reference a child more than one.
+/// In a case where a child must be used more than once, the Expander should handle that node instead to create a temp.
+/// Nodes may be visited multiple times.
 /// </summary>
 internal sealed class Lowerer : BoundTreeRewriter {
     private readonly Expander _expander;
@@ -405,233 +408,6 @@ internal sealed class Lowerer : BoundTreeRewriter {
         );
     }
 
-    internal override BoundNode VisitBinaryOperator(BoundBinaryOperator expression) {
-        /*
-
-        <left> <op> <right>
-
-        ----> <op> has a method attached
-
-        <method>(<left>, <right>)
-
-        ----> <op> is && or ||
-
-        ((<left> ?? false) <op> (<right> ?? false))
-
-        ----> <left> is nullable and <right> is nullable
-
-        ((HasValue(<left>) && HasValue(<right>)) ? new Nullable( Value(<left>) <op> Value(<right>) ) : null)
-
-        ----> <left> is nullable
-
-        (HasValue(<left>) ? new Nullable( Value(<left>) <op> <right> ) : null)
-
-        ----> <right> is nullable
-
-        (<right> isnt null ? new Nullable( <left> <op> Value(<right>) ) : null)
-
-        */
-        var syntax = expression.syntax;
-        var op = expression.operatorKind;
-        var type = expression.Type();
-
-        if (op.Operator() == BinaryOperatorKind.Power) {
-            return Visit(
-                Call(
-                    syntax,
-                    StandardLibrary.GetPowerMethod(op.IsLifted(), op.OperandTypes() == BinaryOperatorKind.Int),
-                    expression.left,
-                    expression.right
-                )
-            );
-        }
-
-        if (expression.method is not null)
-            return Visit(Call(syntax, expression.method, expression.left, expression.right));
-
-        if (op.IsLifted() || op.IsConditional()) {
-            var left = expression.left;
-            var right = expression.right;
-
-            if (left is BoundCastExpression lCast &&
-                lCast.conversion.kind == ConversionKind.ImplicitNullable &&
-                lCast.conversion.underlyingConversions[0].kind == ConversionKind.Identity) {
-                left = lCast.operand;
-            }
-
-            if (right is BoundCastExpression rCast &&
-                rCast.conversion.kind == ConversionKind.ImplicitNullable &&
-                rCast.conversion.underlyingConversions[0].kind == ConversionKind.Identity) {
-                right = rCast.operand;
-            }
-
-            var leftIsNullable = left.Type().IsNullableType();
-            var rightIsNullable = right.Type().IsNullableType();
-
-            if (op.IsConditional() && (leftIsNullable || rightIsNullable)) {
-                var coalescedLeft = leftIsNullable
-                    ? new BoundNullCoalescingOperator(syntax, left, Literal(syntax, false, type), false, null, type)
-                    : left;
-
-                var coalescedRight = rightIsNullable
-                    ? new BoundNullCoalescingOperator(syntax, right, Literal(syntax, false, type), false, null, type)
-                    : right;
-
-                return VisitBinaryOperator(Binary(syntax, coalescedLeft, op, coalescedRight, type));
-            }
-
-            if (leftIsNullable &&
-                rightIsNullable &&
-                left.constantValue is null &&
-                right.constantValue is null) {
-                return VisitConditionalOperator(
-                    Conditional(syntax,
-                        @if: And(syntax,
-                            HasValue(syntax, left),
-                            HasValue(syntax, right)
-                        ),
-                        @then: CreateNullable(syntax,
-                            Binary(syntax,
-                                Value(syntax, left, left.Type().GetNullableUnderlyingType()),
-                                op,
-                                Value(syntax, right, right.Type().GetNullableUnderlyingType()),
-                                type.StrippedType()
-                                ),
-                            type
-                        ),
-                        @else: Literal(syntax, null, type),
-                        type
-                    )
-                );
-            }
-
-            if (leftIsNullable && left.constantValue is null) {
-                return VisitConditionalOperator(
-                    Conditional(syntax,
-                        @if: HasValue(syntax, left),
-                        @then: CreateNullable(syntax,
-                            Binary(syntax,
-                                Value(syntax, left, left.Type().GetNullableUnderlyingType()),
-                                op,
-                                DeNull(right),
-                                type.StrippedType()
-                            ),
-                            type
-                        ),
-                        @else: Literal(syntax, null, type),
-                        type
-                    )
-                );
-            }
-
-            if (rightIsNullable && right.constantValue is null) {
-                return VisitConditionalOperator(
-                    Conditional(syntax,
-                        @if: HasValue(syntax, right),
-                        @then: CreateNullable(syntax,
-                            Binary(syntax,
-                                DeNull(left),
-                                op,
-                                Value(syntax, right, right.Type().GetNullableUnderlyingType()),
-                                type.StrippedType()
-                            ),
-                            type
-                        ),
-                        @else: Literal(syntax, null, type),
-                        type
-                    )
-                );
-            }
-        }
-
-        return base.VisitBinaryOperator(expression);
-    }
-
-    internal override BoundNode VisitNullCoalescingOperator(BoundNullCoalescingOperator expression) {
-        /*
-
-        <left> ?? <right>
-
-        ---->
-
-        (HasValue(<left>) ? Value(<left>) : <right>)
-
-        ----> isPropagation
-
-        (HasValue(<left>) ? <right> : <left>)
-
-        */
-        var syntax = expression.syntax;
-
-        if (expression.isPropagation) {
-            return VisitConditionalOperator(
-                Conditional(syntax,
-                    @if: HasValue(syntax, expression.left),
-                    @then: expression.right,
-                    @else: expression.left,
-                    expression.Type()
-                )
-            );
-        } else {
-            return VisitConditionalOperator(
-                Conditional(syntax,
-                    @if: HasValue(syntax, expression.left),
-                    @then: Value(syntax, expression.left, expression.left.StrippedType()),
-                    @else: expression.right,
-                    expression.Type()
-                )
-            );
-        }
-    }
-
-    internal override BoundNode VisitUnaryOperator(BoundUnaryOperator expression) {
-        /*
-
-        <op> <operand>
-
-        ----> <op> has a method attached
-
-        <method>(<op>)
-
-        ----> <op> is +
-
-        <operand>
-
-        ----> <operand> is nullable
-
-        (HasValue(<operand>) ? new Nullable( <op> Value(<operand>) ) : null)
-
-        */
-        var syntax = expression.syntax;
-        var op = expression.operatorKind;
-
-        if (expression.method is not null)
-            return Visit(Call(syntax, expression.method, expression.operand));
-
-        if (op == UnaryOperatorKind.UnaryPlus)
-            return Visit(expression.operand);
-
-        if (op.IsLifted() && expression.operand.Type().IsNullableType()) {
-            return VisitConditionalOperator(
-                Conditional(syntax,
-                    @if: HasValue(syntax, expression.operand),
-                    @then: CreateNullable(syntax,
-                        Unary(syntax,
-                            op,
-                            Value(syntax, expression.operand, expression.operand.Type().GetNullableUnderlyingType()),
-                            expression.StrippedType()
-                        ),
-                        expression.type
-                    ),
-                    @else: Literal(syntax, null, expression.Type()),
-                    expression.Type()
-                )
-            );
-        }
-
-        return base.VisitUnaryOperator(expression);
-    }
-
     internal override BoundNode VisitArrayAccessExpression(BoundArrayAccessExpression expression) {
         var syntax = expression.syntax;
 
@@ -719,55 +495,7 @@ internal sealed class Lowerer : BoundTreeRewriter {
         return expression.Update(sizes, initializer, type);
     }
 
-    internal override BoundNode VisitIncrementOperator(BoundIncrementOperator expression) {
-        /*
-
-        <op> <operand>
-
-        ----> <op> has a method attached
-
-        <method>(<op>)
-
-        ----> <op> is '++'
-
-        <operand> += 1
-
-        ----> <op> is '--'
-
-        <operand> -= 1
-
-        */
-        var syntax = expression.syntax;
-        var op = expression.operatorKind.Operator();
-
-        if (expression.method is not null)
-            return Visit(Call(syntax, expression.method, expression.operand));
-
-        if (op is UnaryOperatorKind.PrefixIncrement or UnaryOperatorKind.PostfixIncrement)
-            return Visit(Increment(syntax, expression.operand));
-        else
-            return Visit(Decrement(syntax, expression.operand));
-    }
-
     internal override BoundNode VisitIsOperator(BoundIsOperator expression) {
-        // TODO Flatten null checks:
-        /*
-
-        Current:
-
-        a + b + c
-
-        -->
-
-        temp0 = (a isnt null && b isnt null ? a! + b! : null)
-        temp1 = (temp0 isnt null && c isnt null ? temp0! + c! : null)
-
-        TODO Lower to:
-
-        temp0 = (a isnt null && b isnt null && c isnt null ? a! + b! + c! : null)
-
-        */
-
         /*
 
         <left> is <right>
@@ -824,27 +552,6 @@ internal sealed class Lowerer : BoundTreeRewriter {
         return base.VisitNullAssertOperator(expression);
     }
 
-    internal override BoundNode VisitNullErasureOperator(BoundNullErasureOperator expression) {
-        /*
-
-        <operand>?
-
-        ---->
-
-        <operand> ?? <default value>
-
-        */
-        var syntax = expression.syntax;
-
-        return Visit(new BoundNullCoalescingOperator(syntax,
-            expression.operand,
-            Literal(syntax, expression.defaultValue.value, expression.type),
-            false,
-            expression.constantValue,
-            expression.type
-        ));
-    }
-
     internal static BoundExpression CreateNullableGetValueCall(
         SyntaxNode syntax,
         BoundExpression operand,
@@ -881,100 +588,6 @@ internal sealed class Lowerer : BoundTreeRewriter {
         return (MethodSymbol)method.SymbolAsMember(
             CorLibrary.GetSpecialType(SpecialType.Nullable).Construct([new TypeOrConstant(genericType)])
         );
-    }
-
-    internal override BoundNode VisitCastExpression(BoundCastExpression expression) {
-        /*
-
-        (<type>)<operand>
-
-        ----> <op> has a method attached
-
-        <method>(<operand>)
-
-        ----> <operand> is nullable and <type> is nullable
-
-        (HasValue(<operand>) ? new Nullable( (<type!>)Value(<operand>) ) : null)
-
-        ----> <operand> is nullable and <type> is not nullable
-
-        (<type>)Value(<operand>)
-
-        ----> <operand> is not nullable and <type> is nullable
-
-        new Nullable( (<type!>)<operand> )
-
-        ----> <operand>.type == <type>
-
-        <operand>
-
-        */
-        var syntax = expression.syntax;
-
-        if (expression.conversion.method is not null)
-            return Visit(Call(syntax, expression.conversion.method, expression.operand));
-
-        var operand = expression.operand;
-        var type = expression.Type();
-        var operandType = operand.Type();
-
-        if (operandType?.Equals(type, TypeCompareKind.ConsiderEverything) ?? false)
-            return Visit(operand);
-
-        if (expression.conversion.underlyingConversions == default) {
-            if (expression.conversion.kind is ConversionKind.ImplicitNullToPointer)
-                return expression;
-
-            return base.VisitCastExpression(expression);
-        }
-
-        if (operandType.IsNullableType() && type.IsNullableType()) {
-            return VisitConditionalOperator(
-                Conditional(syntax,
-                    @if: HasValue(syntax, operand),
-                    @then: CreateNullable(syntax,
-                        Cast(syntax,
-                            type.GetNullableUnderlyingType(),
-                            Value(syntax, operand, operandType.GetNullableUnderlyingType()),
-                            expression.conversion.underlyingConversions[0],
-                            operand.constantValue
-                        ),
-                        type
-                    ),
-                    @else: Literal(syntax, null, type),
-                    type
-                )
-            );
-        }
-
-        switch (expression.conversion.kind) {
-            case ConversionKind.ImplicitNullable:
-                return Visit(
-                    CreateNullable(
-                        syntax,
-                        Cast(
-                            syntax,
-                            type.GetNullableUnderlyingType(),
-                            operand,
-                            expression.conversion.underlyingConversions[0],
-                            operand.constantValue
-                        ),
-                        type
-                    )
-                );
-            case ConversionKind.ExplicitNullable:
-                return Visit(
-                    Cast(
-                        syntax,
-                        type,
-                        Value(syntax, operand, operandType.GetNullableUnderlyingType()),
-                        expression.conversion.underlyingConversions[0],
-                        operand.constantValue
-                    )
-                );
-        }
-
-        return base.VisitCastExpression(expression);
     }
 
     internal override BoundNode VisitCallExpression(BoundCallExpression expression) {
@@ -1045,72 +658,6 @@ internal sealed class Lowerer : BoundTreeRewriter {
         );
     }
 
-    internal override BoundNode VisitCompoundAssignmentOperator(BoundCompoundAssignmentOperator expression) {
-        /*
-
-        <left> <op>= <right>
-
-        ---->
-
-        <left> = <left> <op> <right>
-
-        */
-        var syntax = expression.syntax;
-
-        return VisitAssignmentOperator(
-            Assignment(syntax,
-                expression.left,
-                new BoundBinaryOperator(
-                    syntax,
-                    expression.left,
-                    expression.right,
-                    expression.op.kind,
-                    expression.op.method,
-                    ConstantFolding.FoldBinary(
-                        expression.left,
-                        expression.right,
-                        expression.op.kind,
-                        expression.Type(),
-                        syntax.location,
-                        BelteDiagnosticQueue.Discarded
-                    ),
-                    expression.Type()
-                ),
-                false,
-                expression.Type()
-            )
-        );
-    }
-
-    internal override BoundNode VisitNullCoalescingAssignmentOperator(BoundNullCoalescingAssignmentOperator expression) {
-        /*
-
-        <left> ??= <right>
-
-        ---->
-
-        <left> = <left> ?? <right>
-
-        */
-        var syntax = expression.syntax;
-
-        return VisitAssignmentOperator(
-            Assignment(syntax,
-                expression.left,
-                new BoundNullCoalescingOperator(
-                    syntax,
-                    expression.left,
-                    expression.right,
-                    expression.isPropagation,
-                    null,
-                    expression.Type()
-                ),
-                false,
-                expression.Type()
-            )
-        );
-    }
-
     internal static BoundBlockStatement Flatten(MethodSymbol method, BoundBlockStatement statement) {
         return FlattenBlock(method, statement, true);
     }
@@ -1160,7 +707,7 @@ internal sealed class Lowerer : BoundTreeRewriter {
         );
     }
 
-    private static bool CanFallThrough(BoundStatement boundStatement) {
+    internal static bool CanFallThrough(BoundStatement boundStatement) {
         return boundStatement.kind != BoundKind.ReturnStatement &&
             boundStatement.kind != BoundKind.GotoStatement;
     }
@@ -1169,7 +716,7 @@ internal sealed class Lowerer : BoundTreeRewriter {
         return type.IsNullableType() && CodeGenerator.IsValueType(type.GetNullableUnderlyingType());
     }
 
-    private BoundExpression CreateNullable(
+    internal static BoundExpression CreateNullable(
         SyntaxNode syntax,
         BoundExpression expression,
         TypeSymbol nullableType) {
@@ -1207,7 +754,7 @@ internal sealed class Lowerer : BoundTreeRewriter {
         );
     }
 
-    private static BoundExpression RewriteNull(SyntaxNode syntax, BoundExpression expression) {
+    internal static BoundExpression RewriteNull(SyntaxNode syntax, BoundExpression expression) {
         if (ConstantValue.IsNull(expression.constantValue)) {
             return Call(
                 syntax,
@@ -1237,7 +784,7 @@ internal sealed class Lowerer : BoundTreeRewriter {
         return expression;
     }
 
-    private BoundExpression DeNull(BoundExpression expression) {
+    internal static BoundExpression DeNull(BoundExpression expression) {
         if (expression.constantValue is null)
             return expression;
 

--- a/src/Buckle/Compiler/CodeAnalysis/Lowering/Lowerer.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Lowering/Lowerer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using Buckle.CodeAnalysis.Binding;
 using Buckle.CodeAnalysis.CodeGeneration;
 using Buckle.CodeAnalysis.Symbols;
@@ -590,6 +591,13 @@ internal sealed class Lowerer : BoundTreeRewriter {
         );
     }
 
+    internal override BoundNode VisitCastExpression(BoundCastExpression node) {
+        if (node.conversion.kind == ConversionKind.ImplicitNullToPointer)
+            return node;
+
+        return base.VisitCastExpression(node);
+    }
+
     internal override BoundNode VisitCallExpression(BoundCallExpression expression) {
         /*
 
@@ -740,7 +748,7 @@ internal sealed class Lowerer : BoundTreeRewriter {
         );
     }
 
-    internal static BoundNode VisitConstant(BoundExpression expression) {
+    internal static BoundExpression VisitConstant(BoundExpression expression) {
         var syntax = expression.syntax;
         var type = expression.Type();
 

--- a/src/Buckle/Compiler/CodeAnalysis/Lowering/Optimizer.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Lowering/Optimizer.cs
@@ -9,7 +9,7 @@ using static Buckle.CodeAnalysis.Binding.BoundFactory;
 namespace Buckle.CodeAnalysis.Lowering;
 
 /// <summary>
-/// Optimizes BoundExpressions and BoundStatements.
+/// Optimizes BoundExpressions and BoundStatements. Can be run multiple times.
 /// </summary>
 internal sealed class Optimizer : BoundTreeRewriter {
     private Optimizer() { }


### PR DESCRIPTION
# Description

There was an entire class of bugs around the expander being "dumb" and inserting an expression prelude too early in the block causing errors. One example was `int! b = a?.Length()?;` where the method access would be apart of a prelude for `x?`, but it would crash incorrectly when `a` was null. The conditional access should have preventing the prelude of `x?` from running.

The fix was to completely rewrite the Expander to track how child expressions are being used to know when hoisting is needed, and also by redoing conditional expression logic by moving it all from the Lowerer into the Expander to rewrite into conditional gotos instead of relying on conditional operators everywhere.

The result is a bug free (from my testing) Expander that also is more efficient because chains of "simple" expressions no longer hoist anything. For example, `int! a = 1; int! b = 2; int! c = 3; int! d = a + b + c;` used to hoist `a + b` into a temporary local. This no longer happens because the binary can see that the children have no potential for hoisting. The result is a much better temp allocating policy.

In terms of optimization there are still some that could be done. Namely "easy-outing" expressions that normally turn into gotos into conditional operators if the children are "simple". (For example && and || operators.) But this PR was focused on pure semantic correctness. The resulting efficiency improvements were happenstance.

Beyond bug fixing, implemented conditional cascades (?..) and chained conditional accesses into an assignment (`a?.b?.c = x`).
