### PR TITLE
Rw/newnull

### DIFF
--- a/docs/Current/ClassesAndObjects.md
+++ b/docs/Current/ClassesAndObjects.md
@@ -447,8 +447,8 @@ A `T extends Y` constraint ensures template parameter `T` is or derives from `Y`
 A `T is primitive` constraint ensure template parameter `T` is a primitive type.
 
 A `T is notnull` constraint constrains the template parameter `T` to being a non-nullable type. Non-nullable annotations
-are disallowed in type template arguments, so this constraint is required to instantiate a template to a non-nullable
-type.
+are disallowed on type template parameters, so this constraint is required for the template class to know the template
+parameter is a non-nullable type.
 
 ## 4.6 Enums
 

--- a/docs/Current/ControlFlow.md
+++ b/docs/Current/ControlFlow.md
@@ -247,7 +247,7 @@ To avoid this exception while still allowing nullable types in the condition exp
 For example:
 
 ```belte
-int a = null;
+int? a = null;
 
 if ((a > 4)?) {
   ...
@@ -266,7 +266,7 @@ A null-binding contract can be used to declare a temporary local within an `if` 
 local is not null.
 
 ```belte
-int a = 3;
+int? a = 3;
 
 if (a -> x!) {
   int! b = x;
@@ -278,12 +278,12 @@ If the source expression is null, the block does not run. Otherwise, a non-nulla
 Similar to an ordinary if statement, an else block can be defined that runs only if the source expression is null.
 
 ```belte
-int a = 3;
+int? a = 3;
 
 if (a -> x!) {
   int! b = x;
 } else {
-  int b = a;
+  int? b = a;
 }
 ```
 

--- a/docs/Current/Data.md
+++ b/docs/Current/Data.md
@@ -4,6 +4,7 @@
   - [3.1.1](#311-casts) Casts
   - [3.1.2](#312-string-interpolation) String Interpolation
   - [3.1.3](#313-function-type) Function Type
+  - [3.1.4](#314-default-literal) Default Literal
 - [3.2](#32-operators) Operators
   - [3.2.1](#321-operator-precedence) Operator Precedence
   - [3.2.2](#322-uncommon-operators) Uncommon Operators
@@ -37,9 +38,9 @@ Apart from classes, there are many primitive types. The most common ones include
 | Any | `any` | Any integer, decimal, boolean, or string value |
 | Type | `type` | Represents a type |
 
-Each of these can be set to `null` to represent they do not have a known value if they are nullable. Most types are
-nullable by default unless suffixed with `!`. Sized numerics, pointers, function pointers, structs, and type template
-arguments are always non-nullable.
+Each of these can be set to `null` to represent they do not have a known value if they are nullable. Reference types
+(classes) are nullable by default unless suffixed with `!`. Value types (primitives, pointers, structs) are non-nullable
+by default unless suffixed with `?`. Pointers and function pointers are always non-nullable.
 
 Apart from these, many types exist for specific contexts:
 
@@ -112,6 +113,19 @@ int Add(int a, int b) {
 
 Function types cannot include pointer types in the return value or parameter list. For cases where you need this
 functionality, use function pointers instead.
+
+### 3.1.4 Default Literal
+
+The `default` literal can be used to indicate `null` for nullable types or the default value for primitives.
+
+For example:
+
+```belte
+int a = default; // a = 0
+int? a = default; // a = null
+```
+
+Types with no default value (non-nullable class types) cannot use the `default` literal.
 
 ## 3.2 Operators
 
@@ -226,7 +240,8 @@ variable with no value, making it `null` until later defined. The latter gives t
 
 ### 3.3.1 Implicit Typing
 
-Instead of using type-names to declare, implicit keywords `var` and `const` can be used if the initializer is distinct.
+Instead of using type-names to declare, implicit keywords `var`, `const`, and `constexpr` can be used if the initializer
+is distinct.
 
 Examples:
 
@@ -237,10 +252,23 @@ const b = 3; // Same as 'const int b = 3;'
 
 ## 3.4 Attributes and Modifiers
 
-All data is nullable by default. To disable this, an exclamation mark can be used:
+Reference-type data is nullable by default. To disable this, an exclamation mark can be used:
+
+```belte
+MyType! a = new MyType();
+```
+
+Value-type data is non-nullable by default. To enable nullability, a question mark can be used:
+
+```belte
+int? a = null;
+```
+
+Both of these annotations are allowed in situations where they are redundant for clarity purposes:
 
 ```belte
 int! a = 3;
+MyType? b = new MyType();
 ```
 
 ## 3.5 References

--- a/docs/Current/GraphicsLibrary/Graphics.md
+++ b/docs/Current/GraphicsLibrary/Graphics.md
@@ -15,15 +15,15 @@ The Belte public interface for the Graphics class can be found
 | `void LockFramerate(int!)` | Locks `Update` framerate to an fps. |
 | `Texture LoadTexture(string!)` | Loads a texture from an image path. |
 | `Texture LoadTexture(string!, int!, int!, int!)` | Loads a texture from an image path with an RGB mask. |
-| `Sprite LoadSprite(string!, Vec2, Vec2, int)` | Loads a sprite from an image path with a screen position, scale, and rotation. |
-| `int Draw(Texture, Rect, Rect, int, bool, decimal)` | Draws a texture to the screen with a given src rect, dst rect, rotation, whether or not to flip, and alpha. |
-| `int DrawSprite(Sprite)` | Draws a sprite to the screen. |
-| `int DrawSprite(Sprite, Vec2)` | Draws a sprite to the screen with an offset from its position. |
-| `Text LoadText(string, string!, Vec2, decimal!, decimal, int, int, int)` | Loads a text object with a text string, font path, screen position, font size, angle, and RGB color. |
-| `int DrawText(Text)` | Draws a text object to the screen. |
-| `int DrawRect(Rect, int, int, int)` | Draws a rectangle with an RGB color to the screen. |
-| `int DrawRect(Rect, int, int, int, int)` | Draws a rectangle with an RGBA color to the screen. |
-| `void StopDraw(int)` | Stops drawing a specific object using the ID returned from the draw call to stop (REPL only). |
+| `Sprite LoadSprite(string!, Vec2, Vec2, int?)` | Loads a sprite from an image path with a screen position, scale, and rotation. |
+| `int? Draw(Texture, Rect, Rect, int?, bool?, decimal?)` | Draws a texture to the screen with a given src rect, dst rect, rotation, whether or not to flip, and alpha. |
+| `int? DrawSprite(Sprite)` | Draws a sprite to the screen. |
+| `int? DrawSprite(Sprite, Vec2)` | Draws a sprite to the screen with an offset from its position. |
+| `Text LoadText(string, string!, Vec2, decimal!, decimal?, int?, int?, int?)` | Loads a text object with a text string, font path, screen position, font size, angle, and RGB color. |
+| `int? DrawText(Text)` | Draws a text object to the screen. |
+| `int? DrawRect(Rect, int?, int?, int?)` | Draws a rectangle with an RGB color to the screen. |
+| `int? DrawRect(Rect, int?, int?, int?, int?)` | Draws a rectangle with an RGBA color to the screen. |
+| `void StopDraw(int?)` | Stops drawing a specific object using the ID returned from the draw call to stop (REPL only). |
 | `bool! GetKey(string!)` | Checks if a given key is being pressed. |
 | `void Fill(int!, int!, int!)` | Fills the screen with an RGB color. |
 | `bool! GetMouseButton(string!)` | Checks if a mouse button is being pressed. |

--- a/docs/Current/LowLevelFeatures.md
+++ b/docs/Current/LowLevelFeatures.md
@@ -109,10 +109,9 @@ int[] v = { 1, 2, 3 };
 
 To allow for better interop, several numeric types can be used to specify
 specific sizes. These being `int8`, `uint8`, `int16`, `uint16`, `int32`,
-`uint32`, `int64`, `uint64`, `float32`, `float64`. These types are always
-non-nullable.
+`uint32`, `int64`, `uint64`, `float32`, `float64`.
 
-All arithmetic upcasts to `int` and `decimal`, so casting is required in cases
+Most arithmetic upcasts to `int` and `decimal`, so casting is required in cases
 such as:
 
 ```belte
@@ -120,6 +119,9 @@ int32 myInt1 = 5;
 int32 myInt2 = 27;
 int32 myInt3 = (int32)(myInt1 | myInt2);
 ```
+
+The only case where arithmetic does not cast to `int` or `decimal` is in the
+case of `uint64` which cannot fit inside `int`.
 
 Unless knowing the specific size of the integer is required, use the normal
 `int` and `decimal` types, which (eventually) will support specifying ranges.
@@ -444,7 +446,7 @@ il {
 ```belte
 il {
   ldstr "Hello, world!";
-  call Console.PrintLine : (string);
+  call Console.PrintLine : (string?);
 }
 ```
 

--- a/docs/Current/Overview.md
+++ b/docs/Current/Overview.md
@@ -11,6 +11,13 @@ Currently, the Belte compiler, Buckle, supports interpretation and building to a
 - [1.2](#12-keywords) Keywords
   - [1.2.1](#121-non-contextual-keywords) Non-Contextual Keywords
   - [1.2.2](#122-contextual-keywords) Contextual Keywords
+- [1.3](#13-nullability-and-types) Nullability and Types
+  - [1.3.1](#131-normal-types) Normal Types
+  - [1.3.2](#132-pointers-and-function-pointers) Pointers and Function Pointers
+  - [1.3.3](#133-initializers) Initializers
+  - [1.3.4](#134-fields) Fields
+  - [1.3.5](#135-implicit-typing) Implicit Typing
+  - [1.3.6](#136-null-flow-analysis) Null-Flow Analysis
 
 ## 1.1 Endpoint Specific Features
 
@@ -55,7 +62,8 @@ These keywords are reserved names and cannot be used as identifiers.
 - [const](ClassesAndObjects.md#434-const) (methods)
 - [constructor](ClassesAndObjects.md#44-constructors)
 - [continue](ControlFlow.md#246-continue)
-- [default](ControlFlow.md#25-switch)
+- [default](Data.md#314-default-literal) (literal)
+- [default](ControlFlow.md#25-switch) (switch label)
 - [define](Preprocessor.md#71-defineundef)
 - [do](ControlFlow.md#242-do-while-loops)
 - [elif](Preprocessor.md#72-control)
@@ -128,3 +136,260 @@ These keywords only act as keywords inside specific contexts. As such they can b
 - [notnull](ClassesAndObjects.md#4512-special-constraints)
 - [noverify](LowLevelFeatures.md#6111-verification)
 - [primitive](ClassesAndObjects.md#4512-special-constraints)
+
+## 1.3 Nullability and Types
+
+Nullability is treated in a non-standard way in Belte. As such, a close read of the following section is recommended,
+which is a consolidation of important nullability semantics found in the rest of the documentation.
+
+To summarize:
+
+- Reference types (classes) are nullable by default
+- Value types (primitives, pointers, structs) are non-nullable by default
+- `!` removes nullability
+- `?` adds nullability
+- Pointer types are never nullable
+
+A type is "nullable" when it permits `null`.
+
+### 1.3.1 Normal Types
+
+Classes are reference types meaning they are heap allocated, garbage collected, and not copied when passed.
+
+For example:
+
+```belte
+var a = new MyClass();
+var b = a;
+b.i = 5;
+
+class MyClass {
+  public int i = 0;
+}
+```
+
+In this example, `a.i` is `5` because both `a` and `b` refer to the same object in memory.
+
+Reference types are nullable by default. To make it non-nullable, a `!` annotation can be used:
+
+```belte
+var a = new MyClass();
+a = null; // OK
+
+var! a = new MyClass();
+a = null; // Invalid
+```
+
+Notice how nullable annotations apply normally even when implicitly typing. The following are identical:
+
+```belte
+MyClass! a = new MyClass();
+var! a = new MyClass();
+```
+
+All non-reference types are non-nullable by default (this includes primitives, structs, and pointers). The only
+exception is the primitive `any` type which is nullable by default.
+
+To make a non-reference type nullable, a `?` annotation can be used:
+
+```belte
+int a = 3;
+a = null; // Invalid
+
+int? a = 3;
+a = null; // OK
+```
+
+Most value-types (non-reference-types) are able to made nullable. Pointers and function pointers are not.
+
+In much of the documentation and standard library, redundant annotations are used for clarity. Note that the following
+are identical because `int` defaults to being non-nullable:
+
+```belte
+int a = 3;
+int! a = 3;
+```
+
+Likewise, the following are identical because class types default to being nullable:
+
+```belte
+MyClass a = new MyClass();
+MyClass? a = new MyClass();
+```
+
+Redundant annotations are encouraged in source docs for clarity.
+
+### 1.3.2 Pointers and Function Pointers
+
+Nullability in pointers is not covered with the type system, but rather with the `nullptr` keyword. A `nullptr` under
+the hood is just a 0-valued pointer. The following are equivalent:
+
+```belte
+int* ptr = nullptr;
+int* ptr = (int*)0;
+int* ptr;
+```
+
+Even though pointers and function pointers themselves do not use the nullable type system, their elements can:
+
+```belte
+int?* ptr; // OK
+int?*? ptr; // Invalid
+
+void(int?)* ptr; // OK
+void(int?)*? ptr; // Invalid
+```
+
+### 1.3.3 Initializers
+
+Local initializers are required for non-nullable types. For nullable types, initializers are optional and a local
+without one will be set to null. The following are identical:
+
+```belte
+int? a = null;
+int? a;
+```
+
+The exception to this is pointers and function pointers. They are set to `nullptr` by default if no initializer is
+present. The following are identical:
+
+```belte
+int* ptr = nullptr;
+int* ptr;
+```
+
+When implicitly typing, the inferred type is usually the direct type of the initializer. The following are identical:
+
+```belte
+int a = 3;
+var a = 3;
+```
+
+The exception to this is object creation expressions, which will automatically "lift", meaning that an implicit local
+with an initializer that is an object creation expression will default to being nullable. The following are identical:
+
+```belte
+MyClass a = new MyClass();
+MyClass? a = new MyClass();
+var a = new MyClass();
+var? a = new MyClass();
+```
+
+As the object creation itself is not nullable, they can be used for non-nullable reference types. The following are
+identical:
+
+```belte
+MyClass! a = new MyClass();
+var! a = new MyClass();
+```
+
+## 1.3.4 Fields
+
+Unlike locals, non-nullable fields do not require an initializer and instead are set to a default value. Struct fields
+cannot have initializers at all. The default value of numeric types is `0`, for booleans `false`, and an empty string
+for strings.
+
+An mentioned earlier, pointers and function pointers default to `nullptr`.
+
+A non-nullable struct's default value is a created struct where each field is set to it's default value. For example:
+
+```belte
+var a = new MyClass();
+var b = a.str.num;
+// b equals 0
+
+class MyClass {
+  MyStruct str;
+}
+
+struct MyStruct {
+  int num;
+}
+```
+
+## 1.3.5 Implicit Typing
+
+`var`, `const`, and `constexpr` can be used when defining a local indicating that their type should be inferred. The
+inferred type is usually the exact type of the initializer. The following are identical:
+
+```belte
+int a = 3;
+var a = 3;
+```
+
+Nullability persists when inferring a type. The following are identical:
+
+```belte
+int? a = Func();
+var a = Func();
+
+int? Func() { ... }
+```
+
+`var` means a normal local declaration. `const` and `constexpr` infer the type of a local with the respective modifiers.
+The following are identical:
+
+```belte
+const int a = 3;
+const a = 3;
+
+constexpr int a = 3;
+constexpr a = 3;
+```
+
+`const` means the local cannot be assigned to or otherwise modified. `constexpr` means the value of the local is a
+compile-time constant that will be substituted at compile time. For classes, a `const` modifier means fields can only be
+read but not written to, and only methods marked `const` can be called. Class-types cannot use the `constexpr` modifier
+because they are not compile-time constants.
+
+## 1.3.6 Null-Flow Analysis
+
+Belte does not currently perform automatic null-flow analysis. Instead, explicit null checks and control flow should be
+used.
+
+When a value is needed to be non-null at a certain time, the [`!` operator](Data.md#3221-x) can be used that asserts
+that the value is not null, otherwise a runtime error occurs. For example:
+
+```belte
+int? a = Func();
+int! b = a!; // If a is null, runtime exception
+```
+
+To conditionally execute code if a value is not null, a
+[null-binding contract](ControlFlow.md#232-null-binding-contracts) can be used:
+
+```belte
+int? a = Func();
+
+if (a -> b!) {
+  ...
+}
+```
+
+In this example, `b` is declared as a non-nullable local set to the value of `a`, so in this case the type of `b` is
+`int!`. `b` only lives inside of the block.
+
+To use a type's default value in the case of null, the [`?` operator](Data.md#3222-x) can be used. For example:
+
+```belte
+bool? a = Func();
+
+if (a?) {
+  ...
+} else {
+  ...
+}
+```
+
+In this example, the else block is executed if `a` is false or null. Note that conditions inside if, for, and while
+constructs can be nullable. If the condition is null at runtime, an exception is thrown. For example:
+
+```belte
+bool? a = Func();
+
+if (a) {
+  ...
+}
+```
+
+In this example, if `a` is null, a runtime exception is thrown at the if condition.

--- a/docs/Current/StandardLibrary/Console.md
+++ b/docs/Current/StandardLibrary/Console.md
@@ -16,19 +16,19 @@ The Belte public interface for the Console class can be found
 | `int GetWidth()` | Gets the console character width. |
 | `int GetHeight()` | Gets the console character height. |
 | `string! Input()` | Gets a line of input from the console. |
-| `void PrintLine(string)` | Writes a string to the console followed by a line return. |
-| `void PrintLine(any)` | Writes a value to the console followed by a line return. |
+| `void PrintLine(string?)` | Writes a string to the console followed by a line return. |
+| `void PrintLine(any?)` | Writes a value to the console followed by a line return. |
 | `void PrintLine(Object)` | Writes the result of `Object.ToString()` to the console followed by a line return. |
-| `void PrintLine(char[])` | Writes a char array to the console as a string followed by a line return. |
+| `void PrintLine(char?[]?)` | Writes a char array to the console as a string followed by a line return. |
 | `void PrintLine()` | Writes an empty line to the console. |
-| `void Print(string)` | Writes a string to the console. |
-| `void Print(any)` | Writes a value to the console. |
+| `void Print(string?)` | Writes a string to the console. |
+| `void Print(any?)` | Writes a value to the console. |
 | `void Print(Object)` | Writes the result of `Object.ToString()` to the console. |
-| `void Print(char[])` | Writes a char array to the console as a string. |
+| `void Print(char?[]?)` | Writes a char array to the console as a string. |
 | `void ResetColor()` | Resets the foreground and background colors of the console. |
 | `void SetForegroundColor(int!)` | Sets the console foreground color based on [Color](#5121-color). |
 | `void SetBackgroundColor(int!)` | Sets the console background color based on [Color](#5121-color). |
-| `void SetCursorPosition(int, int)` | Sets the console cursor position based on left and top. If either argument is null it will be ignored i.e. that axis of the cursor will not change. |
+| `void SetCursorPosition(int?, int?)` | Sets the console cursor position based on left and top. If either argument is null it will be ignored i.e. that axis of the cursor will not change. |
 | `void SetCursorVisibility(bool!)` | Sets the console cursor to be visible or not. |
 
 ## 5.1.2 Classes

--- a/docs/Current/StandardLibrary/Int.md
+++ b/docs/Current/StandardLibrary/Int.md
@@ -11,4 +11,4 @@ The Belte public interface for the Int class can be found
 
 | Signature | Description |
 |-|-|
-| `int Parse(string)` | Tries to parse the given string into an int. Returns null if the string is not a valid int. |
+| `int? Parse(string?)` | Tries to parse the given string into an int. Returns null if the string is not a valid int. |

--- a/docs/Current/StandardLibrary/LowLevel.md
+++ b/docs/Current/StandardLibrary/LowLevel.md
@@ -15,6 +15,7 @@ The Belte public interface for the LowLevel class can be found
 |-|-|
 | `int! GetHashCode(Object!)` | Equivalent to calling `Object.GetHashCode()`. |
 | `string! GetTypeName(Object!)` | Equivalent to calling `Object.GetTypeName()`. |
+| `type! GetType(any!)` | Gets the type of the passed value. |
 | `int! Length<type T>(T!)` | Gets the length of the given array, or 0 if not passed an array. |
 | `void Sort<type T>(T!)` | Sorts the given array, or does nothing if not passed an array. |
 | `int32 SizeOf<type T>()` | Gets the size of the template argument type in number of bytes. (Using the [`sizeof` operator](../LowLevelFeatures.md#69-sizeof-operator) is preferred.) |

--- a/docs/Current/StandardLibrary/Random.md
+++ b/docs/Current/StandardLibrary/Random.md
@@ -11,5 +11,5 @@ The Belte public interface for the Random class can be found
 
 | Signature | Description |
 |-|-|
-| `int! RandInt(int max)` | Gets a random non-negative `int` that is less that `max`, or less than the int-64 maximum if `max` is null. |
+| `int! RandInt(int? max)` | Gets a random non-negative `int` that is less that `max`, or less than the int-64 maximum if `max` is null. |
 | `decimal! Random()` | Gets a random `decimal` greater than or equal to `0` and less than `1`. |

--- a/docs/Current/StandardLibrary/String.md
+++ b/docs/Current/StandardLibrary/String.md
@@ -11,11 +11,11 @@ The Belte public interface for the String class can be found
 
 | Signature | Description |
 |-|-|
-| `int Ascii(string!)` | Returns the ascii value of the given string given that it is 1 character long. Returns null otherwise. (Note that the ascii value of a `char` can be attained directly by casting it to an `int`.) |
+| `int? Ascii(string!)` | Returns the ascii value of the given string given that it is 1 character long. Returns null otherwise. (Note that the ascii value of a `char` can be attained directly by casting it to an `int`.) |
 | `string! Char(int!)` | Returns a string of length 1 containing the corresponding character of the given ascii code. (Note that the `char` of an ascii value can be attained directly by casting an `int` to a `char`.) |
-| `bool! IsDigit(char)` | If the given char is 0 through 9. |
-| `bool! IsNullOrWhiteSpace(string)` | Returns true if the given string is null, empty, or contains only whitespace characters. |
-| `bool! IsNullOrWhiteSpace(char)` | Returns true if the given char is null or is a whitespace character. |
+| `bool! IsDigit(char?)` | If the given char is 0 through 9. |
+| `bool! IsNullOrWhiteSpace(string?)` | Returns true if the given string is null, empty, or contains only whitespace characters. |
+| `bool! IsNullOrWhiteSpace(char?)` | Returns true if the given char is null or is a whitespace character. |
 | `int! Length(string!)` | Returns the length of a string. |
 | `string![]! Split(string!, string!)` | Splits the first given string at every instance of the second given string. The return value will not contain any instances of the second given string. |
-| `string Substring(string, int, int)` | Returns a copy of the given string starting at the given index with a given length. |
+| `string? Substring(string?, int?, int?)` | Returns a copy of the given string starting at the given index with a given length. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,13 @@
     - [1.2](Current/Overview.md#12-keywords) Keywords
       - [1.2.1](Current/Overview.md#121-non-contextual-keywords) Non-Contextual Keywords
       - [1.2.2](Current/Overview.md#122-contextual-keywords) Contextual Keywords
+    - [1.3](Current/Overview.md#13-nullability-and-types) Nullability and Types
+      - [1.3.1](Current/Overview.md#131-normal-types) Normal Types
+      - [1.3.2](Current/Overview.md#132-pointers-and-function-pointers) Pointers and Function Pointers
+      - [1.3.3](Current/Overview.md#133-initializers) Initializers
+      - [1.3.4](Current/Overview.md#134-fields) Fields
+      - [1.3.5](Current/Overview.md#135-implicit-typing) Implicit Typing
+      - [1.3.6](Current/Overview.md#136-null-flow-analysis) Null-Flow Analysis
   - [2](Current/ControlFlow.md) Control Flow
     - [2.1](Current/ControlFlow.md#21-functions) Functions
       - [2.1.1](Current/ControlFlow.md#211-nested-functions) Nested Functions
@@ -52,6 +59,7 @@
       - [3.1.1](Current/Data.md#311-casts) Casts
       - [3.1.2](Current/Data.md#312-string-interpolation) String Interpolation
       - [3.1.3](Current/Data.md#313-function-type) Function Type
+      - [3.1.4](Current/Data.md#314-default-literal) Default Literal
     - [3.2](Current/Data.md#32-operators) Operators
       - [3.2.1](Current/Data.md#321-operator-precedence) Operator Precedence
       - [3.2.2](Current/Data.md#322-uncommon-operators) Uncommon Operators

--- a/samples/Snake/Snake.blt
+++ b/samples/Snake/Snake.blt
@@ -32,7 +32,7 @@ class Snake {
         }
     }
 
-    public void AddBodySegment(decimal x, decimal y) {
+    public void AddBodySegment(decimal? x, decimal? y) {
         coords[bodySize++] = new Vec2(x, y);
     }
 }

--- a/samples/Win32/Program.blt
+++ b/samples/Win32/Program.blt
@@ -61,7 +61,7 @@ public static class Program {
         int64* lpParam);
 
     [DllImport("kernel32.dll")]
-    static extern int64* GetModuleHandle(string lpModuleName);
+    static extern int64* GetModuleHandle(string? lpModuleName);
 
     [DllImport("user32.dll")]
     static extern void PostQuitMessage(int32 nExitCode);

--- a/samples/Xor/Program.blt
+++ b/samples/Xor/Program.blt
@@ -33,7 +33,7 @@ List<int> FindDoubleMissing(List<int> given, List<int> total) {
     var par1 = PartitionList(total, lsb);
     var u = XorList(par0) ^ XorList(par1);
     var v = uv ^ u;
-    return new List<int>(new int[] { u, v });
+    return new List<int>({ u, v });
 }
 
 var result = FindDoubleMissing({ 1, 2, 3, 4, 5, 6 }, { 1, 3, 4, 6 });

--- a/src/Belte/Belte.Runtime/Utilities.cs
+++ b/src/Belte/Belte.Runtime/Utilities.cs
@@ -12,6 +12,10 @@ public static class Utilities {
         return o.GetType().Name;
     }
 
+    public static Type AnyGetType(object o) {
+        return o.GetType();
+    }
+
     public static T AssertNull<T>(T value) {
         if (value is null)
             throw new NullReferenceException();

--- a/src/Belte/Native/Graphics/FRect.blt
+++ b/src/Belte/Native/Graphics/FRect.blt
@@ -1,11 +1,11 @@
 
 public class FRect {
-    public decimal x;
-    public decimal y;
-    public decimal w;
-    public decimal h;
+    public decimal? x;
+    public decimal? y;
+    public decimal? w;
+    public decimal? h;
 
-    public constructor(decimal x, decimal y, decimal w, decimal h) {
+    public constructor(decimal? x, decimal? y, decimal? w, decimal? h) {
         this.x = x;
         this.y = y;
         this.w = w;

--- a/src/Belte/Native/Graphics/Graphics.blt
+++ b/src/Belte/Native/Graphics/Graphics.blt
@@ -8,23 +8,23 @@ public static class Graphics {
 
     public static Texture LoadTexture(string! path, int! r, int! g, int! b);
 
-    public static Sprite LoadSprite(string! path, Vec2 position, Vec2 scale, int rotation);
+    public static Sprite LoadSprite(string! path, Vec2 position, Vec2 scale, int? rotation);
 
-    public static int Draw(Texture texture, Rect srcRect, Rect dstRect, int rotation, bool flip, decimal alpha);
+    public static int? Draw(Texture texture, Rect srcRect, Rect dstRect, int? rotation, bool? flip, decimal? alpha);
 
-    public static int DrawSprite(Sprite sprite);
+    public static int? DrawSprite(Sprite sprite);
 
-    public static int DrawSprite(Sprite sprite, Vec2 offset);
+    public static int? DrawSprite(Sprite sprite, Vec2 offset);
 
-    public static Text LoadText(string text, string! fontPath, Vec2 position, decimal! fontSize, decimal angle, int r, int g, int b);
+    public static Text LoadText(string? text, string! fontPath, Vec2 position, decimal! fontSize, decimal? angle, int? r, int? g, int? b);
 
-    public static int DrawText(Text text);
+    public static int? DrawText(Text text);
 
-    public static int DrawRect(Rect rect, int r, int g, int b);
+    public static int? DrawRect(Rect rect, int? r, int? g, int? b);
 
-    public static int DrawRect(Rect rect, int r, int g, int b, int a);
+    public static int? DrawRect(Rect rect, int? r, int? g, int? b, int? a);
 
-    public static void StopDraw(int id);
+    public static void StopDraw(int? id);
 
     public static bool! GetKey(string! key);
 

--- a/src/Belte/Native/Graphics/Sound.blt
+++ b/src/Belte/Native/Graphics/Sound.blt
@@ -1,6 +1,6 @@
 
 public class Sound {
-    private int ptr;
-    public decimal volume;
-    public bool loop;
+    private int? ptr;
+    public decimal? volume;
+    public bool? loop;
 }

--- a/src/Belte/Native/Graphics/Sprite.blt
+++ b/src/Belte/Native/Graphics/Sprite.blt
@@ -1,12 +1,12 @@
 
 public class Sprite {
     public Vec2 position;
-    public int rotation;
+    public int? rotation;
     public Rect src;
     public Rect dst;
     public Texture texture;
 
-    public constructor(Texture texture, Vec2 position, Vec2 scale, int rotation) {
+    public constructor(Texture texture, Vec2 position, Vec2 scale, int? rotation) {
         this.position = position;
         this.rotation = rotation;
         this.texture = texture;
@@ -24,7 +24,7 @@ public class Sprite {
         );
     }
 
-    public constructor(Texture texture, Rect src, Rect dst, int rotation) {
+    public constructor(Texture texture, Rect src, Rect dst, int? rotation) {
         this.src = src ?? new Rect(0, 0, texture.width, texture.height);
         this.dst = dst;
         this.rotation = rotation;
@@ -33,14 +33,14 @@ public class Sprite {
         position = new Vec2(dst.x + dst.w / 2, dst.y + dst.h / 2);
     }
 
-    public void SetPosition(int x, int y) {
+    public void SetPosition(int? x, int? y) {
         dst.x = x! - dst.w / 2;
         dst.y = y! - dst.h / 2;
         position.x = x;
         position.y = y;
     }
 
-    public void SetPosition(decimal x, decimal y) {
+    public void SetPosition(decimal? x, decimal? y) {
         dst.x = (int!)(x! - dst.w / 2);
         dst.y = (int!)(y! - dst.h / 2);
         position.x = x;

--- a/src/Belte/Native/Graphics/Text.blt
+++ b/src/Belte/Native/Graphics/Text.blt
@@ -1,12 +1,12 @@
 
 public class Text {
-    private int ptr;
+    private int? ptr;
     public string text;
     public string! fontPath;
     public Vec2 position;
     public decimal! fontSize;
-    public decimal angle;
-    public int r;
-    public int g;
-    public int b;
+    public decimal? angle;
+    public int? r;
+    public int? g;
+    public int? b;
 }

--- a/src/Belte/Native/Graphics/Vec2.blt
+++ b/src/Belte/Native/Graphics/Vec2.blt
@@ -1,9 +1,9 @@
 
 public class Vec2 {
-    public decimal x;
-    public decimal y;
+    public decimal? x;
+    public decimal? y;
 
-    public constructor(decimal x, decimal y) {
+    public constructor(decimal? x, decimal? y) {
         this.x = x;
         this.y = y;
     }

--- a/src/Belte/Native/Graphics/Vec4.blt
+++ b/src/Belte/Native/Graphics/Vec4.blt
@@ -1,11 +1,11 @@
 
 public class Vec4 {
-    public decimal a;
-    public decimal b;
-    public decimal c;
-    public decimal d;
+    public decimal? a;
+    public decimal? b;
+    public decimal? c;
+    public decimal? d;
 
-    public constructor(decimal a, decimal b, decimal c, decimal d) {
+    public constructor(decimal? a, decimal? b, decimal? c, decimal? d) {
         this.a = a;
         this.b = b;
         this.c = c;

--- a/src/Belte/Native/Standard/Collections/Dictionary.blt
+++ b/src/Belte/Native/Standard/Collections/Dictionary.blt
@@ -98,8 +98,8 @@ public lowlevel sealed class Dictionary<type TKey, type TValue> {
 
                     _entries[i].hashCode = -1;
                     _entries[i].next = _freeList;
-                    _entries[i].key = null;
-                    _entries[i].value = null;
+                    _entries[i].key = default;
+                    _entries[i].value = default;
                     _freeList = i;
                     _freeCount++;
 
@@ -157,7 +157,7 @@ public lowlevel sealed class Dictionary<type TKey, type TValue> {
                 if (add)
                     throw new ArgumentNullException();
 
-                _entries[i].value = value!;
+                _entries[i].value = value;
                 return;
             }
         }
@@ -180,8 +180,8 @@ public lowlevel sealed class Dictionary<type TKey, type TValue> {
 
         _entries[index].hashCode = hashCode;
         _entries[index].next = _buckets[targetBucket];
-        _entries[index].key = key!;
-        _entries[index].value = value!;
+        _entries[index].key = key;
+        _entries[index].value = value;
         _buckets[targetBucket] = index;
     }
 

--- a/src/Belte/Native/Standard/Collections/List.blt
+++ b/src/Belte/Native/Standard/Collections/List.blt
@@ -120,11 +120,11 @@ public lowlevel sealed class List<type T> {
             _length--;
     }
 
-    public override string ToString() {
+    public override string? ToString() {
         if (_length == 0)
             return "{ }";
 
-        string representation = "{ ";
+        string? representation = "{ ";
 
         for (int i = 0; i < _length - 1; i++)
             representation += _array[i].ToString() + ", ";
@@ -132,14 +132,14 @@ public lowlevel sealed class List<type T> {
         return representation + _array[_length - 1].ToString() + " }";
     }
 
-    public static ref T operator[](List<T> list, int index) {
+    public static ref T operator[](List<T> list, int? index) {
         if (index is null)
-            return null;
+            throw new ArgumentNullException();
 
         index = list.PosIndex(index!);
 
         if (index < 0 || index >= list._length)
-            return null;
+            throw new ArgumentOutOfRangeException();
 
         return ref list._array[index];
     }

--- a/src/Belte/Native/Standard/Console.blt
+++ b/src/Belte/Native/Standard/Console.blt
@@ -1,21 +1,21 @@
 
 public static class Console {
-    public static int GetWidth();
+    public static int? GetWidth();
 
-    public static int GetHeight();
+    public static int? GetHeight();
 
     public static string! Input();
 
-    public static void PrintLine(string message);
-    public static void PrintLine(any value);
+    public static void PrintLine(string? message);
+    public static void PrintLine(any? value);
     public static void PrintLine(Object value);
-    public static void PrintLine(char[] chars);
+    public static void PrintLine(char?[]? chars);
     public static void PrintLine();
 
-    public static void Print(string message);
-    public static void Print(any value);
+    public static void Print(string? message);
+    public static void Print(any? value);
     public static void Print(Object value);
-    public static void Print(char[] chars);
+    public static void Print(char?[]? chars);
 
     public static void ResetColor();
 
@@ -23,7 +23,7 @@ public static class Console {
 
     public static void SetBackgroundColor(int! color);
 
-    public static void SetCursorPosition(int left, int top);
+    public static void SetCursorPosition(int? left, int? top);
 
     public static void SetCursorVisibility(bool! visible);
 

--- a/src/Belte/Native/Standard/Exceptions/Exception.blt
+++ b/src/Belte/Native/Standard/Exceptions/Exception.blt
@@ -2,9 +2,9 @@
 public class Exception {
     public constructor() : this("Exception thrown") { }
 
-    public constructor(string message) {
+    public constructor(string? message) {
         this.message = message;
     }
 
-    public string message;
+    public string? message;
 }

--- a/src/Belte/Native/Standard/Int.blt
+++ b/src/Belte/Native/Standard/Int.blt
@@ -1,4 +1,4 @@
 
 public static class Int {
-    public static int Parse(string text);
+    public static int? Parse(string? text);
 }

--- a/src/Belte/Native/Standard/Math.blt
+++ b/src/Belte/Native/Standard/Math.blt
@@ -3,99 +3,99 @@ public static class Math {
     public constexpr E = 2.7182818284590451;
     public constexpr PI = 3.1415926535897931;
 
-    public static decimal Abs(decimal value);
+    public static decimal? Abs(decimal? value);
     public static decimal! Abs(decimal! value);
-    public static int Abs(int value);
+    public static int? Abs(int? value);
     public static int! Abs(int! value);
 
-    public static decimal Acos(decimal d);
+    public static decimal? Acos(decimal? d);
     public static decimal! Acos(decimal! d);
 
-    public static decimal Acosh(decimal d);
+    public static decimal? Acosh(decimal? d);
     public static decimal! Acosh(decimal! d);
 
-    public static decimal Asin(decimal d);
+    public static decimal? Asin(decimal? d);
     public static decimal! Asin(decimal! d);
 
-    public static decimal Asinh(decimal d);
+    public static decimal? Asinh(decimal? d);
     public static decimal! Asinh(decimal! d);
 
-    public static decimal Atan(decimal d);
+    public static decimal? Atan(decimal? d);
     public static decimal! Atan(decimal! d);
 
-    public static decimal Atanh(decimal d);
+    public static decimal? Atanh(decimal? d);
     public static decimal! Atanh(decimal! d);
 
-    public static decimal Ceiling(decimal d);
+    public static decimal? Ceiling(decimal? d);
     public static decimal! Ceiling(decimal! d);
 
-    public static decimal Clamp(decimal value, decimal min, decimal max);
+    public static decimal? Clamp(decimal? value, decimal? min, decimal? max);
     public static decimal! Clamp(decimal! value, decimal! min, decimal! max);
-    public static int Clamp(int value, int min, int max);
+    public static int? Clamp(int? value, int? min, int? max);
     public static int! Clamp(int! value, int! min, int! max);
 
-    public static decimal Cos(decimal d);
+    public static decimal? Cos(decimal? d);
     public static decimal! Cos(decimal! d);
 
-    public static decimal Cosh(decimal d);
+    public static decimal? Cosh(decimal? d);
     public static decimal! Cosh(decimal! d);
 
-    public static decimal Exp(decimal d);
+    public static decimal? Exp(decimal? d);
     public static decimal! Exp(decimal! d);
 
-    public static decimal Floor(decimal d);
+    public static decimal? Floor(decimal? d);
     public static decimal! Floor(decimal! d);
 
-    public static decimal Lerp(decimal start, decimal end, decimal rate);
+    public static decimal? Lerp(decimal? start, decimal? end, decimal? rate);
     public static decimal! Lerp(decimal! start, decimal! end, decimal! rate);
 
-    public static decimal Log(decimal d, decimal base);
+    public static decimal? Log(decimal? d, decimal? base);
     public static decimal! Log(decimal! d, decimal! base);
-    public static decimal Log(decimal d);
+    public static decimal? Log(decimal? d);
     public static decimal! Log(decimal! d);
 
-    public static decimal Max(decimal val1, decimal val2);
+    public static decimal? Max(decimal? val1, decimal? val2);
     public static decimal! Max(decimal! val1, decimal! val2);
-    public static int Max(int val1, int val2);
+    public static int? Max(int? val1, int? val2);
     public static int! Max(int! val1, int! val2);
 
-    public static decimal Min(decimal val1, decimal val2);
+    public static decimal? Min(decimal? val1, decimal? val2);
     public static decimal! Min(decimal! val1, decimal! val2);
-    public static int Min(int val1, int val2);
+    public static int? Min(int? val1, int? val2);
     public static int! Min(int! val1, int! val2);
 
-    public static decimal Pow(decimal x, decimal y);
+    public static decimal? Pow(decimal? x, decimal? y);
     public static decimal! Pow(decimal! x, decimal! y);
 
-    public static decimal Round(decimal value);
+    public static decimal? Round(decimal? value);
     public static decimal! Round(decimal! value);
 
-    public static int Sign(decimal value);
+    public static int? Sign(decimal? value);
     public static int! Sign(decimal! value);
-    public static int Sign(int value);
+    public static int? Sign(int? value);
     public static int! Sign(int! value);
 
-    public static decimal Sin(decimal d);
+    public static decimal? Sin(decimal? d);
     public static decimal! Sin(decimal! d);
 
-    public static decimal Sinh(decimal d);
+    public static decimal? Sinh(decimal? d);
     public static decimal! Sinh(decimal! d);
 
-    public static decimal Sqrt(decimal d);
+    public static decimal? Sqrt(decimal? d);
     public static decimal! Sqrt(decimal! d);
 
-    public static decimal Tan(decimal d);
+    public static decimal? Tan(decimal? d);
     public static decimal! Tan(decimal! d);
 
-    public static decimal Tanh(decimal d);
+    public static decimal? Tanh(decimal? d);
     public static decimal! Tanh(decimal! d);
 
-    public static decimal Truncate(decimal value);
+    public static decimal? Truncate(decimal? value);
     public static decimal! Truncate(decimal! value);
 
-    public static decimal DegToRad(decimal degrees);
+    public static decimal? DegToRad(decimal? degrees);
     public static decimal! DegToRad(decimal! degrees);
 
-    public static decimal RadToDeg(decimal radians);
+    public static decimal? RadToDeg(decimal? radians);
     public static decimal! RadToDeg(decimal! radians);
 }

--- a/src/Belte/Native/Standard/Object.blt
+++ b/src/Belte/Native/Standard/Object.blt
@@ -2,7 +2,7 @@
 public class Object {
     public constructor() { }
 
-    public virtual string ToString() {
+    public virtual string? ToString() {
         return LowLevel.GetTypeName(this);
     }
 

--- a/src/Belte/Native/Standard/Random.blt
+++ b/src/Belte/Native/Standard/Random.blt
@@ -1,6 +1,6 @@
 
 public static class Random {
-    public static int! RandInt(int max);
+    public static int! RandInt(int? max);
 
     public static decimal! Random();
 }

--- a/src/Belte/Native/Standard/String.blt
+++ b/src/Belte/Native/Standard/String.blt
@@ -1,18 +1,18 @@
 
 public static class String {
-    public static int Ascii(string! chr);
+    public static int? Ascii(string! chr);
 
     public static string! Char(int! ascii);
 
-    public static bool! IsDigit(char chr);
+    public static bool! IsDigit(char? chr);
 
-    public static bool! IsNullOrWhiteSpace(string str);
+    public static bool! IsNullOrWhiteSpace(string? str);
 
-    public static bool! IsNullOrWhiteSpace(char str);
+    public static bool! IsNullOrWhiteSpace(char? str);
 
     public static int! Length(string! str);
 
     public static string![]! Split(string! text, string! separator);
 
-    public static string Substring(string text, int start, int length);
+    public static string? Substring(string? text, int? start, int? length);
 }

--- a/src/Buckle/Compiler.Tests/CodeAnalysis/Evaluating/EvaluatorTests.cs
+++ b/src/Buckle/Compiler.Tests/CodeAnalysis/Evaluating/EvaluatorTests.cs
@@ -135,10 +135,10 @@ public sealed class EvaluatorTests {
     [InlineData("return 3 is null;", false)]
     [InlineData("return null == null;", true)]
     [InlineData("return 3 == null;", false)]
-    [InlineData("bool a = true; bool b = null; return a || b;", true)]
-    [InlineData("bool a = true; bool b = null; return a && b;", false)]
-    [InlineData("bool a = null; bool b = null; return a || b;", false)]
-    [InlineData("bool a = null; bool b = null; return a && b;", false)]
+    [InlineData("bool? a = true; bool? b = null; return a || b;", true)]
+    [InlineData("bool? a = true; bool? b = null; return a && b;", false)]
+    [InlineData("bool? a = null; bool? b = null; return a || b;", false)]
+    [InlineData("bool? a = null; bool? b = null; return a && b;", false)]
     [InlineData("return (null + 3) is null;", true)]
     [InlineData("return (null > 3) is null;", true)]
     [InlineData("return 3 is any;", true)]
@@ -154,250 +154,261 @@ public sealed class EvaluatorTests {
     [InlineData("return 9 % 5;", 4)]
     [InlineData("return 5 ?? 2;", 5)]
     [InlineData("return 5 ?! 2;", 2)]
-    [InlineData("int a = 3; return a?;", 3)]
-    [InlineData("int a = null; return a?;", 0)]
-    [InlineData("string a = \"t\"; return a?;", "t")]
-    [InlineData("string a = null; return a?;", "")]
-    [InlineData("bool a = true; return a?;", true)]
-    [InlineData("bool a = null; return a?;", false)]
+    [InlineData("int? a = 3; return a?;", 3)]
+    [InlineData("int? a = null; return a?;", 0)]
+    [InlineData("string? a = \"t\"; return a?;", "t")]
+    [InlineData("string? a = null; return a?;", "")]
+    [InlineData("bool? a = true; return a?;", true)]
+    [InlineData("bool? a = null; return a?;", false)]
     // Compound assignments
-    [InlineData("var a = 1; a += (2 + 3); return a;", 6)]
-    [InlineData("var a = 1; a -= (2 + 3); return a;", -4)]
-    [InlineData("var a = 1; a *= (2 + 3); return a;", 5)]
-    [InlineData("var a = 1; a /= (2 + 3); return a;", 0)]
-    [InlineData("var a = 2; a **= 2; return a;", 4)]
-    [InlineData("var a = true; a &= (false); return a;", false)]
-    [InlineData("var a = 1; a &= 3; return a;", 1)]
-    [InlineData("var a = 1; a &= 0; return a;", 0)]
-    [InlineData("var a = true; a |= (false); return a;", true)]
-    [InlineData("var a = 1; a |= 0; return a;", 1)]
-    [InlineData("var a = true; a ^= (true); return a;", false)]
-    [InlineData("var a = 1; a ^= 0; return a;", 1)]
-    [InlineData("var a = 1; a <<= 1; return a;", 2)]
-    [InlineData("var a = 2; a >>= 1; return a;", 1)]
-    [InlineData("var a = 8; a >>>= 1; return a;", 4)]
-    [InlineData("var a = -8; a >>>= 1; return a;", 9223372036854775804)]
-    [InlineData("var a = 12; a >>>= 5; return a;", 0)]
-    [InlineData("var a = 5; a %= 2; return a;", 1)]
-    [InlineData("var a = 5; a ??= 2; return a;", 5)]
-    [InlineData("var a = 5; a ?!= 2; return a;", 2)]
-    [InlineData("int a = null; a ??= 2; return a;", 2)]
-    [InlineData("int a = null; a ?!= 2; return a;", null)]
-    [InlineData("var a = 1; var b = 2; var c = 3; a += b += c; return a;", 6)]
-    [InlineData("var a = 1; var b = 2; var c = 3; a += b += c; return b;", 5)]
-    [InlineData("var a = 3; return a is null;", false)]
-    [InlineData("var a = 3; return a isnt null;", true)]
-    [InlineData("var a = 3; a += null; return a;", null)]
-    [InlineData("int a = 3; a += null; return a is null;", true)]
-    [InlineData("int a = 3; a += null; return a isnt null;", false)]
+    [InlineData("var? a = 1; a += (2 + 3); return a;", 6)]
+    [InlineData("var? a = 1; a -= (2 + 3); return a;", -4)]
+    [InlineData("var? a = 1; a *= (2 + 3); return a;", 5)]
+    [InlineData("var? a = 1; a /= (2 + 3); return a;", 0)]
+    [InlineData("var? a = 2; a **= 2; return a;", 4)]
+    [InlineData("var? a = true; a &= (false); return a;", false)]
+    [InlineData("var? a = 1; a &= 3; return a;", 1)]
+    [InlineData("var? a = 1; a &= 0; return a;", 0)]
+    [InlineData("var? a = true; a |= (false); return a;", true)]
+    [InlineData("var? a = 1; a |= 0; return a;", 1)]
+    [InlineData("var? a = true; a ^= (true); return a;", false)]
+    [InlineData("var? a = 1; a ^= 0; return a;", 1)]
+    [InlineData("var? a = 1; a <<= 1; return a;", 2)]
+    [InlineData("var? a = 2; a >>= 1; return a;", 1)]
+    [InlineData("var? a = 8; a >>>= 1; return a;", 4)]
+    [InlineData("var? a = -8; a >>>= 1; return a;", 9223372036854775804)]
+    [InlineData("var? a = 12; a >>>= 5; return a;", 0)]
+    [InlineData("var? a = 5; a %= 2; return a;", 1)]
+    [InlineData("var? a = 5; a ??= 2; return a;", 5)]
+    [InlineData("var? a = 5; a ?!= 2; return a;", 2)]
+    [InlineData("int? a = null; a ??= 2; return a;", 2)]
+    [InlineData("int? a = null; a ?!= 2; return a;", null)]
+    [InlineData("var? a = 1; var? b = 2; var? c = 3; a += b += c; return a;", 6)]
+    [InlineData("var? a = 1; var? b = 2; var? c = 3; a += b += c; return b;", 5)]
+    [InlineData("var? a = 3; return a is null;", false)]
+    [InlineData("var? a = 3; return a isnt null;", true)]
+    [InlineData("var? a = 3; a += null; return a;", null)]
+    [InlineData("int? a = 3; a += null; return a is null;", true)]
+    [InlineData("int? a = 3; a += null; return a isnt null;", false)]
     // Ternary expressions
     [InlineData("return true ? 3 : 5;", 3)]
     [InlineData("return false ? \"asdf\" : \"asdf2\";", "asdf2")]
-    [InlineData("int a = 3; int b = a > 2 ? 5 : 3; return b;", 5)]
-    [InlineData("int a = 3; int b = a > 2 && false ? a + 5 : a + 3; return b;", 6)]
+    [InlineData("int? a = 3; int? b = a > 2 ? 5 : 3; return b;", 5)]
+    [InlineData("int? a = 3; int? b = a > 2 && false ? a + 5 : a + 3; return b;", 6)]
     // Assignment expressions
-    [InlineData("int a = 10; return a;", 10)]
-    [InlineData("int a = 10; return a * a;", 100)]
-    [InlineData("int a = 1; return 10 * a;", 10)]
-    [InlineData("int a; return a;", null)]
+    [InlineData("int? a = 10; return a;", 10)]
+    [InlineData("int? a = 10; return a * a;", 100)]
+    [InlineData("int? a = 1; return 10 * a;", 10)]
+    [InlineData("int? a; return a;", null)]
+    [InlineData("int a = default; return a;", 0)]
+    [InlineData("int? a = default; return a;", null)]
+    [InlineData("int[][] a; a = new int[][] { { 1 } }; return a[0][0];", 1)]
     // Name expressions
-    [InlineData("int a = 3; int b = 6; return a;", 3)]
-    [InlineData("int a = 3; int b = 6; return b;", 6)]
-    [InlineData("int a = 3; int b = 6; b += a; return a;", 3)]
-    [InlineData("int a = 3; int b = 6; b += a; return b;", 9)]
+    [InlineData("int? a = 3; int? b = 6; return a;", 3)]
+    [InlineData("int? a = 3; int? b = 6; return b;", 6)]
+    [InlineData("int? a = 3; int? b = 6; b += a; return a;", 3)]
+    [InlineData("int? a = 3; int? b = 6; b += a; return b;", 9)]
     // Postfix expressions
-    [InlineData("int a = 3; a++; return a;", 4)]
-    [InlineData("int a = 3; a--; return a;", 2)]
-    [InlineData("int a = 3; a--; a++; return a;", 3)]
-    [InlineData("int a = 1; a--; a--; return a;", -1)]
-    [InlineData("int a = 4; int b = a++; return b;", 4)]
-    [InlineData("int a = 4; int b = a--; return b;", 4)]
-    [InlineData("int a = 4; return a!;", 4)]
-    [InlineData("int a = 4; return a! + 1;", 5)]
-    [InlineData("decimal a = 3.6; a++; return a;", 4.6)]
-    [InlineData("decimal a = 3.6; a--; return a;", 2.6)]
+    [InlineData("int? a = 3; a++; return a;", 4)]
+    [InlineData("int? a = 3; a--; return a;", 2)]
+    [InlineData("int? a = 3; a--; a++; return a;", 3)]
+    [InlineData("int? a = 1; a--; a--; return a;", -1)]
+    [InlineData("int? a = 4; int? b = a++; return b;", 4)]
+    [InlineData("int? a = 4; int? b = a--; return b;", 4)]
+    [InlineData("int? a = 4; return a!;", 4)]
+    [InlineData("int? a = 4; return a! + 1;", 5)]
+    [InlineData("decimal? a = 3.6; a++; return a;", 4.6)]
+    [InlineData("decimal? a = 3.6; a--; return a;", 2.6)]
     // Prefix expressions
-    [InlineData("int a = 3; ++a; return a;", 4)]
-    [InlineData("int a = 3; --a; return a;", 2)]
-    [InlineData("int a = 3; --a; ++a; return a;", 3)]
-    [InlineData("int a = 1; --a; --a; return a;", -1)]
-    [InlineData("int a = 4; int b = ++a; return b;", 5)]
-    [InlineData("int a = 4; int b = --a; return b;", 3)]
-    [InlineData("decimal a = 3.6; ++a; return a;", 4.6)]
-    [InlineData("decimal a = 3.6; --a; return a;", 2.6)]
+    [InlineData("int? a = 3; ++a; return a;", 4)]
+    [InlineData("int? a = 3; --a; return a;", 2)]
+    [InlineData("int? a = 3; --a; ++a; return a;", 3)]
+    [InlineData("int? a = 1; --a; --a; return a;", -1)]
+    [InlineData("int? a = 4; int? b = ++a; return b;", 5)]
+    [InlineData("int? a = 4; int? b = --a; return b;", 3)]
+    [InlineData("decimal? a = 3.6; ++a; return a;", 4.6)]
+    [InlineData("decimal? a = 3.6; --a; return a;", 2.6)]
     // Parenthesized expressions
-    [InlineData("int a = (3 + 4) * 2; return a;", 14)]
-    [InlineData("int a = 3 + (4 * 2); return a;", 11)]
-    [InlineData("int a = 12 / (4 * 2); return a;", 1)]
-    [InlineData("int a = (12 / 4) * 2; return a;", 6)]
+    [InlineData("int? a = (3 + 4) * 2; return a;", 14)]
+    [InlineData("int? a = 3 + (4 * 2); return a;", 11)]
+    [InlineData("int? a = 12 / (4 * 2); return a;", 1)]
+    [InlineData("int? a = (12 / 4) * 2; return a;", 6)]
     // Call expressions
-    [InlineData("int F(int a, int b, int c) { return a + b * c; } return F(b: 3, c: 2, a: 9);", 15)]
-    [InlineData("int F(int a = 3) { return a; } return F(5);", 5)]
-    [InlineData("int F(int a = 3) { return a; } return F();", 3)]
-    [InlineData("int F(int a, int b, int c = 6) { return a + b * c; } return F(b: 3, c: 2, a: 9);", 15)]
-    [InlineData("int F(int a, int b, int c = 6) { return a + b * c; } return F(b: 3, a: 9);", 27)]
-    [InlineData("int F(int a, int b) { if (a is null) return 1; if (b is null) return 2; return 3;} return F(1, 2);", 3)]
-    [InlineData("int F(int a, int b) { if (a is null) return 1; if (b is null) return 2; return 3;} return F(1,);", 2)]
-    [InlineData("int F(int a, int b) { if (a is null) return 1; if (b is null) return 2; return 3;} return F(,2);", 1)]
-    [InlineData("class A { public int a; public int M() { if (a is null) a = 3; return a++; } } var myA = new A(); return myA.M();", 3)]
-    [InlineData("class A { public int a; public int M() { if (a is null) a = 3; return a++; } } var myA = new A(); myA.M(); return myA.M();", 4)]
-    [InlineData("int F(int a, int b) { return a + b; } int(int, int) a = F; return a(3, 4);", 7)]
-    [InlineData("int F(int a) { return a + 3; } int(int) a = F; return a(3);", 6)]
-    [InlineData("int F() { return 3; } int() a = F; return a();", 3)]
-    [InlineData("void F(int a, int b) { } void(int, int) a = F; a(3, 4); return null;", null)]
-    [InlineData("void F(int a) { } void(int) a = F; a(3); return null;", null)]
+    [InlineData("int? F(int? a, int? b, int? c) { return a + b * c; } return F(b: 3, c: 2, a: 9);", 15)]
+    [InlineData("int? F(int? a = 3) { return a; } return F(5);", 5)]
+    [InlineData("int? F(int? a = 3) { return a; } return F();", 3)]
+    [InlineData("int? F(int? a, int? b, int? c = 6) { return a + b * c; } return F(b: 3, c: 2, a: 9);", 15)]
+    [InlineData("int? F(int? a, int? b, int? c = 6) { return a + b * c; } return F(b: 3, a: 9);", 27)]
+    [InlineData("int? F(int? a, int? b) { if (a is null) return 1; if (b is null) return 2; return 3;} return F(1, 2);", 3)]
+    [InlineData("int? F(int? a, int? b) { if (a is null) return 1; if (b is null) return 2; return 3;} return F(1,);", 2)]
+    [InlineData("int? F(int? a, int? b) { if (a is null) return 1; if (b is null) return 2; return 3;} return F(,2);", 1)]
+    [InlineData("class A { public int? a; public int? M() { if (a is null) a = 3; return a++; } } var myA = new A(); return myA.M();", 3)]
+    [InlineData("class A { public int? a; public int? M() { if (a is null) a = 3; return a++; } } var myA = new A(); myA.M(); return myA.M();", 4)]
+    [InlineData("int? F(int? a, int? b) { return a + b; } int?(int?, int?) a = F; return a(3, 4);", 7)]
+    [InlineData("int? F(int? a) { return a + 3; } int?(int?) a = F; return a(3);", 6)]
+    [InlineData("int? F() { return 3; } int?() a = F; return a();", 3)]
+    [InlineData("void F(int? a, int? b) { } void(int?, int?) a = F; a(3, 4); return null;", null)]
+    [InlineData("void F(int? a) { } void(int?) a = F; a(3); return null;", null)]
     [InlineData("void F() { } void() a = F; a(); return null;", null)]
     // Cast expressions
-    [InlineData("return (decimal)3;", 3)]
-    [InlineData("return (int)3.4;", 3)]
-    [InlineData("return (int)3.6;", 3)]
+    [InlineData("return (decimal?)3;", 3)]
+    [InlineData("return (int?)3.4;", 3)]
+    [InlineData("return (int?)3.6;", 3)]
     [InlineData("return (int!)3;", 3)]
-    [InlineData("return 10 * (int)1.5;", 10)]
-    [InlineData("string a = (string)(int)3.6; return a;", "3")]
-    [InlineData("return (string)null;", null)]
-    [InlineData("return (int)null;", null)]
+    [InlineData("return 10 * (int?)1.5;", 10)]
+    [InlineData("string? a = (string?)(int?)3.6; return a;", "3")]
+    [InlineData("return (string?)null;", null)]
+    [InlineData("return (int?)null;", null)]
     [InlineData("int! a = 3; decimal! b = 3.5; return (int!)b == a;", true)]
-    [InlineData("int! a = 3; string b = \"test\" + (string)a; return b;", "test3")]
-    [InlineData("lowlevel { any a = new int[] {1, 2, 3}; return ((int[])a)[1]; }", 2)]
-    [InlineData("lowlevel { any a = new bool[] {true, false}; return ((bool[])a)[0]; }", true)]
+    [InlineData("int! a = 3; string? b = \"test\" + (string?)a; return b;", "test3")]
+    [InlineData("lowlevel { any a = new int?[] {1, 2, 3}; return ((int?[])a)[1]; }", 2)]
+    [InlineData("lowlevel { any a = new bool?[] {true, false}; return ((bool?[])a)[0]; }", true)]
     [InlineData("lowlevel { any[] a = {1, 3.5, true, \"test\"}; return a[0]; }", 1)]
     [InlineData("lowlevel { any[] a = {1, 3.5, true, \"test\"}; return a[1]; }", 3.5)]
     [InlineData("lowlevel { any[] a = {1, 3.5, true, \"test\"}; return a[2]; }", true)]
     [InlineData("lowlevel { any[] a = {1, 3.5, true, \"test\"}; return a[3]; }", "test")]
     // Reference expressions
-    [InlineData("int x = 4; ref int y = ref x; x++; return y;", 5)]
-    [InlineData("int x = 4; ref int y = ref x; y++; return x;", 5)]
-    [InlineData("int x = 4; int y = 3; ref int z = ref x; z = ref y; z++; return x;", 4)]
-    [InlineData("lowlevel { int[] a = {1, 2, 3}; a[0] = 6; return a[0]; }", 6)]
-    [InlineData("int M() { ref int F(ref int a) { return ref a; } int b = 3; F(ref b) = 6; return b; } return M();", 6)]
+    [InlineData("int? x = 4; ref int? y = ref x; x++; return y;", 5)]
+    [InlineData("int? x = 4; ref int? y = ref x; y++; return x;", 5)]
+    [InlineData("int? x = 4; int? y = 3; ref int? z = ref x; z = ref y; z++; return x;", 4)]
+    [InlineData("lowlevel { int?[] a = {1, 2, 3}; a[0] = 6; return a[0]; }", 6)]
+    [InlineData("int? M() { ref int? F(ref int? a) { return ref a; } int? b = 3; F(ref b) = 6; return b; } return M();", 6)]
     // Cascade list expression
-    [InlineData("class A { public int f = 0; } var a = new A()..f=1.0..f=5; return a.f;", 5)]
-    [InlineData("class A { public int f = 0; public void M() { f++; } } var a = new A()..M()..M(); return a.f;", 2)]
+    [InlineData("class A { public int? f = 0; } var a = new A()..f=1.0..f=5; return a.f;", 5)]
+    [InlineData("class A { public int? f = 0; public void M() { f++; } } var a = new A()..M()..M(); return a.f;", 2)]
     // Initializer list expressions and index expressions
-    [InlineData("lowlevel { decimal[] a = {3.1, 2.56, 5.23123}; return a[2]; }", 5.23123)]
-    [InlineData("lowlevel { decimal[] a = {3.1, 2.56, 5.23123}; return a[0]; }", 3.1)]
-    [InlineData("lowlevel { string[] a = {\"hello\", \"world\"}; return a[1]; }", "world")]
-    [InlineData("lowlevel { bool[] a = {true, true, false, false}; return a[3]; }", false)]
-    [InlineData("lowlevel { bool[] a = {true, true, false, false}; return a?[3]; }", false)]
-    [InlineData("lowlevel { bool[] a; return a?[3]; }", null)]
-    [InlineData("lowlevel { bool[] a = {true, false}; a = null; return a?[3]; }", null)]
-    [InlineData("lowlevel { bool[] a = null; return a?[3]; }", null)]
-    [InlineData("lowlevel { int[] a = {1, 2, null}; return a[0]; }", 1)]
-    [InlineData("lowlevel { int[] a = {1, 2, null}; return a[2]; }", null)]
-    [InlineData("lowlevel { int[][] a = { new int[] { 1 } }; return a[0][0]; }", 1)]
-    [InlineData("lowlevel { var a = new int[] { 1, 2, 3 }; a = { 4, 5, 6 }; return a[0]; }", 4)]
+    [InlineData("lowlevel { decimal?[] a = {3.1, 2.56, 5.23123}; return a[2]; }", 5.23123)]
+    [InlineData("lowlevel { decimal?[] a = {3.1, 2.56, 5.23123}; return a[0]; }", 3.1)]
+    [InlineData("lowlevel { string?[] a = {\"hello\", \"world\"}; return a[1]; }", "world")]
+    [InlineData("lowlevel { bool?[] a = {true, true, false, false}; return a[3]; }", false)]
+    [InlineData("lowlevel { bool?[] a = {true, true, false, false}; return a?[3]; }", false)]
+    [InlineData("lowlevel { bool?[] a; return a?[3]; }", null)]
+    [InlineData("lowlevel { bool?[] a = {true, false}; a = null; return a?[3]; }", null)]
+    [InlineData("lowlevel { bool?[] a = null; return a?[3]; }", null)]
+    [InlineData("lowlevel { int?[] a = {1, 2, null}; return a[0]; }", 1)]
+    [InlineData("lowlevel { int?[] a = {1, 2, null}; return a[2]; }", null)]
+    [InlineData("lowlevel { int?[][] a = { new int?[] { 1 } }; return a[0][0]; }", 1)]
+    [InlineData("lowlevel { var a = new int?[] { 1, 2, 3 }; a = { 4, 5, 6 }; return a[0]; }", 4)]
     [InlineData(@"
         class A {
-            public decimal f = 1;
+            public decimal? f = 1;
         }
         var c = new A[2];
         c[0] = new A();
-        int i = 0;
+        int? i = 0;
         var f = c[i].f;
         return f;
         ", 1)]
     // Member access expressions
-    [InlineData("class A { public int num; } A myVar = new A(); myVar.num = 3; return myVar.num + 1;", 4)]
-    [InlineData("class A { public int num; } class B { public A a; } B myVar = new B(); myVar.a = new A(); myVar.a.num = 3; return myVar.a.num + 1;", 4)]
-    [InlineData("class A { public int a; public int b; } A myVar = new A(); myVar.a = 3; myVar.b = myVar.a + 3; return myVar.b;", 6)]
-    [InlineData("class A { public int a; public int b; } A myVar = new A(); myVar.a = 3; myVar.b = myVar.a + 3; return myVar.a;", 3)]
-    [InlineData("class A { public int num; } A myVar; int a = myVar?.num; return a;", null)]
-    [InlineData("class A { public int num; } A myVar = new A(); myVar.num = 7; int a = myVar?.num; return a;", 7)]
-    [InlineData("class A { public static int a = 3; } return A.a;", 3)]
-    [InlineData("class A { public static int a = 3; static constructor() { a = 10; } } return A.a;", 10)]
-    [InlineData("class A { public static int a = 3; } A.a = 20; return A.a;", 20)]
+    [InlineData("class A { public int? num; } A myVar = new A(); myVar.num = 3; return myVar.num + 1;", 4)]
+    [InlineData("class A { public int? num; } class B { public A a; } B myVar = new B(); myVar.a = new A(); myVar.a.num = 3; return myVar.a.num + 1;", 4)]
+    [InlineData("class A { public int? a; public int? b; } A myVar = new A(); myVar.a = 3; myVar.b = myVar.a + 3; return myVar.b;", 6)]
+    [InlineData("class A { public int? a; public int? b; } A myVar = new A(); myVar.a = 3; myVar.b = myVar.a + 3; return myVar.a;", 3)]
+    [InlineData("class A { public int? num; } A myVar; int? a = myVar?.num; return a;", null)]
+    [InlineData("class A { public int? num; } A myVar = new A(); myVar.num = 7; int? a = myVar?.num; return a;", 7)]
+    [InlineData("class A { public static int? a = 3; } return A.a;", 3)]
+    [InlineData("class A { public static int? a = 3; static constructor() { a = 10; } } return A.a;", 10)]
+    [InlineData("class A { public static int? a = 3; } A.a = 20; return A.a;", 20)]
+    [InlineData("struct A { public int a; } var a = new A(); return a.a;", 0)]
+    [InlineData("struct A { public int? a; } var a = new A(); return a.a;", null)]
+    [InlineData("struct A { public int a; } A? a; a = new A(); return a.a;", 0)]
+    [InlineData("struct A { public int a; } A? a; return a?.a;", null)]
+    [InlineData("class A { public int a; } A? a; return a?.a;", null)]
     // This expression
-    [InlineData("class A { public int a; public void SetA(int a) { this.a = 1; this.a = a; } public int GetA() { return a; } } var myA = new A(); myA.SetA(3); return myA.GetA();", 3)]
-    [InlineData("class A { public int a; public void SetA(int a) { this.a = 1; a = a; } public int GetA() { return a; } } var myA = new A(); myA.SetA(3); return myA.GetA();", 1)]
-    [InlineData("class A { public int M() { return 1; } public int N() { int M() { return 2; } return M(); } } var myVar = new A(); return myVar.N();", 2)]
-    [InlineData("class A { public int M() { return 1; } public int N() { int M() { return 2; } return this.M(); } } var myVar = new A(); return myVar.N();", 1)]
+    [InlineData("class A { public int? a; public void SetA(int? a) { this.a = 1; this.a = a; } public int? GetA() { return a; } } var myA = new A(); myA.SetA(3); return myA.GetA();", 3)]
+    [InlineData("class A { public int? a; public void SetA(int? a) { this.a = 1; a = a; } public int? GetA() { return a; } } var myA = new A(); myA.SetA(3); return myA.GetA();", 1)]
+    [InlineData("class A { public int? M() { return 1; } public int? N() { int? M() { return 2; } return M(); } } var myVar = new A(); return myVar.N();", 2)]
+    [InlineData("class A { public int? M() { return 1; } public int? N() { int? M() { return 2; } return this.M(); } } var myVar = new A(); return myVar.N();", 1)]
     // Static member access
-    [InlineData("class A { public constexpr int a = 3; } return A.a;", 3)]
-    [InlineData("class A { public constexpr int a; } return A.a;", null)]
-    [InlineData("class A { public static int B() { return 0; } } return A.B();", 0)]
-    [InlineData("class A { public static int B(int a) { return a + 3; } } return A.B(4);", 7)]
+    [InlineData("class A { public constexpr int? a = 3; } return A.a;", 3)]
+    [InlineData("class A { public constexpr int? a; } return A.a;", null)]
+    [InlineData("class A { public static int? B() { return 0; } } return A.B();", 0)]
+    [InlineData("class A { public static int? B(int a) { return a + 3; } } return A.B(4);", 7)]
     // Structs
     [InlineData("struct A { public int! a; } var a = new A(); a.a = 4; var b = a; b.a = 10; return a.a;", 4)]
     // If statements
-    [InlineData("int a = 0; if (a == 0) { a = 10; } return a;", 10)]
-    [InlineData("int a = 0; if (a == 4) { a = 10; } return a;", 0)]
-    [InlineData("int a = 0; if (a == 0) { a = 10; } else { a = 5; } return a;", 10)]
-    [InlineData("int a = 0; if (a == 4) { a = 10; } else { a = 5; } return a;", 5)]
+    [InlineData("int? a = 0; if (a == 0) { a = 10; } return a;", 10)]
+    [InlineData("int? a = 0; if (a == 4) { a = 10; } return a;", 0)]
+    [InlineData("int? a = 0; if (a == 0) { a = 10; } else { a = 5; } return a;", 10)]
+    [InlineData("int? a = 0; if (a == 4) { a = 10; } else { a = 5; } return a;", 5)]
     // Null-Binding statements
-    [InlineData("int a = 10; int! b = 0; if (a -> x!) { b = x; } return b;", 10)]
-    [InlineData("int a = null; int! b = 0; if (a -> x!) { b = x; } return b;", 0)]
+    [InlineData("int? a = 10; int! b = 0; if (a -> x!) { b = x; } return b;", 10)]
+    [InlineData("int? a = null; int! b = 0; if (a -> x!) { b = x; } return b;", 0)]
     // Local function statements
-    [InlineData("int A() { int B() { return 2; } return B() + 1; } return A();", 3)]
-    [InlineData("int A() { int B() { int A() { return 2; } return A() + 1; } return B() + 1; } return A();", 4)]
-    [InlineData("int A() { int a = 1; int B(int b) { return a + b; } return B(4); } return A();", 5)]
-    [InlineData("int A() { int a = 5; int B(int b) { return a + b; } return B(1); } return A();", 6)]
-    [InlineData("int A() { int a = 5; void B() { a = 6; } B(); return a; } return A();", 6)]
+    [InlineData("int? A() { int? B() { return 2; } return B() + 1; } return A();", 3)]
+    [InlineData("int? A() { int? B() { int? A() { return 2; } return A() + 1; } return B() + 1; } return A();", 4)]
+    [InlineData("int? A() { int? a = 1; int? B(int? b) { return a + b; } return B(4); } return A();", 5)]
+    [InlineData("int? A() { int? a = 5; int? B(int? b) { return a + b; } return B(1); } return A();", 6)]
+    [InlineData("int? A() { int? a = 5; void B() { a = 6; } B(); return a; } return A();", 6)]
     // Block statements and return statements
-    [InlineData("{ int a = 3; return a; }", 3)]
-    [InlineData("int a = 5; { a = 3; return a; }", 3)]
-    [InlineData("int a = 5; { a = 3; } return a;", 3)]
-    [InlineData("int a = 5; { int b = 3 + a; return b; } return a;", 8)]
+    [InlineData("{ int? a = 3; return a; }", 3)]
+    [InlineData("int? a = 5; { a = 3; return a; }", 3)]
+    [InlineData("int? a = 5; { a = 3; } return a;", 3)]
+    [InlineData("int? a = 5; { int? b = 3 + a; return b; } return a;", 8)]
     // Constructors
     [InlineData("class A { public constructor() { } }", null)]
-    [InlineData("class A { public int a; public constructor(int b) { a = b; } } var myVar = new A(6); return myVar.a;", 6)]
-    [InlineData("class A { public int a; public constructor(int b) { a = b; } public constructor(int b, int c) { a = b + c; } } var myVar = new A(6); return myVar.a;", 6)]
-    [InlineData("class A { public int a; public constructor(int b) { a = b; } public constructor(int b, int c) { a = b + c; } } var myVar = new A(6, 1); return myVar.a;", 7)]
+    [InlineData("class A { public int? a; public constructor(int? b) { a = b; } } var myVar = new A(6); return myVar.a;", 6)]
+    [InlineData("class A { public int? a; public constructor(int? b) { a = b; } public constructor(int? b, int? c) { a = b + c; } } var myVar = new A(6); return myVar.a;", 6)]
+    [InlineData("class A { public int? a; public constructor(int? b) { a = b; } public constructor(int? b, int? c) { a = b + c; } } var myVar = new A(6, 1); return myVar.a;", 7)]
     // For statements
-    [InlineData("int result = 1; for (int i = 0; i <= 10; i++) { result += result; } return result;", 2048)]
-    [InlineData("int result = 0; for (int i = 0; i < 5; i++) { result++; } return result;", 5)]
-    [InlineData("int result; for (int i = 0; i <= 10; i++) { result = i; } return result;", 10)]
-    [InlineData("int result = 1; for (int i = 10; i > 0; i--) { result += i; } return result;", 56)]
+    [InlineData("int? result = 1; for (int? i = 0; i <= 10; i++) { result += result; } return result;", 2048)]
+    [InlineData("int? result = 0; for (int? i = 0; i < 5; i++) { result++; } return result;", 5)]
+    [InlineData("int? result; for (int? i = 0; i <= 10; i++) { result = i; } return result;", 10)]
+    [InlineData("int? result = 1; for (int? i = 10; i > 0; i--) { result += i; } return result;", 56)]
     // While statements
-    [InlineData("int i = 0; int result = 1; while (i <= 10) { result += result; i++; } return result;", 2048)]
-    [InlineData("int i = 0; int result = 0; while (i < 5) { result++; i++; } return result;", 5)]
-    [InlineData("int i = 0; int result; while (i <= 10) { result = i; i++; } return result;", 10)]
-    [InlineData("int i = 10; int result = 1; while (i > 0) { result += i; i--; } return result;", 56)]
+    [InlineData("int? i = 0; int? result = 1; while (i <= 10) { result += result; i++; } return result;", 2048)]
+    [InlineData("int? i = 0; int? result = 0; while (i < 5) { result++; i++; } return result;", 5)]
+    [InlineData("int? i = 0; int? result; while (i <= 10) { result = i; i++; } return result;", 10)]
+    [InlineData("int? i = 10; int? result = 1; while (i > 0) { result += i; i--; } return result;", 56)]
     // Do-While statements
-    [InlineData("int result = 0; do { result++; } while (result < 10); return result;", 10)]
-    [InlineData("int result = 0; do { result++; } while (false); return result;", 1)]
-    [InlineData("int result = 0; do { result++; } while (result < 0); return result;", 1)]
-    [InlineData("int result = 10; do { result*=2; } while (result < 30); return result;", 40)]
+    [InlineData("int? result = 0; do { result++; } while (result < 10); return result;", 10)]
+    [InlineData("int? result = 0; do { result++; } while (false); return result;", 1)]
+    [InlineData("int? result = 0; do { result++; } while (result < 0); return result;", 1)]
+    [InlineData("int? result = 10; do { result*=2; } while (result < 30); return result;", 40)]
     // Break statements
-    [InlineData("int result = 3; for (int i = 0; i < 10; i++) { result++; if (result == 5) break; } return result;", 5)]
-    [InlineData("int result = 3; for (int i = 0; i < 10; i++) { result++; if (result < 5) break; } return result;", 4)]
-    [InlineData("int result = 3; while (true) { result++; if (result == 5) break; } return result;", 5)]
-    [InlineData("int result = 3; while (true) { result++; if (result > 5) break; } return result;", 6)]
+    [InlineData("int? result = 3; for (int? i = 0; i < 10; i++) { result++; if (result == 5) break; } return result;", 5)]
+    [InlineData("int? result = 3; for (int? i = 0; i < 10; i++) { result++; if (result < 5) break; } return result;", 4)]
+    [InlineData("int? result = 3; while (true) { result++; if (result == 5) break; } return result;", 5)]
+    [InlineData("int? result = 3; while (true) { result++; if (result > 5) break; } return result;", 6)]
     // Continue statements
-    [InlineData("var cond = false; int res = 3; while (true) { if (cond) continue; else break; res = 4; } return res;", 3)]
-    [InlineData("var cond = false; int res = 3; while (true) { if (cond) continue; res = 4; if (res == 4) break; } return res;", 4)]
-    [InlineData("var cond = true; int res = 3; while (true) { if (cond) ; else continue; res = 4; if (res == 4) break; } return res;", 4)]
-    [InlineData("var cond = true; int res = 3; while (true) { if (cond) break; else continue; res = 4; } return res;", 3)]
+    [InlineData("var? cond = false; int? res = 3; while (true) { if (cond) continue; else break; res = 4; } return res;", 3)]
+    [InlineData("var? cond = false; int? res = 3; while (true) { if (cond) continue; res = 4; if (res == 4) break; } return res;", 4)]
+    [InlineData("var? cond = true; int? res = 3; while (true) { if (cond) ; else continue; res = 4; if (res == 4) break; } return res;", 4)]
+    [InlineData("var? cond = true; int? res = 3; while (true) { if (cond) break; else continue; res = 4; } return res;", 3)]
     // Libraries
     [InlineData("class A { } var a = new A(); return a.ToString();", "A")]
-    [InlineData("class A { public override string ToString() { return \"a\"; } } var a = new A(); return a.ToString();", "a")]
+    [InlineData("class A { public override string? ToString() { return \"a\"; } } var a = new A(); return a.ToString();", "a")]
     [InlineData("any[] a = {1, 2, 3}; return LowLevel.Length<any[]>(a);", 3)]
     // TypeOf expressions
     [InlineData("lowlevel { type a = typeof(int[]); }", null)]
-    [InlineData("type a = typeof(string);", null)]
-    [InlineData("type a = typeof(decimal!);", null)]
-    [InlineData("class A { public int num; } type a = typeof(A);", null)]
+    [InlineData("type? a = typeof(string);", null)]
+    [InlineData("type? a = typeof(decimal!);", null)]
+    [InlineData("class A { public int? num; } type? a = typeof(A);", null)]
     [InlineData("return typeof(int) == typeof(int);", true)]
+    [InlineData("return typeof(int) == typeof(int!);", true)]
+    [InlineData("return typeof(int?) == typeof(int?);", true)]
+    [InlineData("return typeof(int?) == typeof(int);", false)]
     [InlineData("return typeof(int) == typeof(bool);", false)]
-    [InlineData("class C<type T> { public bool M() { return typeof(T) == typeof(int); } } var c = new C<int>(); return c.M();", true)]
-    [InlineData("class C<type T> where { T is notnull; } { public bool M() { return typeof(T) == typeof(int); } } var c = new C<int>(); return c.M();", false)]
-    [InlineData("class C<type T> { public bool M() { return typeof(T) == typeof(int); } } var c = new C<bool>(); return c.M();", false)]
-    [InlineData("bool C<type T>() { return typeof(T) == typeof(int); } return C<int>();", true)]
-    [InlineData("bool C<type T>() { return typeof(T) == typeof(int); } return C<bool>();", false)]
+    [InlineData("class C<type T> { public bool? M() { return typeof(T) == typeof(int?); } } var c = new C<int?>(); return c.M();", true)]
+    [InlineData("class C<type T> where { T is notnull; } { public bool? M() { return typeof(T) == typeof(int?); } } var c = new C<int?>(); return c.M();", false)]
+    [InlineData("class C<type T> { public bool? M() { return typeof(T) == typeof(int?); } } var c = new C<bool?>(); return c.M();", false)]
+    [InlineData("bool? C<type T>() { return typeof(T) == typeof(int?); } return C<int?>();", true)]
+    [InlineData("bool? C<type T>() { return typeof(T) == typeof(int?); } return C<bool?>();", false)]
     // Operators
     [InlineData(@"
         class A {
-            public int a;
-            public constructor(int a) { this.a = a; }
-            public static int operator+(A a) { return a.a; }
-            public static int operator+(A a, int b) { return a.a + b; }
+            public int? a;
+            public constructor(int? a) { this.a = a; }
+            public static int? operator+(A a) { return a.a; }
+            public static int? operator+(A a, int? b) { return a.a + b; }
         }
 
         var a = new A(3);
         return a + 5;", 8)]
     [InlineData(@"
         class A {
-            public int[] a = { 1, 2, 3 };
-            public static ref int operator[](A a, int b) {
+            public int?[] a = { 1, 2, 3 };
+            public static ref int? operator[](A a, int? b) {
                 return ref a.a[b];
             }
         }
@@ -407,8 +418,8 @@ public sealed class EvaluatorTests {
         return a[1] + a[0];", 4)]
     [InlineData(@"
         class A {
-            public int a;
-            public static implicit operator A(int b) {
+            public int? a;
+            public static implicit operator A(int? b) {
                 var c = new A();
                 c.a = b;
                 return c;
@@ -420,30 +431,30 @@ public sealed class EvaluatorTests {
     // Overrides
     [InlineData(@"
         class A {
-            public virtual string M() { return ""A""; }
-            public string T() { return M(); }
+            public virtual string? M() { return ""A""; }
+            public string? T() { return M(); }
         }
 
         class B extends A {
-            public override string M() { return ""B""; }
+            public override string? M() { return ""B""; }
         }
 
         var b = new B();
         return b.T();", "B")]
-    [InlineData("lowlevel class A { public int[] b = { 1, 2, 3 }; } var a = new A(); ref var r = ref a.b; r[0]++; return a.b[0];", 2)]
+    [InlineData("lowlevel class A { public int?[] b = { 1, 2, 3 }; } var a = new A(); ref var r = ref a.b; r[0]++; return a.b[0];", 2)]
     // Try statements
-    [InlineData("try { int x = 0; int a = 56/x; return a; } catch { return 3; }", 3)]
-    [InlineData("try { int a = 56/1; return a; } catch { return 3; }", 56)]
-    [InlineData("int a = 3; try { int x = 0; int b = 56/x; a += b; return a; } catch { a += 3; return a; } finally { a++; }", 6)]
-    [InlineData("int a = 3; try { int b = 56/1; a += b; return a; } catch { a += 3; return a; } finally { a++; }", 59)]
+    [InlineData("try { int? x = 0; int? a = 56/x; return a; } catch { return 3; }", 3)]
+    [InlineData("try { int? a = 56/1; return a; } catch { return 3; }", 56)]
+    [InlineData("int? a = 3; try { int? x = 0; int? b = 56/x; a += b; return a; } catch { a += 3; return a; } finally { a++; }", 6)]
+    [InlineData("int? a = 3; try { int? b = 56/1; a += b; return a; } catch { a += 3; return a; } finally { a++; }", 59)]
     // Switch statements
-    [InlineData("var a = 3; int b = 1; switch (a) { case 3: b = 5; } return b;", 5)]
-    [InlineData("var a = 3; int b = 1; switch (a) { case 4: b = 5; } return b;", 1)]
-    [InlineData("var a = 3; int b = 1; switch (a) { case 3: goto case 5; case 5: goto default; default: b = 6; } return b;", 6)]
-    [InlineData("var a = 3; int b = 1; switch (a) { case 1: case 2: case 3: case 4: b = 6; } return b;", 6)]
+    [InlineData("var? a = 3; int? b = 1; switch (a) { case 3: b = 5; } return b;", 5)]
+    [InlineData("var? a = 3; int? b = 1; switch (a) { case 4: b = 5; } return b;", 1)]
+    [InlineData("var? a = 3; int? b = 1; switch (a) { case 3: goto case 5; case 5: goto default; default: b = 6; } return b;", 6)]
+    [InlineData("var? a = 3; int? b = 1; switch (a) { case 1: case 2: case 3: case 4: b = 6; } return b;", 6)]
     // String interpolation
-    [InlineData("var a = 3; return f\"a is {a}\";", "a is 3")]
-    [InlineData("int a = null; return f\"a is {a}\";", "a is ")]
+    [InlineData("var? a = 3; return f\"a is {a}\";", "a is 3")]
+    [InlineData("int? a = null; return f\"a is {a}\";", "a is ")]
     [InlineData("return f\"a is {null}\";", "a is ")]
     [InlineData("List<int> a = null; return f\"a is {a}\";", "a is ")]
     [InlineData("class A { public override string ToString() { return \"text\"; } } A a = new A(); return f\"a is {a}\";", "a is text")]
@@ -455,22 +466,23 @@ public sealed class EvaluatorTests {
     // [InlineData("lowlevel int[] Test<int[] a>() { return a; } lowlevel { return Test<{1, 2, 3}>()[1]; }", 2)]
     // [InlineData("lowlevel { int[] Test<int[] a>() { return a; } return Test<{1, 2, 3}>()[1]; }", 2)]
     [InlineData("class A<type t> { public t a; } var a = new A<string>(); a.a = \"test\"; return a.a;", "test")]
-    [InlineData("class A<type t> { public t a; } lowlevel { var a = new A<int[]>(); a.a = new int[] {1, 2, 3}; return a.a[1]; }", 2)]
-    [InlineData("class A<type t> { }; var a = new A<A<int>>();", null)]
-    [InlineData("T Test<type T>(T a) { return a; } return Test<int>(3);", 3)]
-    [InlineData("T Test<type T>() { return null; } return Test<int>();", null)]
+    [InlineData("class A<type t> { public t a; } lowlevel { var a = new A<int?[]>(); a.a = new int?[] {1, 2, 3}; return a.a[1]; }", 2)]
+    [InlineData("class A<type t> { }; var a = new A<A<int?>>();", null)]
+    [InlineData("T Test<type T>(T a) { return a; } return Test<int?>(3);", 3)]
+    [InlineData("T Test<type T>() { return default; } return Test<int?>();", null)]
+    [InlineData("T Test<type T>() { return default; } return Test<int>();", 0)]
     // Misc for coverage
-    [InlineData("using H = int; H myVar = 3; return myVar;", 3)]
+    [InlineData("using H = int?; H myVar = 3; return myVar;", 3)]
     [InlineData("enum A { q, w, e, r, t } return A.t;", 4)]
     [InlineData("enum flags A { q, w, e, r, t } return A.t;", 8)]
     [InlineData("enum A { q, w, e, r, t } A a = .t; return (int)a;", 4)]
-    [InlineData("class P { int a = 3; public int M(int a) { return a; } } var myP = new P(); return myP.M(4);", 4)]
-    [InlineData("class P { public int M(int a, int b) { return a + b; } public int M(int a) { return a; } } var myP = new P(); return myP.M(4, 5);", 9)]
-    [InlineData("class P { public static T M<type T>() { T a = null; return a; } } return P.M<int>();", null)]
+    [InlineData("class P { int? a = 3; public int? M(int? a) { return a; } } var myP = new P(); return myP.M(4);", 4)]
+    [InlineData("class P { public int? M(int? a, int? b) { return a + b; } public int? M(int? a) { return a; } } var myP = new P(); return myP.M(4, 5);", 9)]
+    [InlineData("class P { public static T M<type T>() { T a = default; return a; } } return P.M<int?>();", null)]
     // TODO these crash
     // [InlineData("class P { public static T M<type T>(T b) { T a = b; L(); return a; void L() { a = null; } } } return P.M<int>(3);", null)]
     // [InlineData("class P { public static T M<type T>(T b) { T a = b; L<bool>(); return a; void L<type T2>() { a = null; } } } return P.M<int>();", null)]
-    [InlineData("static class P { [DllImport(\"kernel32.dll\")]static extern int64* GetModuleHandle(string lpModuleName); } return null;", null)]
+    [InlineData("static class P { [DllImport(\"kernel32.dll\")]static extern int64* GetModuleHandle(string? lpModuleName); } return null;", null)]
     [InlineData("static class P { [DllImport(\"msvcrt.dll\", CallingConvention: CallingConvention.Cdecl)]static extern void* memcpy(void* dest, void* src, uint64 count); } return null;", null)]
     [InlineData(@"
     struct A { B b; }
@@ -501,7 +513,7 @@ public sealed class EvaluatorTests {
     ", 0)]
     [InlineData(@"
     class A {
-        public int a;
+        public int? a;
     }
 
     A a = new A();
@@ -510,7 +522,7 @@ public sealed class EvaluatorTests {
     ", 3)]
     [InlineData(@"
     class A {
-        public int a;
+        public int? a;
         public A b;
     }
 
@@ -520,7 +532,7 @@ public sealed class EvaluatorTests {
     ", null)]
     [InlineData(@"
     class A {
-        public int a;
+        public int? a;
         public void M() { a = 5; }
     }
 
@@ -529,7 +541,7 @@ public sealed class EvaluatorTests {
     ", 5)]
     [InlineData(@"
     class A {
-        public int a;
+        public int? a;
         public void M() { a = 5; }
     }
 
@@ -539,7 +551,7 @@ public sealed class EvaluatorTests {
     ", null)]
     [InlineData(@"
     class A {
-        public int a;
+        public int? a;
         public A b;
     }
 
@@ -547,12 +559,12 @@ public sealed class EvaluatorTests {
     return a.b.a;
     ", 4)]
     [InlineData(@"
-    int[][] a = null;
+    int?[][] a = null;
     a?[0]?[0] = 5;
     return a?[0]?[0];
     ", null)]
     [InlineData(@"
-    int[][] a = { { 1 } };
+    int?[][] a = { { 1 } };
     a?[0]?[0] = 5;
     return a?[0]?[0];
     ", 5)]

--- a/src/Buckle/Compiler.Tests/CodeAnalysis/Evaluating/EvaluatorTests.cs
+++ b/src/Buckle/Compiler.Tests/CodeAnalysis/Evaluating/EvaluatorTests.cs
@@ -160,6 +160,7 @@ public sealed class EvaluatorTests {
     [InlineData("string? a = null; return a?;", "")]
     [InlineData("bool? a = true; return a?;", true)]
     [InlineData("bool? a = null; return a?;", false)]
+    [InlineData("return ~((uint64)1 << 7);", 18446744073709551487)]
     // Compound assignments
     [InlineData("var? a = 1; a += (2 + 3); return a;", 6)]
     [InlineData("var? a = 1; a -= (2 + 3); return a;", -4)]
@@ -203,6 +204,12 @@ public sealed class EvaluatorTests {
     [InlineData("int a = default; return a;", 0)]
     [InlineData("int? a = default; return a;", null)]
     [InlineData("int[][] a; a = new int[][] { { 1 } }; return a[0][0];", 1)]
+    [InlineData("uint64 a = 3; var b = 1 + a; return LowLevel.GetType(b) == typeof(uint64);", true)]
+    [InlineData("uint64 a = 3; var b = 1 + a; return LowLevel.GetType(a) == LowLevel.GetType(b);", true)]
+    [InlineData("return typeof(int) == typeof(int64);", true)]
+    [InlineData("return typeof(int32) == typeof(int64);", false)]
+    [InlineData("return typeof(decimal) == typeof(float64);", true)]
+    [InlineData("return typeof(float32) == typeof(float64);", false)]
     // Name expressions
     [InlineData("int? a = 3; int? b = 6; return a;", 3)]
     [InlineData("int? a = 3; int? b = 6; return b;", 6)]
@@ -389,6 +396,7 @@ public sealed class EvaluatorTests {
     [InlineData("return typeof(int?) == typeof(int?);", true)]
     [InlineData("return typeof(int?) == typeof(int);", false)]
     [InlineData("return typeof(int) == typeof(bool);", false)]
+    [InlineData("return typeof(int*) == typeof(int64*);", true)]
     [InlineData("class C<type T> { public bool? M() { return typeof(T) == typeof(int?); } } var c = new C<int?>(); return c.M();", true)]
     [InlineData("class C<type T> where { T is notnull; } { public bool? M() { return typeof(T) == typeof(int?); } } var c = new C<int?>(); return c.M();", false)]
     [InlineData("class C<type T> { public bool? M() { return typeof(T) == typeof(int?); } } var c = new C<bool?>(); return c.M();", false)]

--- a/src/Buckle/Compiler.Tests/Diagnostics/DiagnosticTests.cs
+++ b/src/Buckle/Compiler.Tests/Diagnostics/DiagnosticTests.cs
@@ -31,7 +31,7 @@ public sealed class DiagnosticTests {
     public void Reports_Warning_BU0002_NullDereference() {
         var text = @"
             class A {
-                public int num;
+                public int? num;
             }
 
             void MyFunc(A a) {
@@ -52,7 +52,7 @@ public sealed class DiagnosticTests {
     [Fact]
     public void Reports_Error_BU0004_InvalidType() {
         var text = @"
-            int x = [99999999999999999999];
+            int? x = [99999999999999999999];
         ";
 
         var diagnostics = @"
@@ -91,7 +91,7 @@ public sealed class DiagnosticTests {
     [Fact]
     public void Reports_Error_BU0007_CannotConvertImplicitly() {
         var text = @"
-            string x = [3];
+            string? x = [3];
         ";
 
         var diagnostics = @"
@@ -130,7 +130,7 @@ public sealed class DiagnosticTests {
     [Fact]
     public void Reports_Error_BU0010_NamedArgumentTwice() {
         var text = @"
-            void F(int x) { }
+            void F(int? x) { }
             F(x: 1, [x]: 3);
         ";
 
@@ -183,7 +183,7 @@ public sealed class DiagnosticTests {
 
             namespace [B::C] { }
 
-            int a = 3;
+            int? a = 3;
         ";
 
         var diagnostics = @"
@@ -196,7 +196,7 @@ public sealed class DiagnosticTests {
     [Fact]
     public void Reports_Error_BU0015_BadArgumentName() {
         var text = @"
-            void Test(string a) { }
+            void Test(string? a) { }
             Test([msg]: ""test"");
         ";
 
@@ -210,7 +210,7 @@ public sealed class DiagnosticTests {
     [Fact]
     public void Reports_Error_BU0016_MainAndGlobals() {
         var text = @"
-            int a = 3;
+            int? a = 3;
 
             void [Main]() { }
         ";
@@ -225,7 +225,7 @@ public sealed class DiagnosticTests {
     [Fact]
     public void Reports_Error_BU0017_UndefinedSymbol() {
         var text = @"
-            int x = [y];
+            int? x = [y];
         ";
 
         var diagnostics = @"
@@ -255,7 +255,7 @@ public sealed class DiagnosticTests {
     [Fact]
     public void Reports_Error_BU0019_NotAllPathsReturn() {
         var text = @"
-            int [myFunc]() { }
+            int? [myFunc]() { }
         ";
 
         var diagnostics = @"
@@ -269,10 +269,10 @@ public sealed class DiagnosticTests {
     public void Reports_Error_BU0020_CannotConvert() {
         var text = @"
             class A {
-                int num;
+                int? num;
             }
 
-            bool x = [new A()];
+            bool? x = [new A()];
         ";
 
         var diagnostics = @"
@@ -337,8 +337,8 @@ public sealed class DiagnosticTests {
     [Fact]
     public void Reports_Error_BU0025_CannotApplyIndexing() {
         var text = @"
-            int x = 3;
-            int y = [x\[0\]];
+            int? x = 3;
+            int? y = [x\[0\]];
         ";
 
         var diagnostics = @"
@@ -369,7 +369,7 @@ public sealed class DiagnosticTests {
     [Fact]
     public void Reports_Error_BU0027_UnterminatedString() {
         var text = @"
-            string x = [""];[]
+            string? x = [""];[]
         ";
 
         var diagnostics = @"
@@ -416,8 +416,8 @@ public sealed class DiagnosticTests {
     public void Reports_Error_BU0030_DuplicateConversion() {
         var text = @"
             class A {
-                public static implicit operator int(A a) { return 1; }
-                public static implicit [operator] int(A a) { return 1; }
+                public static implicit operator int?(A a) { return 1; }
+                public static implicit [operator] int?(A a) { return 1; }
             }
         ";
 
@@ -447,8 +447,8 @@ public sealed class DiagnosticTests {
     [Fact]
     public void Reports_Error_BU0032_CannotCallNonMethod() {
         var text = @"
-            int x = 3;
-            int y = [x]();
+            int? x = 3;
+            int? y = [x]();
         ";
 
         var diagnostics = @"
@@ -534,7 +534,7 @@ public sealed class DiagnosticTests {
     [Fact]
     public void Reports_Error_BU0038_MissingReturnValue() {
         var text = @"
-            int myFunc() {
+            int? myFunc() {
                 [return];
             }
         ";
@@ -608,7 +608,7 @@ public sealed class DiagnosticTests {
     public void Reports_Error_BU0044_ArrayInitWrongLength() {
         var text = @"
             lowlevel {
-                int\[\] x = new int\[4\] [{1, 2, 3}];
+                int?\[\] x = new int?\[4\] [{1, 2, 3}];
             }
         ";
 
@@ -666,8 +666,8 @@ public sealed class DiagnosticTests {
     [Fact]
     public void Reports_Error_BU0049_InitializeByReferenceWithByValue() {
         var text = @"
-            int x = 3;
-            [ref int y = x];
+            int? x = 3;
+            [ref int? y = x];
         ";
 
         var diagnostics = @"
@@ -680,8 +680,8 @@ public sealed class DiagnosticTests {
     [Fact]
     public void Reports_Error_BU0050_InitializeByValueWithByReference() {
         var text = @"
-            int x = 3;
-            [int y = ref x];
+            int? x = 3;
+            [int? y = ref x];
         ";
 
         var diagnostics = @"
@@ -740,7 +740,7 @@ public sealed class DiagnosticTests {
     public void Reports_Error_BU0056_ExpectedToken() {
         var text = @"
             class [{]
-                int num;
+                int? num;
             }
         ";
 
@@ -755,9 +755,9 @@ public sealed class DiagnosticTests {
     public void Reports_Error_BU0057_NoMethodOverload() {
         var text = @"
             class A {
-                public static void F(int a) { }
+                public static void F(int? a) { }
 
-                public static void F(string a) { }
+                public static void F(string? a) { }
             }
 
             A.[F](3, false);
@@ -774,9 +774,9 @@ public sealed class DiagnosticTests {
     public void Reports_Error_BU0058_AmbiguousMethodOverload() {
         var text = @"
             class A {
-                public static void myFunc(int a) { }
+                public static void myFunc(int? a) { }
 
-                public static void myFunc(string a) { }
+                public static void myFunc(string? a) { }
             }
 
             A.[myFunc](null);
@@ -827,7 +827,7 @@ public sealed class DiagnosticTests {
     public void Reports_Error_BU0061_NoSuchMember() {
         var text = @"
             class MyClass {
-                int a;
+                int? a;
             }
 
             var myVar = new MyClass();
@@ -871,20 +871,21 @@ public sealed class DiagnosticTests {
     // ! Error_BU0064_ConstantToNonConstantReference
     // Unreachable currently
 
-    [Fact]
-    public void Reports_Error_BU0065_CannotAnnotateStruct() {
-        var text = @"
-            struct A { }
-            [[A!] a];
-        ";
+    // ! Currently not enforced
+    // [Fact]
+    // public void Reports_Error_BU0065_CannotAnnotateStruct() {
+    //     var text = @"
+    //         struct A { }
+    //         [[A!] a];
+    //     ";
 
-        var diagnostics = @"
-            cannot use a non-nullable annotation on a struct type
-            non-nullable locals and class fields must have an initializer
-        ";
+    //     var diagnostics = @"
+    //         cannot use a nullable or non-nullable annotation on a struct type
+    //         non-nullable locals and class fields must have an initializer
+    //     ";
 
-        AssertDiagnostics(text, diagnostics, _writer);
-    }
+    //     AssertDiagnostics(text, diagnostics, _writer);
+    // }
 
     [Fact]
     public void Reports_Error_BU0066_IncorrectUnaryOperatorArgs() {
@@ -904,7 +905,7 @@ public sealed class DiagnosticTests {
     [Fact]
     public void Reports_Error_BU0067_ParameterAlreadySpecified() {
         var text = @"
-            void M(int x) { }
+            void M(int? x) { }
             M(x: 2, [x]: 2);
         ";
 
@@ -918,7 +919,7 @@ public sealed class DiagnosticTests {
     [Fact]
     public void Reports_Error_BU0068_DefaultMustBeConstant() {
         var text = @"
-            void MyFunc(int a = [Console.Input()]) { }
+            void MyFunc(int? a = [Console.Input()]) { }
         ";
 
         var diagnostics = @"
@@ -931,7 +932,7 @@ public sealed class DiagnosticTests {
     [Fact]
     public void Reports_Error_BU0069_DefaultBeforeNoDefault() {
         var text = @"
-            void MyFunc(int a = 3, int b[)] { }
+            void MyFunc(int? a = 3, int? b[)] { }
         ";
 
         var diagnostics = @"
@@ -972,7 +973,7 @@ public sealed class DiagnosticTests {
     [Fact]
     public void Reports_Error_BU0072_CannotImplyNull() {
         var text = @"
-            void MyFunc(int a, int! b) { }
+            void MyFunc(int? a, int! b) { }
 
             MyFunc(,[]);
         ";
@@ -1028,7 +1029,7 @@ public sealed class DiagnosticTests {
     [Fact]
     public void Reports_Error_BU0076_DivideByZero() {
         var text = @"
-            int myInt = [5 / 0];
+            int? myInt = [5 / 0];
         ";
 
         var diagnostics = @"
@@ -1072,7 +1073,7 @@ public sealed class DiagnosticTests {
     [Fact]
     public void Reports_Error_BU0080_PrimitivesDoNotHaveMembers() {
         var text = @"
-            int myInt = 3;
+            int? myInt = 3;
             [myInt.b];
         ";
 
@@ -1218,7 +1219,7 @@ public sealed class DiagnosticTests {
     public void Reports_Error_BU0091_CannotInitializeInStructs() {
         var text = @"
             struct A {
-                int num [=] 3;
+                int? num [=] 3;
             }
         ";
 
@@ -1282,7 +1283,7 @@ public sealed class DiagnosticTests {
     [Fact]
     public void Reports_Error_BU0095_RefReturnGlobal() {
         var text = @"
-            int a = 3; ref int b = ref a; ref int F() { return ref [b]; }
+            int? a = 3; ref int? b = ref a; ref int? F() { return ref [b]; }
         ";
 
         var diagnostics = @"
@@ -1313,7 +1314,7 @@ public sealed class DiagnosticTests {
     public void Reports_Error_BU0098_StaticConstructorParameter() {
         var text = @"
             static class A {
-                static [constructor](int a) { }
+                static [constructor](int? a) { }
             }
         ";
 
@@ -1370,7 +1371,7 @@ public sealed class DiagnosticTests {
     public void Reports_Error_BU0102_AssignmentInConstMethod() {
         var text = @"
             class A {
-                int a = 3;
+                int? a = 3;
                 const void B() {
                     [a]++;
                 }
@@ -1388,7 +1389,7 @@ public sealed class DiagnosticTests {
     public void Reports_Error_BU0103_NonConstantCallInConstant() {
         var text = @"
             class A {
-                int a = 3;
+                int? a = 3;
                 void B() {
                     a++;
                 }
@@ -1409,7 +1410,7 @@ public sealed class DiagnosticTests {
     public void Reports_Error_BU0104_NonConstantCallOnConstant() {
         var text = @"
             class A {
-                int a = 3;
+                int? a = 3;
                 public void B() {
                     a++;
                 }
@@ -1428,8 +1429,8 @@ public sealed class DiagnosticTests {
     [Fact]
     public void Reports_Error_BU0105_CannotBeRefAndConstexpr() {
         var text = @"
-            int x = 3;
-            constexpr ref int [y] = [ref x];
+            int? x = 3;
+            constexpr ref int? [y] = [ref x];
         ";
 
         var diagnostics = @"
@@ -1443,8 +1444,8 @@ public sealed class DiagnosticTests {
     [Fact]
     public void Reports_Error_BU0106_ConstantExpected() {
         var text = @"
-            int Test() { return 3; }
-            constexpr int y = [Test()];
+            int? Test() { return 3; }
+            constexpr int? y = [Test()];
         ";
 
         var diagnostics = @"
@@ -1502,7 +1503,7 @@ public sealed class DiagnosticTests {
     public void Reports_Error_BU0110_OperatorInStaticClass() {
         var text = @"
             static class A {
-                public static int operator[+](int a, int b) { return a; }
+                public static int? operator[+](int? a, int? b) { return a; }
             }
         ";
 
@@ -1516,8 +1517,8 @@ public sealed class DiagnosticTests {
     [Fact]
     public void Reports_Error_BU0111_RefReturnParameter2() {
         var text = @"
-            struct A { int f; }
-            ref int M(A a) {
+            struct A { int? f; }
+            ref int? M(A a) {
                 return ref [a].f;
             }
         ";
@@ -1595,7 +1596,7 @@ public sealed class DiagnosticTests {
     [Fact]
     public void Reports_Error_BU0119_RefReturnParameter() {
         var text = @"
-            ref int M(int a) {
+            ref int? M(int? a) {
                 return ref [a];
             }
         ";
@@ -1639,7 +1640,7 @@ public sealed class DiagnosticTests {
     [Fact]
     public void Reports_Error_BU0123_CannotExtendCheckNonType() {
         var text = @"
-            class A<int [T]> where { T extends Object; } { }
+            class A<int? [T]> where { T extends Object; } { }
         ";
 
         var diagnostics = @"
@@ -1652,7 +1653,7 @@ public sealed class DiagnosticTests {
     [Fact]
     public void Reports_Error_BU0124_ConstraintIsNotConstant() {
         var text = @"
-            class A<string a> where { [a == Console.Input()]; } { }
+            class A<string? a> where { [a == Console.Input()]; } { }
         ";
 
         var diagnostics = @"
@@ -1665,9 +1666,9 @@ public sealed class DiagnosticTests {
     [Fact]
     public void Reports_Error_BU0125_RefReturnNonreturnableLocal2() {
         var text = @"
-            struct C { int f; }
+            struct C { int? f; }
 
-            ref int A() {
+            ref int? A() {
                 C a = new C();
                 ref C b = ref a;
                 return ref [b].f;
@@ -1699,7 +1700,7 @@ public sealed class DiagnosticTests {
     [Fact]
     public void Reports_Error_BU0127_ConstraintWasNull() {
         var text = @"
-            class A<int a> where { a == 3; } { }
+            class A<int? a> where { a == 3; } { }
             var a = new [A<null>]();
         ";
 
@@ -1713,7 +1714,7 @@ public sealed class DiagnosticTests {
     [Fact]
     public void Reports_Error_BU0128_ConstraintFailed() {
         var text = @"
-            class A<int a> where { a == 3; } { }
+            class A<int? a> where { a == 3; } { }
             var a = new [A<4>]();
         ";
 
@@ -1727,9 +1728,9 @@ public sealed class DiagnosticTests {
     [Fact]
     public void Reports_Error_BU0129_RefReturnNonreturnableLocal() {
         var text = @"
-            ref int A() {
-                int a = 3;
-                ref int b = ref a;
+            ref int? A() {
+                int? a = 3;
+                ref int? b = ref a;
                 return ref [b];
             }
         ";
@@ -1744,9 +1745,9 @@ public sealed class DiagnosticTests {
     [Fact]
     public void Reports_Error_BU0130_RefReturnLocal2() {
         var text = @"
-            struct A { public int f; }
+            struct A { public int? f; }
 
-            ref int M() {
+            ref int? M() {
                 A a = new A();
                 return ref [a].f;
             }
@@ -1762,8 +1763,8 @@ public sealed class DiagnosticTests {
     [Fact]
     public void Reports_Error_BU0131_RefReturnLocal() {
         var text = @"
-            ref int A() {
-                int a = 3;
+            ref int? A() {
+                int? a = 3;
                 return ref [a];
             }
         ";
@@ -1909,7 +1910,7 @@ public sealed class DiagnosticTests {
     public void Reports_Error_BU0143_OperatorNeedsMatch() {
         var text = @"
             class A {
-                public static bool [operator]==(A x, A y) {
+                public static bool? [operator]==(A x, A y) {
                     return true;
                 }
             }
@@ -2079,7 +2080,7 @@ public sealed class DiagnosticTests {
     [Fact]
     public void Reports_Error_BU0155_CannotDeriveTemplate2() {
         var text = @"
-            class A<[type T], int T2> where { T extends T2; } { }
+            class A<[type T], int? T2> where { T extends T2; } { }
         ";
 
         var diagnostics = @"
@@ -2198,10 +2199,10 @@ public sealed class DiagnosticTests {
     public void Reports_Error_BU0163_LocalUsedBeforeDeclarationAndHidesField() {
         var text = @"
             class A {
-                int a;
+                int? a;
                 void F() {
-                    int b = [a] + 3;
-                    int a = 7;
+                    int? b = [a] + 3;
+                    int? a = 7;
                 }
             }
         ";
@@ -2218,8 +2219,8 @@ public sealed class DiagnosticTests {
         var text = @"
             class A {
                 void F() {
-                    int b = [a] + 3;
-                    int a = 7;
+                    int? b = [a] + 3;
+                    int? a = 7;
                 }
             }
         ";
@@ -2314,8 +2315,8 @@ public sealed class DiagnosticTests {
     public void Reports_Error_BU0171_MustNotHaveRefReturn() {
         var text = @"
             class A {
-                int f;
-                int F() {
+                int? f;
+                int? F() {
                     [return] ref f;
                 }
             }
@@ -2332,8 +2333,8 @@ public sealed class DiagnosticTests {
     public void Reports_Error_BU0172_MustHaveRefReturn() {
         var text = @"
             class A {
-                int f;
-                ref int F() {
+                int? f;
+                ref int? F() {
                     [return] f;
                 }
             }
@@ -2363,7 +2364,7 @@ public sealed class DiagnosticTests {
     [Fact]
     public void Reports_Error_BU0174_MethodGroupCannotBeUsedAsValue() {
         var text = @"
-            int F() { }
+            int? F() { }
             var a = [F];
         ";
 
@@ -2377,8 +2378,8 @@ public sealed class DiagnosticTests {
     [Fact]
     public void Reports_Error_BU0175_LocalShadowsParameter() {
         var text = @"
-            void F(int a) {
-                int [a] = 3;
+            void F(int? a) {
+                int? [a] = 3;
             }
         ";
 
@@ -2408,8 +2409,8 @@ public sealed class DiagnosticTests {
     public void Reports_Error_BU0177_LocalAlreadyDeclared() {
         var text = @"
             void F() {
-                int a = 3;
-                int [a] = 6;
+                int? a = 3;
+                int? [a] = 6;
             }
         ";
 
@@ -2423,7 +2424,7 @@ public sealed class DiagnosticTests {
     [Fact]
     public void Reports_Error_BU0178_CannotConvertArgument() {
         var text = @"
-            void F(int a) { }
+            void F(int? a) { }
             F([true]);
         ";
 
@@ -2437,7 +2438,7 @@ public sealed class DiagnosticTests {
     [Fact]
     public void Reports_Error_BU0179_CannotConvertImplicitlyNullable() {
         var text = @"
-            int a = 3;
+            int? a = 3;
             int! b = [a];
         ";
 
@@ -2485,9 +2486,9 @@ public sealed class DiagnosticTests {
     [Fact]
     public void Reports_Error_BU0182_ProgramLocalReferencedOutsideOfTopLevelStatement() {
         var text = @"
-            int a = 3;
+            int? a = 3;
             class A {
-                int f = [a];
+                int? f = [a];
             }
         ";
 
@@ -2595,8 +2596,8 @@ public sealed class DiagnosticTests {
     public void Reports_Error_BU0192_InstanceRequiredInFieldInitializer() {
         var text = @"
             class A {
-                int a = [F]();
-                int F() { return 3; }
+                int? a = [F]();
+                int? F() { return 3; }
             }
         ";
 
@@ -2612,7 +2613,7 @@ public sealed class DiagnosticTests {
         var text = @"
             void Outer() {
             void M(int a) { }
-            int a = 3;
+            int? a = 3;
             M([ref a]);
             }
         ";
@@ -2627,8 +2628,8 @@ public sealed class DiagnosticTests {
     [Fact]
     public void Reports_Error_BU0194_ArgumentWrongRef() {
         var text = @"
-            void M(ref int a) { }
-            int a = 3;
+            void M(ref int? a) { }
+            int? a = 3;
             M([a]);
         ";
 
@@ -2642,7 +2643,7 @@ public sealed class DiagnosticTests {
     [Fact]
     public void Reports_Error_BU0195_NoCorrespondingArgument() {
         var text = @"
-            void F(int a, int b) { }
+            void F(int? a, int? b) { }
             [F](a: 3);
         ";
 
@@ -2656,7 +2657,7 @@ public sealed class DiagnosticTests {
     [Fact]
     public void Reports_Error_BU0196_BadNonTrailingNamedArgument() {
         var text = @"
-            void F(int a, int b) { }
+            void F(int? a, int? b) { }
             F([b]: 3, 3);
         ";
 
@@ -2670,7 +2671,7 @@ public sealed class DiagnosticTests {
     [Fact]
     public void Reports_Error_BU0197_NamedArgumentUsedInPositional() {
         var text = @"
-            void F(int a, int b) { }
+            void F(int? a, int? b) { }
             F(3, [a]: 5);
         ";
 
@@ -2724,7 +2725,7 @@ public sealed class DiagnosticTests {
     [Fact]
     public void Reports_Error_BU0201_RefLocalOrParameterExpected() {
         var text = @"
-            int a = 3;
+            int? a = 3;
             [true ? 3 : 2] = ref a;
         ";
 
@@ -2738,7 +2739,7 @@ public sealed class DiagnosticTests {
     [Fact]
     public void Reports_Error_BU0202_RefLValueExpected() {
         var text = @"
-            ref int a = ref [3];
+            ref int? a = ref [3];
         ";
 
         var diagnostics = @"
@@ -2751,8 +2752,8 @@ public sealed class DiagnosticTests {
     [Fact]
     public void Reports_Error_BU0203_RefReturnLValueExpected() {
         var text = @"
-            int F() { return 3; }
-            ref int G() { return ref [F()]; }
+            int? F() { return 3; }
+            ref int? G() { return ref [F()]; }
         ";
 
         var diagnostics = @"
@@ -2783,7 +2784,7 @@ public sealed class DiagnosticTests {
     public void Reports_Error_BU0206_NonInvocableMemberCalled() {
         var text = @"
             class A {
-                constexpr int f;
+                constexpr int? f;
             }
             [A.f]();
         ";
@@ -2836,8 +2837,8 @@ public sealed class DiagnosticTests {
     public void Reports_Error_BU0218_RefReturnConstant() {
         var text = @"
             class A {
-                const int x = 3;
-                ref int F() {
+                const int? x = 3;
+                ref int? F() {
                     return ref [x];
                 }
             }
@@ -2854,11 +2855,11 @@ public sealed class DiagnosticTests {
     public void Reports_Error_BU0219_RefConstant() {
         var text = @"
             class A {
-                const int x = 3;
+                const int? x = 3;
                 void F() {
                     G(ref [x]);
                 }
-                void G(ref int a) { }
+                void G(ref int? a) { }
             }
         ";
 
@@ -2873,7 +2874,7 @@ public sealed class DiagnosticTests {
     public void Reports_Error_BU0220_AssignmentConstantField() {
         var text = @"
             class A {
-                const int x = 3;
+                const int? x = 3;
                 void F() {
                     [x] = 7;
                 }
@@ -2910,7 +2911,7 @@ public sealed class DiagnosticTests {
     [Fact]
     public void Reports_Error_BU0235_LocalSameNameAsTemplate() {
         var text = @"
-            void M<type T>(int [T]) { }
+            void M<type T>(int? [T]) { }
             ;
         ";
 
@@ -2924,7 +2925,7 @@ public sealed class DiagnosticTests {
     [Fact]
     public void Reports_Error_BU0236_DuplicateParameterName() {
         var text = @"
-            void F(int a, int [a]) {}
+            void F(int? a, int? [a]) {}
         ";
 
         var diagnostics = @"
@@ -3025,7 +3026,7 @@ public sealed class DiagnosticTests {
     [Fact]
     public void Reports_Error_BU0249_RefDefaultValue() {
         var text = @"
-            void F([ref] int a = 3) { }
+            void F([ref] int? a = 3) { }
         ";
 
         var diagnostics = @"
@@ -3038,7 +3039,7 @@ public sealed class DiagnosticTests {
     [Fact]
     public void Reports_Error_BU0250_NoCastForDefaultParameter() {
         var text = @"
-            void F(bool [a] = ""Test"") { }
+            void F(bool? [a] = ""Test"") { }
         ";
 
         var diagnostics = @"
@@ -3054,7 +3055,7 @@ public sealed class DiagnosticTests {
     public void Reports_Warning_BU0252_DefaultValueNoEffect() {
         var text = @"
             class A {
-                public static A operator+(A a, int [b] = 3) { return a; }
+                public static A operator+(A a, int? [b] = 3) { return a; }
             }
         ";
 
@@ -3086,7 +3087,7 @@ public sealed class DiagnosticTests {
     [Fact]
     public void Reports_Error_BU0257_CircularConstantValue() {
         var text = @"
-            constexpr int a = [[a]];
+            constexpr int? a = [[a]];
         ";
 
         var diagnostics = @"
@@ -3101,8 +3102,8 @@ public sealed class DiagnosticTests {
     public void Reports_Error_BU0258_DuplicateNameInClass() {
         var text = @"
             class A {
-                int a;
-                int [a];
+                int? a;
+                int? [a];
             }
         ";
 
@@ -3181,8 +3182,8 @@ public sealed class DiagnosticTests {
     public void Reports_Warning_BU0264_EqualityOpWithoutEquals() {
         var text = @"
             class [[A]] {
-                public static bool operator==(A a, A b) { return true; }
-                public static bool operator!=(A a, A b) { return false; }
+                public static bool? operator==(A a, A b) { return true; }
+                public static bool? operator!=(A a, A b) { return false; }
             }
         ";
 
@@ -3198,8 +3199,8 @@ public sealed class DiagnosticTests {
     public void Reports_Warning_BU0265_EqualityOpWithoutGetHashCode() {
         var text = @"
             class [[A]] {
-                public static bool operator==(A a, A b) { return true; }
-                public static bool operator!=(A a, A b) { return false; }
+                public static bool? operator==(A a, A b) { return true; }
+                public static bool? operator!=(A a, A b) { return false; }
             }
         ";
 
@@ -3450,11 +3451,11 @@ public sealed class DiagnosticTests {
     public void Reports_Error_BU0284_CantChangeRefReturnOnOverride() {
         var text = @"
             class A {
-                public virtual ref int M(ref int a) { return ref a; }
+                public virtual ref int? M(ref int? a) { return ref a; }
             }
 
             class B extends A {
-                public override int [M](ref int a) { return 3; }
+                public override int? [M](ref int? a) { return 3; }
             }
             ;
         ";
@@ -3473,7 +3474,7 @@ public sealed class DiagnosticTests {
                 public virtual void F() {}
             }
             class B extends A {
-                public override int [F]() { return 3; }
+                public override int? [F]() { return 3; }
             }
         ";
 
@@ -3531,7 +3532,7 @@ public sealed class DiagnosticTests {
     public void Reports_Error_BU0295_BadShiftOperatorSignature() {
         var text = @"
             class A {
-                public static A [operator]<<(int a, int b) { return null; }
+                public static A [operator]<<(int? a, int? b) { return null; }
             }
         ";
 
@@ -3549,7 +3550,7 @@ public sealed class DiagnosticTests {
     public void Reports_Error_BU0297_BadBinaryOperatorSignature() {
         var text = @"
             class A {
-                public static A [operator]+(int a, int b) { return null; }
+                public static A [operator]+(int? a, int? b) { return null; }
             }
         ";
 
@@ -3570,7 +3571,7 @@ public sealed class DiagnosticTests {
     public void Reports_Error_BU0300_BadIncrementOperatorSignature() {
         var text = @"
             class A {
-                public static A [operator]++(int a) { return null; }
+                public static A [operator]++(int? a) { return null; }
             }
         ";
 
@@ -3588,7 +3589,7 @@ public sealed class DiagnosticTests {
     public void Reports_Error_BU0302_BadIncrementReturnType() {
         var text = @"
             class A {
-                public static int [operator]++(A a) { return null; }
+                public static int? [operator]++(A a) { return null; }
             }
         ";
 
@@ -3667,7 +3668,7 @@ public sealed class DiagnosticTests {
     [Fact]
     public void Reports_Error_BU0309_BadArity2() {
         var text = @"
-            class A<int t> { }
+            class A<int? t> { }
             var a = new [A]();
         ";
 
@@ -3682,7 +3683,7 @@ public sealed class DiagnosticTests {
     public void Reports_Error_BU0310_ProtectedInStruct() {
         var text = @"
             struct A {
-                protected [int f];
+                protected [int? f];
             }
         ";
 
@@ -3743,7 +3744,7 @@ public sealed class DiagnosticTests {
     public void Reports_Error_BU0314_RefAssignReturnOnly() {
         var text = @"
             struct A {
-                protected [int f];
+                protected [int? f];
             }
         ";
 
@@ -3757,7 +3758,7 @@ public sealed class DiagnosticTests {
     [Fact]
     public void Reports_Error_BU0315_RefAssignNarrower() {
         var text = @"
-            void M(int a, ref int b) {
+            void M(int? a, ref int? b) {
                 [b = ref a];
             }
         ";
@@ -3924,7 +3925,7 @@ public sealed class DiagnosticTests {
     public void Reports_Error_BU0330_ObjectConstraintFailed() {
         var text = @"
             class A<type T> where { T extends Object; } {}
-            var a = new [A<int>]();
+            var a = new [A<int?>]();
         ";
 
         var diagnostics = @"
@@ -3967,7 +3968,7 @@ public sealed class DiagnosticTests {
     [Fact]
     public void Reports_Error_BU0334_CannotIsCheckNonType() {
         var text = @"
-            class A<int [T]> where { T is primitive; } { }
+            class A<int? [T]> where { T is primitive; } { }
         ";
 
         var diagnostics = @"
@@ -3980,7 +3981,7 @@ public sealed class DiagnosticTests {
     [Fact]
     public void Reports_Error_BU0335_CannotPassGlobalByRef() {
         var text = @"
-            ref int F(ref int a) { return ref a; } int b = 3; F([ref b]) = 6; return b;
+            ref int? F(ref int? a) { return ref a; } int? b = 3; F([ref b]) = 6; return b;
         ";
 
         var diagnostics = @"
@@ -4079,8 +4080,8 @@ public sealed class DiagnosticTests {
     [Fact]
     public void Reports_Error_BU0342_PtrExpected() {
         var text = @"
-            int a = 3;
-            int b = [*a];
+            int? a = 3;
+            int? b = [*a];
         ";
 
         var diagnostics = @"
@@ -4093,9 +4094,9 @@ public sealed class DiagnosticTests {
     [Fact]
     public void Reports_Error_BU0343_VoidPtr() {
         var text = @"
-            int a = 3;
+            int? a = 3;
             void* ptr = &a;
-            int b = [*ptr];
+            int? b = [*ptr];
         ";
 
         var diagnostics = @"
@@ -4108,7 +4109,7 @@ public sealed class DiagnosticTests {
     [Fact]
     public void Reports_Error_BU0344_CannotConvertConstantValue() {
         var text = @"
-            var a = (bool)[""asdf""];
+            var? a = (bool?)[""asdf""];
         ";
 
         var diagnostics = @"
@@ -4266,7 +4267,7 @@ public sealed class DiagnosticTests {
     public void Reports_Error_BU0355_IllegalFixedType() {
         var text = @"
             struct A {
-                [char] a\[30\];
+                [char?] a\[30\];
             }
         ";
 
@@ -4803,7 +4804,7 @@ public sealed class DiagnosticTests {
     public void Reports_Error_BU0394_LengthMustReturnInt() {
         var text = @"
             public class A {
-                public static bool [operator] length(A a) { return true; }
+                public static bool? [operator] length(A a) { return true; }
             }
         ";
 
@@ -4818,7 +4819,7 @@ public sealed class DiagnosticTests {
     public void Reports_Error_BU0395_IterMustReturnEnumerator() {
         var text = @"
             public class A {
-                public static bool [operator] iter(A a) { return true; }
+                public static bool? [operator] iter(A a) { return true; }
             }
         ";
 
@@ -4864,7 +4865,7 @@ public sealed class DiagnosticTests {
         var text = @"
             namespace A;
 
-            int [a] = 3;
+            int? [a] = 3;
         ";
 
         var diagnostics = @"
@@ -5009,7 +5010,7 @@ public sealed class DiagnosticTests {
     [Fact]
     public void Reports_Error_BU0408_BadReturnType() {
         var text = @"
-            int F() { return 3; }
+            int? F() { return 3; }
             void() a = [F];
         ";
 
@@ -5023,8 +5024,8 @@ public sealed class DiagnosticTests {
     [Fact]
     public void Reports_Error_BU0409_FunctionRefMismatch() {
         var text = @"
-            ref int F(ref int a) { return ref a; }
-            int(ref int) a = [F];
+            ref int? F(ref int? a) { return ref a; }
+            int?(ref int?) a = [F];
         ";
 
         var diagnostics = @"
@@ -5042,6 +5043,60 @@ public sealed class DiagnosticTests {
 
         var diagnostics = @"
             unrecognized calling convention 'asdf'; valid calling conventions are 'stdcall', 'winapi', 'fastcall', 'cdecl', and 'thiscall'
+        ";
+
+        AssertDiagnostics(text, diagnostics, _writer);
+    }
+
+    [Fact]
+    public void Reports_Error_BU0411_CannotAnnotatePointer() {
+        var text = @"
+            [int32*?] a;
+        ";
+
+        var diagnostics = @"
+            cannot use a nullable annotation on a pointer or function pointer type
+        ";
+
+        AssertDiagnostics(text, diagnostics, _writer);
+    }
+
+    [Fact]
+    public void Reports_Error_BU0412_CannotAnnotateTypeTemplate() {
+        var text = @"
+            class A<[type?] T> { }
+        ";
+
+        var diagnostics = @"
+            type template parameters cannot be nullable
+        ";
+
+        AssertDiagnostics(text, diagnostics, _writer);
+    }
+
+    [Fact]
+    public void Reports_Error_BU0413_CannotAnnotateTemplate() {
+        var text = @"
+            class A<type T> {
+                public [T!] a;
+            }
+        ";
+
+        var diagnostics = @"
+            cannot use a non-nullable annotation on a template parameter type
+        ";
+
+        AssertDiagnostics(text, diagnostics, _writer);
+    }
+
+    [Fact]
+    public void Reports_Error_BU0414_DefaultLiteralNoTargetType() {
+        var text = @"
+            var a = [default];
+        ";
+
+        var diagnostics = @"
+            there is no target type for the default literal
         ";
 
         AssertDiagnostics(text, diagnostics, _writer);

--- a/src/Buckle/Compiler.Tests/IssueTests.cs
+++ b/src/Buckle/Compiler.Tests/IssueTests.cs
@@ -44,7 +44,7 @@ public sealed class IssueTests {
     [Fact]
     public void Evaluator_VariableDeclaration_Reports_UndefinedSymbol() {
         var text = @"
-            ref int a = ref [b];
+            ref int? a = ref [b];
         ";
 
         var diagnostics = @"
@@ -95,8 +95,8 @@ public sealed class IssueTests {
     [Fact]
     public void Evaluator_CastExpression_Versus_ParenthesizedExpression() {
         var text = @"
-            int x = 3;
-            int y = (x) + 1;
+            int? x = 3;
+            int? y = (x) + 1;
             return y;
         ";
 
@@ -110,7 +110,7 @@ public sealed class IssueTests {
     public void Evaluator_ReferenceExpression_Reports_CannotConvert() {
         var text = @"
             class A {
-                public int num;
+                public int? num;
             }
 
             void MyFunction(A a) {
@@ -133,8 +133,8 @@ public sealed class IssueTests {
     [Fact]
     public void Evaluator_AssignmentExpression_Reports_CannotAssignConstReference() {
         var text = @"
-            int x = 3;
-            const ref int y = ref x;
+            int? x = 3;
+            const ref int? y = ref x;
             [y] = ref x;
         ";
 
@@ -178,7 +178,7 @@ public sealed class IssueTests {
     public void Evaluator_Classes_ReassignNull() {
         var text = @"
             class A {
-                public int num;
+                public int? num;
             }
 
             var x = new A();
@@ -204,7 +204,7 @@ public sealed class IssueTests {
     [Fact]
     public void Evaluator_CompoundExpression_Reports_Undefined() {
         var text = @"
-            var x = 10;
+            var? x = 10;
             [x += false];
         ";
 
@@ -232,7 +232,7 @@ public sealed class IssueTests {
     public void Evaluator_CompoundDeclarationExpression_Reports_CannotAssign() {
         var text = @"
             {
-                const int x = 10;
+                const int? x = 10;
                 [x] += 1;
             }
         ";
@@ -258,7 +258,7 @@ public sealed class IssueTests {
     [Fact]
     public void Evaluator_InvokeFunctionArguments_Missing() {
         var text = @"
-            void myFunc(int a) { }
+            void myFunc(int? a) { }
             [myFunc]();
         ";
 
@@ -272,7 +272,7 @@ public sealed class IssueTests {
     [Fact]
     public void Evaluator_InvokeFunctionArguments_Exceeding() {
         var text = @"
-            void myFunc(int a) { }
+            void myFunc(int? a) { }
             [myFunc](1, 2, 3);
         ";
 
@@ -286,7 +286,7 @@ public sealed class IssueTests {
     [Fact]
     public void Evaluator_FunctionParameters_NoInfiniteLoop() {
         var text = @"
-            void hi(string name=[)] {
+            void hi(string? name=[)] {
                 Console.PrintLine(""Hi "" + name + ""!"");
             }
         ";
@@ -301,7 +301,7 @@ public sealed class IssueTests {
     [Fact]
     public void Evaluator_FunctionReturn_Missing() {
         var text = @"
-            int [add](int a, int b) {
+            int? [add](int? a, int? b) {
             }
         ";
 
@@ -373,7 +373,7 @@ public sealed class IssueTests {
     [Fact]
     public void Evaluator_ForStatement_Reports_CannotConvert() {
         var text = @"
-            for (int i = 0; [i]; i++) {}
+            for (int? i = 0; [i]; i++) {}
         ";
 
         var diagnostics = @"
@@ -449,7 +449,7 @@ public sealed class IssueTests {
     [Fact]
     public void Evaluator_AssignmentExpression_Reports_Readonly() {
         var text = @"
-            const int x = 10;
+            const int? x = 10;
             [x] = 0;
         ";
 
@@ -463,7 +463,7 @@ public sealed class IssueTests {
     [Fact]
     public void Evaluator_AssignmentExpression_Reports_CannotConvert() {
         var text = @"
-            var x = 10;
+            var? x = 10;
             x = [false];
         ";
 
@@ -519,7 +519,7 @@ public sealed class IssueTests {
     [Fact]
     public void Evaluator_Function_ShouldNotReturnVoid() {
         var text = @"
-            int func() {
+            int? func() {
                 [return];
             }
         ";
@@ -570,7 +570,7 @@ public sealed class IssueTests {
     [Fact]
     public void Evaluator_Parameter_AlreadyDeclared() {
         var text = @"
-            void func(int a, int [a]) {}
+            void func(int? a, int? [a]) {}
         ";
 
         var diagnostics = @"
@@ -583,7 +583,7 @@ public sealed class IssueTests {
     [Fact]
     public void Evaluator_Function_WrongArgumentType() {
         var text = @"
-            void func(int a) {}
+            void func(int? a) {}
             func([false]);
         ";
 
@@ -636,7 +636,7 @@ public sealed class IssueTests {
     [Fact]
     public void Evaluator_Function_CanDeclare() {
         var text = @"
-            void myFunction(int num1, int num2) {
+            void myFunction(int? num1, int? num2) {
                 Console.Print(num1 + num2 / 3.14159);
             }
             myFunction(1, 2);
@@ -650,7 +650,7 @@ public sealed class IssueTests {
     [Fact]
     public void Evaluator_Function_CanCall() {
         var text = @"
-            void myFunction(int num) {
+            void myFunction(int? num) {
                 Console.Print(num ** 2);
             }
             myFunction(2);
@@ -715,8 +715,8 @@ public sealed class IssueTests {
     public void Evaluator_IndexExpression_NotTreatedAsTypeClause() {
         var text = @"
             lowlevel {
-                int a = 1;
-                int\[\] b = {1, 2, 3};
+                int? a = 1;
+                int?\[\] b = {1, 2, 3};
                 b\[a\] = 3;
             }
         ";
@@ -761,7 +761,7 @@ public sealed class IssueTests {
     [Fact]
     public void Evaluator_PostfixExpression_AllowedOnRef() {
         var text = @"
-            int x = 3;
+            int? x = 3;
             ref var y = ref x;
             y++;
         ";
@@ -802,8 +802,8 @@ public sealed class IssueTests {
     [Fact]
     public void Evaluator_Cast_CannotConvertConstRefToRef() {
         var text = @"
-            void Test(ref int a) { a++; }
-            const int a = 3;
+            void Test(ref int? a) { a++; }
+            const int? a = 3;
             Test(ref [a]);
         ";
 
@@ -818,7 +818,7 @@ public sealed class IssueTests {
     public void Evaluator_Assignment_HonorsConstantMemberAccess() {
         var text = @"
             class A {
-                public int a = 3;
+                public int? a = 3;
             }
             const a = new A();
             [a.a]++;
@@ -835,8 +835,8 @@ public sealed class IssueTests {
     public void Evaluator_MethodBody_StaticMethodCannotAccessMembers() {
         var text = @"
             class A {
-                int a;
-                static int Test() { return [a]; }
+                int? a;
+                static int? Test() { return [a]; }
             }
         ";
 
@@ -851,8 +851,8 @@ public sealed class IssueTests {
     public void Evaluator_MethodBody_StaticMethodCannotAccessMethods() {
         var text = @"
             class A {
-                int Test() { return 3; }
-                static int Test1() { return [Test](); }
+                int? Test() { return 3; }
+                static int? Test1() { return [Test](); }
             }
         ";
 
@@ -877,7 +877,7 @@ public sealed class IssueTests {
     [Fact]
     public void Evaluator_ReferenceExpression_NoInfiniteLoop() {
         var text = @"
-            ref int y;
+            ref int? y;
             y = ref y;
         ";
 
@@ -917,7 +917,7 @@ public sealed class IssueTests {
     [Fact]
     public void Evaluator_ClassDeclaration_StaticCanSeeTemplates() {
         var text = @"
-            class A<int a> {
+            class A<int? a> {
                 public static A<a> operator~(A<a> a) {
                     return a;
                 }
@@ -933,9 +933,9 @@ public sealed class IssueTests {
     public void Evaluator_OperatorOverloading_ReturnsCorrectType() {
         var text = @"
             class A<type t> {
-                public int v = 3;
+                public int? v = 3;
 
-                public static A<t> operator+(int a, A<t> b) {
+                public static A<t> operator+(int? a, A<t> b) {
                     b.v = 7;
                     return b;
                 }
@@ -957,7 +957,7 @@ public sealed class IssueTests {
                 T a;
             }
 
-            var a = new A<int>();
+            var a = new A<int?>();
             a.a = 3;
         ";
 
@@ -992,7 +992,7 @@ public sealed class IssueTests {
     [Fact]
     public void Evaluator_Template_TemplatesSeeConstraints() {
         var text = @"
-            string M<type T>(T x) where { T extends Object; } {
+            string? M<type T>(T x) where { T extends Object; } {
                 return x.ToString();
             }
         ";

--- a/src/Buckle/Compiler/CodeAnalysis/Binding/Binder.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Binding/Binder.cs
@@ -525,6 +525,8 @@ internal partial class Binder {
         switch (syntax.kind) {
             case SyntaxKind.NonNullableType:
                 return BindNonNullable();
+            case SyntaxKind.NullableType:
+                return BindNullable();
             case SyntaxKind.IdentifierName:
                 namespaceOrNonNullableType = BindNonTemplateSimpleNamespaceOrTypeOrAliasSymbol(
                     (IdentifierNameSyntax)syntax,
@@ -635,12 +637,15 @@ internal partial class Binder {
             // If we try to resolve hasNotNullConstraint while constraints are being bound we get a loop
             if (typeToCheck.type is TemplateParameterSymbol t &&
                 (basesBeingResolved is null || !basesBeingResolved.Contains(t))) {
-                if (t.hasNotNullConstraint)
-                    return typeToCheck;
+                // TODO Should we always keep non-nullable because it might be or lift T and use T!
+                // if (t.hasNotNullConstraint)
+                return typeToCheck;
             }
 
-            if (typeToCheck.specialType.IsLowLevelNumeric())
+            if (typeToCheck.specialType.IsPrimitiveType() &&
+                typeToCheck.specialType is not SpecialType.Array and not SpecialType.Any) {
                 return typeToCheck;
+            }
 
             return typeToCheck.SetIsAnnotated();
         }
@@ -651,12 +656,38 @@ internal partial class Binder {
             var nonNullableSyntax = (NonNullableTypeSyntax)syntax;
             var nullableType = BindType(nonNullableSyntax.type, diagnostics, basesBeingResolved);
 
-            if (nullableType.type.IsStructType()) {
-                diagnostics.Push(Error.CannotAnnotateStruct(syntax.location));
+            // if (nullableType.type.IsStructType()) {
+            //     diagnostics.Push(Error.CannotAnnotateStruct(syntax.location));
+            //     return nullableType;
+            // }
+
+            if (nullableType.type is TemplateParameterSymbol t &&
+                (basesBeingResolved is null || !basesBeingResolved.Contains(t))) {
+                diagnostics.Push(Error.CannotAnnotateTemplate(syntax.location));
                 return nullableType;
             }
 
             return new TypeWithAnnotations(nullableType.type.StrippedType(), false);
+        }
+
+        TypeWithAnnotations BindNullable() {
+            var nullableSyntax = (NullableTypeSyntax)syntax;
+            var underlyingType = BindType(nullableSyntax.type, diagnostics, basesBeingResolved);
+
+            if (underlyingType.IsNullableType())
+                return underlyingType;
+
+            // if (underlyingType.type.IsStructType()) {
+            //     diagnostics.Push(Error.CannotAnnotateStruct(syntax.location));
+            //     return underlyingType;
+            // }
+
+            if (underlyingType.type.IsPointerOrFunctionPointer()) {
+                diagnostics.Push(Error.CannotAnnotatePointer(syntax.location));
+                return underlyingType;
+            }
+
+            return underlyingType.SetIsAnnotated();
         }
 
         NamespaceOrTypeOrAliasSymbolWithAnnotations BindAlias() {
@@ -875,6 +906,9 @@ internal partial class Binder {
 
             var array = ArrayTypeSymbol.CreateArray(type, 1);
             type = new TypeWithAnnotations(array);
+
+            if (i + 1 < jaggedRank)
+                type = type.SetIsAnnotated();
         }
 
         return type;
@@ -1186,8 +1220,16 @@ internal partial class Binder {
         TypeSyntax syntax,
         BelteDiagnosticQueue diagnostics,
         out bool isImplicitlyTyped,
-        out bool isNonNullable) {
-        return BindTypeOrImplicitType(syntax, diagnostics, out isImplicitlyTyped, out isNonNullable, out _);
+        out bool isNonNullable,
+        out bool isNullable) {
+        return BindTypeOrImplicitType(
+            syntax,
+            diagnostics,
+            out isImplicitlyTyped,
+            out isNonNullable,
+            out isNullable,
+            out _
+        );
     }
 
     internal TypeWithAnnotations BindTypeOrImplicitType(
@@ -1195,16 +1237,20 @@ internal partial class Binder {
         BelteDiagnosticQueue diagnostics,
         out bool isImplicitlyTyped,
         out bool isNonNullable,
+        out bool isNullable,
         out AliasSymbol alias) {
-        if (syntax.isImplicitlyTyped || (syntax is NonNullableTypeSyntax n && n.type.isImplicitlyTyped)) {
+        if (syntax.isImplicitlyTyped || (syntax is NonNullableTypeSyntax nn && nn.type.isImplicitlyTyped) ||
+            (syntax is NullableTypeSyntax n && n.type.isImplicitlyTyped)) {
             isImplicitlyTyped = true;
             isNonNullable = syntax.kind == SyntaxKind.NonNullableType;
+            isNullable = syntax.kind == SyntaxKind.NullableType;
             alias = null;
             return new TypeWithAnnotations(null, true);
         } else {
             var symbol = BindTypeOrAlias(syntax, diagnostics);
             isImplicitlyTyped = false;
             isNonNullable = false;
+            isNullable = false;
             return UnwrapAlias(symbol, out alias, diagnostics, syntax).typeWithAnnotations;
         }
     }
@@ -1273,11 +1319,8 @@ internal partial class Binder {
         var type = typeWithAnnotations.type;
 
         if (type.StrippedType() is not ErrorTypeSymbol) {
-            if (!typeWithAnnotations.isNullable && !type.IsStructType() && !type.IsPointerOrFunctionPointer() &&
-                !type.specialType.IsLowLevelNumeric() && !type.isStatic && type.specialType != SpecialType.Void &&
-                type.typeKind != TypeKind.TemplateParameter) {
+            if (argument.expression.kind == SyntaxKind.NonNullableType)
                 diagnostics.Push(Error.AnnotationsDisallowedInTemplateArgument(templateArgument.location));
-            }
 
             analyzedArguments.types.Add(type);
             analyzedArguments.hasErrors.Add(false);
@@ -1401,6 +1444,19 @@ internal partial class Binder {
                     diagnostics.Push(Error.EnumFieldNoTargetType(expression.syntax.location));
 
                 result = ErrorExpression(expression.syntax, expression);
+                break;
+            case BoundDefaultLiteral literal:
+                if (reportNoTargetType)
+                    diagnostics.Push(Error.DefaultLiteralNoTargetType(literal.syntax.location));
+
+                result = new BoundDefaultExpression(
+                    literal.syntax,
+                    targetType: null,
+                    literal.constantValue,
+                    CreateErrorType(),
+                    hasErrors: true
+                );
+
                 break;
             default:
                 result = expression;
@@ -1794,7 +1850,7 @@ internal partial class Binder {
         InitializerListExpressionSyntax node,
         BelteDiagnosticQueue diagnostics,
         bool inferType,
-        bool shouldLiftIfPossible = true) {
+        bool shouldLiftIfPossible = false) {
         var result = BindArrayInitializerList(
             diagnostics,
             node,
@@ -2610,6 +2666,12 @@ internal partial class Binder {
                 diagnostics.Push(GetStandardLValueError(valueKind, node.location));
                 return false;
             }
+
+            if (fieldAccess.receiver is not null && fieldAccess.receiver.type.IsNullableType() &&
+                fieldAccess.receiver.type.StrippedType().IsStructType()) {
+                diagnostics.Push(GetStandardLValueError(valueKind, node.location));
+                return false;
+            }
         }
 
         if (RequiresRefAssignableVariable(valueKind)) {
@@ -3017,8 +3079,10 @@ internal partial class Binder {
         var resultType = expression.Type();
         var expressionKind = expression.kind;
 
-        if (expression.hasAnyErrors && resultType is not null)
+        if (expression.hasAnyErrors && resultType is not null ||
+            expressionKind is BoundKind.DefaultLiteral or BoundKind.UnboundLambda) {
             return expression;
+        }
 
         if (expressionKind == BoundKind.ErrorExpression) {
             var errorExpression = (BoundErrorExpression)expression;
@@ -4652,7 +4716,9 @@ internal partial class Binder {
         var conversion = conversions.ClassifyConversionFromExpression(expression, boolean);
 
         if (conversion.isImplicit) {
-            if (conversion.kind == ConversionKind.Identity) {
+            var collapsed = Conversion.CollapseConversion(conversion);
+
+            if (collapsed.kind == ConversionKind.Identity) {
                 if (expression.kind == BoundKind.AssignmentOperator) {
                     var assignment = (BoundAssignmentOperator)expression;
 
@@ -5522,7 +5588,12 @@ internal partial class Binder {
 
         return (receiver.hasErrors || access.hasErrors)
             ? access
-            : new BoundConditionalAccessExpression(syntax, receiver, access, access.Type());
+            : new BoundConditionalAccessExpression(
+                syntax,
+                receiver,
+                access,
+                access.Type() is null ? access.Type() : CorLibrary.GetOrCreateNullableType(access.Type())
+            );
     }
 
     private BoundExpression BindMemberAccessBadResult(
@@ -7393,6 +7464,8 @@ internal partial class Binder {
                     return new BoundLiteralExpression(node, new ConstantValue(null, SpecialType.None), null);
                 case SyntaxKind.NullptrKeyword:
                     return new BoundUnconvertedNullptrExpression(node);
+                case SyntaxKind.DefaultKeyword:
+                    return new BoundDefaultLiteral(node);
                 default:
                     throw ExceptionUtilities.UnexpectedValue(node.token.kind);
             }
@@ -11691,6 +11764,7 @@ symIsHidden:;
             ref isConstExpr,
             out var isImplicitlyTyped,
             out var isNonNullable,
+            out var isNullable,
             out var alias
         );
 
@@ -11702,6 +11776,7 @@ symIsHidden:;
             kind,
             isImplicitlyTyped,
             isNonNullable,
+            isNullable,
             node.declaration,
             typeSyntax,
             declarationType,
@@ -11717,6 +11792,7 @@ symIsHidden:;
         DataContainerDeclarationKind kind,
         bool isImplicitlyTyped,
         bool isNonNullable,
+        bool isNullable,
         VariableDeclarationSyntax declaration,
         TypeSyntax typeSyntax,
         TypeWithAnnotations declarationType,
@@ -11734,6 +11810,7 @@ symIsHidden:;
             kind,
             isImplicitlyTyped,
             isNonNullable,
+            isNullable,
             declaration,
             typeSyntax,
             declarationType,
@@ -11779,6 +11856,7 @@ symIsHidden:;
         DataContainerDeclarationKind kind,
         bool isImplicitlyTyped,
         bool isNonNullable,
+        bool isNullable,
         VariableDeclarationSyntax declaration,
         TypeSyntax typeSyntax,
         TypeWithAnnotations declarationType,
@@ -11813,7 +11891,14 @@ symIsHidden:;
                 diagnostics.Push(Error.ConstantAndVariable(localSymbol.location));
             }
 
-            initializer = BindInferredVariableInitializer(diagnostics, value, valueKind, declaration, !isNonNullable);
+            // TODO Should we ever lift the elements?
+            initializer = BindInferredVariableInitializer(
+                diagnostics,
+                value,
+                valueKind,
+                declaration,
+                false /*!isNonNullable || isNullable*/
+            );
 
             if (initializer is not null && initializer.IsLiteralNull()) {
                 diagnostics.Push(Error.NullAssignOnImplicit(declaration.location));
@@ -11838,10 +11923,12 @@ symIsHidden:;
                     declarationType = new TypeWithAnnotations(CreateErrorType("var"));
                     hasErrors = true;
                 } else {
-                    if (!initializerType.IsNullableType() && !localSymbol.isConstExpr &&
-                        !localSymbol.isConst && !isNonNullable) {
+                    if (!initializerType.IsNullableType() && ((!localSymbol.isConstExpr &&
+                        !localSymbol.isConst && !isNonNullable) || isNullable)) {
                         if (!initializer.type.IsStructType() && initializer.type.typeKind != TypeKind.FunctionPointer &&
                             initializer.type.typeKind != TypeKind.Pointer &&
+                            ((!initializer.type.specialType.IsPrimitiveType() ||
+                            initializer.type.specialType is SpecialType.Array or SpecialType.Any) || isNullable) &&
                             (initializer.kind == BoundKind.ObjectCreationExpression ||
                             initializer.constantValue is not null)) {
                             declarationType = declarationType.SetIsAnnotated();
@@ -11850,10 +11937,21 @@ symIsHidden:;
                                 initializer,
                                 diagnostics
                             );
+                            // } else if (initializer.type.IsStructType() && isNullable) {
+                            //     diagnostics.Push(Error.CannotAnnotateStruct(typeSyntax.location));
+                        } else if (initializer.type.IsPointerOrFunctionPointer() && isNullable) {
+                            diagnostics.Push(Error.CannotAnnotatePointer(typeSyntax.location));
                         }
                     } else {
                         if (isNonNullable && declarationType.IsNullableType()) {
                             declarationType = new TypeWithAnnotations(declarationType.nullableUnderlyingTypeOrSelf);
+                            initializer = GenerateConversionForAssignment(
+                                declarationType.type,
+                                initializer,
+                                diagnostics
+                            );
+                        } else if (isNullable && !declarationType.IsNullableType()) {
+                            declarationType = declarationType.SetIsAnnotated();
                             initializer = GenerateConversionForAssignment(
                                 declarationType.type,
                                 initializer,
@@ -12029,7 +12127,7 @@ symIsHidden:;
         ExpressionSyntax initializer,
         BindValueKind valueKind,
         BelteSyntaxNode errorSyntax,
-        bool shouldLiftIfPossible = true) {
+        bool shouldLiftIfPossible = false) {
         if (initializer is null) {
             diagnostics.Push(Error.NoInitOnImplicit(errorSyntax.location));
             return null;
@@ -12156,12 +12254,14 @@ symIsHidden:;
         ref bool isConstExpr,
         out bool isImplicitlyTyped,
         out bool isNonNullable,
+        out bool isNullable,
         out AliasSymbol alias) {
         var declType = BindTypeOrImplicitType(
             typeSyntax.SkipRef(out _),
             diagnostics,
             out isImplicitlyTyped,
             out isNonNullable,
+            out isNullable,
             out alias
         );
 
@@ -13055,6 +13155,9 @@ symIsHidden:;
                 ? ConstantFolding.FoldCast(source, new TypeWithAnnotations(destination), diagnostics)
                 : null;
         }
+
+        if (conversion.kind == ConversionKind.DefaultLiteral)
+            source = new BoundDefaultExpression(source.syntax, targetType: null, constantValue, type: destination);
 
         if (conversion.method is not null && conversion.kind != ConversionKind.MethodGroup) {
             var targetType = conversion.method.GetParameterTypes()[0].type;

--- a/src/Buckle/Compiler/CodeAnalysis/Binding/BoundTree/BoundExpression.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Binding/BoundTree/BoundExpression.cs
@@ -42,6 +42,7 @@ internal abstract partial class BoundExpression : BoundNode {
 
     internal bool NeedsToBeConverted() {
         switch (kind) {
+            case BoundKind.DefaultLiteral:
             case BoundKind.UnconvertedInitializerList:
             case BoundKind.UnconvertedImplicitEnumFieldExpression:
                 return true;

--- a/src/Buckle/Compiler/CodeAnalysis/Binding/BoundTree/BoundNodes.xml
+++ b/src/Buckle/Compiler/CodeAnalysis/Binding/BoundTree/BoundNodes.xml
@@ -215,6 +215,14 @@
   <Node Name="BoundLiteralExpression" Base="BoundExpression">
     <Field Name="constantValue" Type="ConstantValue" PropertyOverrides="true"/>
   </Node>
+  <Node Name="BoundDefaultLiteral" Base="BoundExpression">
+    <Field Name="type" Type="TypeSymbol?" Override="true" Null="always"/>
+  </Node>
+  <Node Name="BoundDefaultExpression" Base="BoundExpression">
+    <Field Name="type" Type="TypeSymbol" Override="true" Null="disallow"/>
+    <Field Name="targetType" Type="BoundTypeExpression?" SkipInVisitor="true"/>
+    <Field Name="constantValue" Type="ConstantValue?" PropertyOverrides="true"/>
+  </Node>
   <Node Name="BoundInterpolatedStringExpression" Base="BoundExpression">
     <Field Name="contents" Type="ImmutableArray&lt;BoundExpression&gt;"/>
     <Field Name="constantValue" Type="ConstantValue?" PropertyOverrides="true"/>

--- a/src/Buckle/Compiler/CodeAnalysis/Binding/BoundTree/BoundTreeExpander.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Binding/BoundTree/BoundTreeExpander.cs
@@ -316,6 +316,7 @@ internal abstract partial class BoundTreeExpander {
 
         return expression.kind switch {
             BoundKind.LiteralExpression => ExpandLiteralExpression((BoundLiteralExpression)expression, out replacement, useKind),
+            BoundKind.DefaultExpression => ExpandDefaultExpression((BoundDefaultExpression)expression, out replacement, useKind),
             BoundKind.InitializerList => ExpandInitializerList((BoundInitializerList)expression, out replacement, useKind),
             BoundKind.InitializerDictionary => ExpandInitializerDictionary((BoundInitializerDictionary)expression, out replacement, useKind),
             BoundKind.DataContainerExpression => ExpandDataContainerExpression((BoundDataContainerExpression)expression, out replacement, useKind),
@@ -725,6 +726,14 @@ internal abstract partial class BoundTreeExpander {
         return [];
     }
 
+    private protected virtual List<BoundStatement> ExpandDefaultExpression(
+        BoundDefaultExpression expression,
+        out BoundExpression replacement,
+        UseKind useKind) {
+        replacement = expression;
+        return [];
+    }
+
     private protected virtual List<BoundStatement> ExpandDataContainerExpression(
         BoundDataContainerExpression expression,
         out BoundExpression replacement,
@@ -1123,10 +1132,13 @@ internal abstract partial class BoundTreeExpander {
         if (!expression.field.isStatic) {
             // Structs are special case because they have limited expansion ability (they are non-nullable)
             // And because they are passed by value so in something like `a.b.c = x`, we can't hoist anything
+            var isTrueStructReceiver = expression.receiver.Type().IsStructType() &&
+                !(expression.receiver is BoundCallExpression c && c.receiver.StrippedType().IsStructType());
+
             var statements = ExpandExpression(
                 expression.receiver,
                 out var newReceiver,
-                expression.receiver.Type().IsStructType() ? UseKind.Writable : UseKind.StableValue
+                isTrueStructReceiver ? UseKind.Writable : UseKind.StableValue
             );
 
             if (statements.Count != 0 || expression.receiver != newReceiver) {

--- a/src/Buckle/Compiler/CodeAnalysis/Binding/ConstantFolding.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Binding/ConstantFolding.cs
@@ -434,7 +434,7 @@ internal static class ConstantFolding {
                     SpecialType.UInt8 => new ConstantValue(~(byte)value, specialType),
                     SpecialType.UInt16 => new ConstantValue(~(ushort)value, specialType),
                     SpecialType.UInt32 => new ConstantValue(~(uint)value, specialType),
-                    SpecialType.UInt64 => new ConstantValue(~(long)value, specialType),
+                    SpecialType.UInt64 => new ConstantValue(~(ulong)value, specialType),
                     _ => throw ExceptionUtilities.UnexpectedValue(specialType),
                 };
             default:

--- a/src/Buckle/Compiler/CodeAnalysis/Binding/Conversions/Conversion.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Binding/Conversions/Conversion.cs
@@ -12,6 +12,7 @@ internal readonly partial struct Conversion : IEquatable<Conversion> {
     internal static Conversion None => new Conversion(ConversionKind.None);
     internal static Conversion Identity => new Conversion(ConversionKind.Identity);
     internal static Conversion Implicit => new Conversion(ConversionKind.Implicit);
+    internal static Conversion DefaultLiteral => new Conversion(ConversionKind.DefaultLiteral);
     internal static Conversion ImplicitConstant => new Conversion(ConversionKind.ImplicitConstant);
     internal static Conversion ImplicitNullable => new Conversion(ConversionKind.ImplicitNullable);
     internal static Conversion ImplicitReference => new Conversion(ConversionKind.ImplicitReference);
@@ -252,7 +253,7 @@ internal readonly partial struct Conversion : IEquatable<Conversion> {
         if (source.specialType == SpecialType.Any && target.specialType == SpecialType.Array)
             return Explicit;
 
-        if (source.Equals(target))
+        if (source.Equals(target, TypeCompareKind.ConsiderEverything))
             return Identity;
 
         if (source.IsPointerOrFunctionPointer() && target.IsPointerOrFunctionPointer()) {

--- a/src/Buckle/Compiler/CodeAnalysis/Binding/Conversions/Conversions.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Binding/Conversions/Conversions.cs
@@ -288,6 +288,8 @@ internal sealed partial class Conversions {
                 return GetImplicitEnumFieldExpressionConversion(fieldAccess, target);
             case BoundMethodGroup methodGroup:
                 return GetMethodGroupConversion(methodGroup, target);
+            case BoundDefaultLiteral literal:
+                return Conversion.DefaultLiteral;
         }
 
         if (sourceExpression.IsLiteralNull()) {

--- a/src/Buckle/Compiler/CodeAnalysis/Binding/Operators/BinaryOperatorEasyOut.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Binding/Operators/BinaryOperatorEasyOut.cs
@@ -272,8 +272,10 @@ internal sealed partial class OverloadResolution {
 
             // TODO This is a hack to ensure unsigned long operations are correct
             // Eventually we want to fill out the easy out chart to account for this instead
-            if (left.specialType.IsUnsigned() && right.specialType.IsUnsigned())
-                result = BinaryOperatorKind.UInt;
+            if (left.specialType.IsUnsigned()) {
+                if (right.specialType.IsUnsigned() || kind.IsShift())
+                    result = BinaryOperatorKind.UInt;
+            }
 
             return result == BinaryOperatorKind.Error ? result : result | kind;
         }
@@ -293,6 +295,12 @@ internal sealed partial class OverloadResolution {
 
         if (rightType is null)
             return;
+
+        if (left.kind == BoundKind.LiteralExpression && right.kind != BoundKind.LiteralExpression)
+            leftType = Binder.ReduceNumericIfApplicable(rightType, left).type;
+
+        if (right.kind == BoundKind.LiteralExpression && left.kind != BoundKind.LiteralExpression)
+            rightType = Binder.ReduceNumericIfApplicable(leftType, right).type;
 
         var easyOut = BinOpEasyOut.OpKind(kind, leftType, rightType);
 

--- a/src/Buckle/Compiler/CodeAnalysis/Binding/Operators/UnaryOperatorEasyOut.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Binding/Operators/UnaryOperatorEasyOut.cs
@@ -68,6 +68,9 @@ internal sealed partial class OverloadResolution {
             var kindIndex = kind.OperatorIndex();
             var result = (kindIndex >= Operators.Length) ? UnaryOperatorKind.Error : Operators[kindIndex][index];
 
+            if (operand.specialType.IsUnsigned())
+                result = UnaryOperatorKind.UInt;
+
             return result == UnaryOperatorKind.Error ? result : result | kind;
         }
     }

--- a/src/Buckle/Compiler/CodeAnalysis/Binding/RefSafetyAnalysis.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Binding/RefSafetyAnalysis.cs
@@ -499,6 +499,8 @@ internal sealed partial class RefSafetyAnalysis : BoundTreeWalkerWithStackGuardW
             return CallingMethodScope;
 
         switch (expression.kind) {
+            case BoundKind.DefaultLiteral:
+            case BoundKind.DefaultExpression:
             case BoundKind.PointerIndexAccessExpression:
             case BoundKind.PointerIndirectionOperator:
                 return CallingMethodScope;
@@ -964,6 +966,9 @@ internal sealed partial class RefSafetyAnalysis : BoundTreeWalkerWithStackGuardW
             case BoundKind.ConditionalAccessExpression:
             case BoundKind.ArrayAccessExpression:
                 return false;
+            case BoundKind.DefaultLiteral:
+            case BoundKind.DefaultExpression:
+                return true;
             default:
                 diagnostics.Push(Error.InternalError(node.location));
                 return false;

--- a/src/Buckle/Compiler/CodeAnalysis/CodeGeneration/CodeGenerator.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/CodeGeneration/CodeGenerator.cs
@@ -1216,6 +1216,9 @@ oneMoreTime:
                     EmitThisExpression((BoundThisExpression)expression);
 
                 break;
+            case BoundKind.DefaultExpression:
+                EmitDefaultExpression((BoundDefaultExpression)expression, used);
+                break;
             case BoundKind.BaseExpression:
                 if (used)
                     EmitBaseExpression((BoundBaseExpression)expression);
@@ -1317,6 +1320,10 @@ oneMoreTime:
             default:
                 throw ExceptionUtilities.UnexpectedValue(expression.kind);
         }
+    }
+
+    private void EmitDefaultExpression(BoundDefaultExpression expression, bool used) {
+        EmitDefaultValue(expression.type, used, expression.syntax);
     }
 
     private void EmitConstantExpression(TypeSymbol type, ConstantValue constant, bool used) {

--- a/src/Buckle/Compiler/CodeAnalysis/Evaluating/Evaluator.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Evaluating/Evaluator.cs
@@ -645,8 +645,14 @@ internal sealed class Evaluator {
 
         var type = node.sourceType.type;
 
-        if (type.StrippedType() is TemplateParameterSymbol t)
-            return EvaluatorValue.Type(SubstituteTemplateParameter(t));
+        if (type.StrippedType() is TemplateParameterSymbol t) {
+            var substituted = SubstituteTemplateParameter(t);
+
+            if (type.IsNullableType())
+                substituted = CorLibrary.GetOrCreateNullableType(substituted);
+
+            type = substituted;
+        }
 
         return EvaluatorValue.Type(type);
     }
@@ -2651,6 +2657,37 @@ internal sealed class Evaluator {
                                     throw ExceptionUtilities.UnexpectedValue(argument.kind);
                             }
                         }
+                    }
+
+                    return true;
+                case "LowLevel_GetType_A": {
+                        var argument = EvaluateExpression(arguments[0], true, abort);
+                        TypeSymbol type;
+
+                        if (argument.kind == ValueKind.HeapPtr) {
+                            type = (NamedTypeSymbol)_context.heap[argument.ptr].type;
+                        } else if (argument.kind == ValueKind.Struct) {
+                            type = argument.@struct.type;
+                        } else {
+                            type = argument.kind switch {
+                                ValueKind.Int8 => CorLibrary.GetSpecialType(SpecialType.Int8),
+                                ValueKind.Int16 => CorLibrary.GetSpecialType(SpecialType.Int16),
+                                ValueKind.Int32 => CorLibrary.GetSpecialType(SpecialType.Int32),
+                                ValueKind.Int64 => CorLibrary.GetSpecialType(SpecialType.Int64),
+                                ValueKind.UInt8 => CorLibrary.GetSpecialType(SpecialType.UInt8),
+                                ValueKind.UInt16 => CorLibrary.GetSpecialType(SpecialType.UInt16),
+                                ValueKind.UInt32 => CorLibrary.GetSpecialType(SpecialType.UInt32),
+                                ValueKind.UInt64 => CorLibrary.GetSpecialType(SpecialType.UInt64),
+                                ValueKind.Float32 => CorLibrary.GetSpecialType(SpecialType.Float32),
+                                ValueKind.Float64 => CorLibrary.GetSpecialType(SpecialType.Float64),
+                                ValueKind.Bool => CorLibrary.GetSpecialType(SpecialType.Bool),
+                                ValueKind.Char => CorLibrary.GetSpecialType(SpecialType.Char),
+                                ValueKind.String => CorLibrary.GetSpecialType(SpecialType.String),
+                                _ => throw ExceptionUtilities.UnexpectedValue(argument.kind)
+                            };
+                        }
+
+                        result = EvaluatorValue.Type(type);
                     }
 
                     return true;

--- a/src/Buckle/Compiler/CodeAnalysis/Evaluating/Evaluator.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Evaluating/Evaluator.cs
@@ -529,7 +529,7 @@ internal sealed class Evaluator {
         var expression = node.expression;
         var value = EvaluateExpression(expression, _isScript, abort);
 
-        if (expression.syntax.kind != Syntax.SyntaxKind.LocalDeclarationStatement)
+        if (expression.syntax.kind != SyntaxKind.LocalDeclarationStatement)
             _lastValue = value;
     }
 
@@ -545,6 +545,7 @@ internal sealed class Evaluator {
             return EvaluatorValue.Literal(node.constantValue.value, node.constantValue.specialType);
 
         return node.kind switch {
+            BoundKind.DefaultExpression => EvaluateDefaultExpression((BoundDefaultExpression)node, used),
             BoundKind.ThisExpression => EvaluateThisExpression((BoundThisExpression)node),
             BoundKind.BaseExpression => EvaluateBaseExpression((BoundBaseExpression)node),
             BoundKind.DataContainerExpression => EvaluateDataContainerExpression((BoundDataContainerExpression)node, used),
@@ -573,12 +574,12 @@ internal sealed class Evaluator {
             BoundKind.UnconvertedNullptrExpression => EvaluatorValue.Null,
             BoundKind.ConvertedStackAllocExpression => throw new BelteEvaluatorException("Stackalloc is not supported in the Evaluator.", node.syntax.location),
             BoundKind.FunctionPointerLoad => throw new BelteEvaluatorException("Function pointers are not supported in the Evaluator.", node.syntax.location),
-            BoundKind.FunctionLoad => EvaluateFunctionLoad((BoundFunctionLoad)node, used, abort),
+            BoundKind.FunctionLoad => EvaluateFunctionLoad((BoundFunctionLoad)node, used),
             _ => throw ExceptionUtilities.UnexpectedValue(node.kind),
         };
     }
 
-    private EvaluatorValue EvaluateFunctionLoad(BoundFunctionLoad node, bool used, ValueWrapper<bool> abort) {
+    private EvaluatorValue EvaluateFunctionLoad(BoundFunctionLoad node, bool used) {
         if (used)
             return new EvaluatorValue() { kind = ValueKind.MethodGroup, data = node.targetMethod };
 
@@ -590,6 +591,34 @@ internal sealed class Evaluator {
             return EvaluateExpression(node.expression, used, abort);
 
         throw ExceptionUtilities.Unreachable();
+    }
+
+    private EvaluatorValue EvaluateDefaultExpression(BoundDefaultExpression node, bool used) {
+        if (!used)
+            return EvaluatorValue.None;
+
+        return EvaluateDefaultExpression(node.type);
+    }
+
+    private EvaluatorValue EvaluateDefaultExpression(TypeSymbol type) {
+        if (type.IsNullableType())
+            return EvaluatorValue.Null;
+
+        if (!type.IsTemplateParameter()) {
+            var constantValue = type.IsVerifierValue() ? LiteralUtilities.GetDefaultValue(type.specialType) : null;
+
+            if (constantValue is not null)
+                return EvaluatorValue.Literal(constantValue, type.specialType);
+        }
+
+        if (type.IsPointerOrFunctionPointer() || type.specialType is SpecialType.UIntPtr or SpecialType.IntPtr) {
+            return new EvaluatorValue() { kind = ValueKind.Ref, uint64 = 0 };
+        } else if (type.IsTemplateParameter()) {
+            var targetType = SubstituteTemplateParameter((TemplateParameterSymbol)type);
+            return EvaluateDefaultExpression(targetType);
+        } else {
+            return CreateObject((NamedTypeSymbol)type);
+        }
     }
 
     private EvaluatorValue EvaluateThisExpression(BoundThisExpression node) {
@@ -616,21 +645,24 @@ internal sealed class Evaluator {
 
         var type = node.sourceType.type;
 
-        if (type.StrippedType() is TemplateParameterSymbol t) {
-            if (t.templateParameterKind == TemplateParameterKind.Method)
-                return EvaluatorValue.Type(_stack.Peek().values[t.ordinal + 1].type);
-
-            var thisParameter = _stack.Peek().values[0];
-            var heapObject = _context.heap[thisParameter.ptr];
-
-            if (!_program.TryGetTypeLayoutIncludingParents((NamedTypeSymbol)heapObject.type, out var layout))
-                throw new BelteInternalException($"Failed to get type layout ({heapObject.type}).");
-
-            var field = layout.GetLocal(type.StrippedType());
-            return EvaluatorValue.Type(heapObject.fields[field.slot].type);
-        }
+        if (type.StrippedType() is TemplateParameterSymbol t)
+            return EvaluatorValue.Type(SubstituteTemplateParameter(t));
 
         return EvaluatorValue.Type(type);
+    }
+
+    private TypeSymbol SubstituteTemplateParameter(TemplateParameterSymbol templateParameter) {
+        if (templateParameter.templateParameterKind == TemplateParameterKind.Method)
+            return (TypeSymbol)_stack.Peek().values[templateParameter.ordinal + 1].type;
+
+        var thisParameter = _stack.Peek().values[0];
+        var heapObject = _context.heap[thisParameter.ptr];
+
+        if (!_program.TryGetTypeLayoutIncludingParents((NamedTypeSymbol)heapObject.type, out var layout))
+            throw new BelteInternalException($"Failed to get type layout ({heapObject.type}).");
+
+        var field = layout.GetLocal(templateParameter);
+        return (TypeSymbol)heapObject.fields[field.slot].type;
     }
 
     private EvaluatorValue EvaluateMethodGroup(BoundMethodGroup node) {
@@ -2287,8 +2319,8 @@ internal sealed class Evaluator {
     }
 
     private EvaluatorValue EvaluateAddressOfTempClone(BoundExpression node, ValueWrapper<bool> abort) {
-        // Should only be reachable with uninitialized ref locals
-        if (!node.IsLiteralNull())
+        // Should only be reachable with uninitialized ref locals and structs
+        if (!node.IsLiteralNull() && !(node is BoundCallExpression c && c.receiver.type.StrippedType().IsStructType()))
             throw ExceptionUtilities.UnexpectedValue(node.kind);
 
         var value = EvaluateExpression(node, true, abort);

--- a/src/Buckle/Compiler/CodeAnalysis/Evaluating/Executor.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Evaluating/Executor.cs
@@ -1395,6 +1395,7 @@ internal sealed partial class Executor : ModuleBuilder {
             { "Math_RadToDeg_D", typeof(double).GetMethod("RadiansToDegrees", Flags, [typeof(double)]) },
             { "LowLevel_GetHashCode_O", typeof(Belte.Runtime.Utilities).GetMethod("GetHashCode", Flags, [typeof(object)]) },
             { "LowLevel_GetTypeName_O", typeof(Belte.Runtime.Utilities).GetMethod("GetTypeName", Flags, [typeof(object)]) },
+            { "LowLevel_GetType_A", typeof(Belte.Runtime.Utilities).GetMethod("AnyGetType", Flags, [typeof(object)]) },
             { "LowLevel_ThrowNullConditionException", typeof(Belte.Runtime.ThrowHelper).GetMethod("ThrowNullConditionException", Flags, Type.EmptyTypes) },
             { "LowLevel_CreateLPCSTR_S", typeof(Belte.Runtime.Utilities).GetMethod("CreateLPCSTR", Flags, [typeof(string)]) },
             { "LowLevel_CreateLPCWSTR_S", typeof(Belte.Runtime.Utilities).GetMethod("CreateLPCWSTR", Flags, [typeof(string)]) },

--- a/src/Buckle/Compiler/CodeAnalysis/LiteralUtilities.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/LiteralUtilities.cs
@@ -392,4 +392,14 @@ internal static class LiteralUtilities {
             _ => throw ExceptionUtilities.UnexpectedValue(type)
         };
     }
+
+    internal static ConstantValue TryGetDefaultValue(TypeSymbol type) {
+        if (type.IsNullableType())
+            return ConstantValue.Null;
+
+        if (TypeHasDefaultValue(type.specialType))
+            return new ConstantValue(GetDefaultValue(type.specialType), type.specialType);
+
+        return null;
+    }
 }

--- a/src/Buckle/Compiler/CodeAnalysis/Lowering/EvaluatorSlotRewriter.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Lowering/EvaluatorSlotRewriter.cs
@@ -177,6 +177,9 @@ internal sealed class EvaluatorSlotRewriter : BoundTreeRewriter {
         if (method.containingType?.Equals(GraphicsLibrary.Graphics) == true && GraphicsLibrary.MethodProducesTemp(method))
             _lateTempCount++;
 
+        if (node.receiver is not null && node.receiver.type.StrippedType().IsStructType())
+            _lateTempCount++;
+
         return base.VisitCallExpression(node);
     }
 }

--- a/src/Buckle/Compiler/CodeAnalysis/Lowering/Expander.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Lowering/Expander.cs
@@ -226,39 +226,57 @@ internal sealed class Expander : BoundTreeExpander {
         temp = <receiver>.<field>
         temp
 
+        ----> <receiver> is nullable struct
+
+        <receiver>.get_Value().<field>
+
         */
-        var statements = base.ExpandFieldAccessExpression(expression, out replacement, UseKind.Value);
+        List<BoundStatement> statements;
 
-        if (expression.type.IsNullableType() && expression.type.GetNullableUnderlyingType().IsStructType()) {
-            // TODO Just need to make sure this is actually unreachable then can remove
-            throw ExceptionUtilities.Unreachable();
-            // var syntax = expression.syntax;
-            // var underlyingType = type.GetNullableUnderlyingType();
-
-            // var statements = ExpandExpression(expression.receiver, out var newReceiver, useKind);
-
-            // newReceiver = Lowerer.CreateNullableGetValueCall(syntax, newReceiver, underlyingType);
-            // var tempLocal = GenerateTempLocal(type);
-
-            // statements.AddRange(
-            //     new BoundLocalDeclarationStatement(syntax,
-            //         new BoundDataContainerDeclaration(syntax, tempLocal, newReceiver)
-            //     )
-            // );
-
-            // replacement = new BoundFieldAccessExpression(syntax,
-            //     Local(syntax, tempLocal),
-            //     expression.field,
-            //     expression.constantValue,
-            //     expression.field.type
-            // );
-
-            // _accessDepth = savedAccessDepth;
-            // return statements;
+        if (expression.receiver is not null && expression.receiver.type.IsNullableType() &&
+            expression.receiver.type.GetNullableUnderlyingType().IsStructType()) {
+            statements = CreateNullableStructAccess(expression, null, out replacement, useKind);
+        } else {
+            statements = base.ExpandFieldAccessExpression(expression, out replacement, UseKind.Value);
         }
 
         if (useKind == UseKind.StableValue)
             return Stabilize(expression.syntax, statements, replacement, out replacement);
+
+        return statements;
+    }
+
+    private List<BoundStatement> CreateNullableStructAccess(
+        BoundFieldAccessExpression access,
+        BoundExpression receiver,
+        out BoundExpression replacement,
+        UseKind useKind) {
+        var syntax = access.syntax;
+        var underlyingType = access.receiver.type.GetNullableUnderlyingType();
+
+        var statements = receiver is null ? ExpandExpression(access.receiver, out receiver, UseKind.Writable) : [];
+        receiver = Lowerer.CreateNullableGetValueCall(syntax, receiver, underlyingType);
+
+        if (useKind == UseKind.Writable) {
+            var tempLocal = GenerateTempLocal(underlyingType);
+
+            statements.Add(LocalDeclaration(syntax, tempLocal, receiver));
+
+            replacement = new BoundFieldAccessExpression(syntax,
+                Local(syntax, tempLocal),
+                access.field,
+                access.constantValue,
+                access.field.type
+            );
+        } else {
+            replacement = new BoundFieldAccessExpression(
+                syntax,
+                receiver,
+                access.field,
+                access.constantValue,
+                access.field.type
+            );
+        }
 
         return statements;
     }
@@ -1106,6 +1124,17 @@ internal sealed class Expander : BoundTreeExpander {
             return [];
         }
 
+        if (expression.conversion.kind == ConversionKind.DefaultLiteral) {
+            replacement = new BoundDefaultExpression(
+                syntax,
+                null,
+                LiteralUtilities.TryGetDefaultValue(expression.type),
+                expression.type
+            );
+
+            return [];
+        }
+
         if (expression.conversion.method is not null) {
             var statements = ExpandExpression(operand, out var newOperand);
             replacement = Call(
@@ -1366,7 +1395,6 @@ internal sealed class Expander : BoundTreeExpander {
         break:
         temp
 
-
         ----> <left> is conditional access <cond> and is isolated
 
         goto break if <cond.receiver> is null
@@ -1446,6 +1474,12 @@ internal sealed class Expander : BoundTreeExpander {
             switch (access.kind) {
                 case BoundKind.FieldAccessExpression:
                     var fieldAccess = (BoundFieldAccessExpression)access;
+
+                    if (fieldAccess.receiver is not null && fieldAccess.receiver.type.IsNullableType() &&
+                        fieldAccess.receiver.type.StrippedType().IsStructType()) {
+                        return CreateNullableStructAccess(fieldAccess, currentReceiver, out newReceiver, UseKind.Value);
+                    }
+
                     newReceiver = new BoundFieldAccessExpression(
                         access.syntax,
                         currentReceiver,
@@ -1453,6 +1487,7 @@ internal sealed class Expander : BoundTreeExpander {
                         fieldAccess.constantValue,
                         fieldAccess.type
                     );
+
                     return [];
                 case BoundKind.ArrayAccessExpression: {
                         var arrayAccess = (BoundArrayAccessExpression)access;
@@ -1569,7 +1604,17 @@ internal sealed class Expander : BoundTreeExpander {
         BoundExpression trueExpression;
 
         if (access is BoundFieldAccessExpression f) {
-            trueExpression = new BoundFieldAccessExpression(syntax, newReceiver, f.field, f.constantValue, f.Type());
+            statements.AddRange(ExpandFieldAccessExpression(
+                new BoundFieldAccessExpression(
+                    syntax,
+                    newReceiver,
+                    f.field,
+                    f.constantValue,
+                    f.Type()
+                ),
+                out trueExpression,
+                UseKind.Value
+            ));
         } else if (access is BoundArrayAccessExpression a) {
             statements.AddRange(ExpandExpression(a.index, out var indexReplacement));
             trueExpression = new BoundArrayAccessExpression(syntax, newReceiver, indexReplacement, null, a.Type());
@@ -1589,6 +1634,9 @@ internal sealed class Expander : BoundTreeExpander {
             throw ExceptionUtilities.Unreachable();
         }
 
+        if (!trueExpression.Type().IsNullableType() && CodeGenerator.IsValueType(trueExpression.Type()))
+            trueExpression = Lowerer.CreateNullable(syntax, trueExpression, expression.type);
+
         replacement = new BoundConditionalOperator(
             syntax,
             HasValue(syntax, newReceiver),
@@ -1596,13 +1644,16 @@ internal sealed class Expander : BoundTreeExpander {
             trueExpression,
             Literal(syntax, null, access.Type()),
             null,
-            access.Type()
+            expression.type
         );
 
-        if (access is BoundFieldAccessExpression)
+        if (access is BoundFieldAccessExpression fa &&
+            !(fa.receiver is not null && fa.receiver.Type().IsNullableType() &&
+                fa.receiver.StrippedType().IsStructType())) {
             return statements;
-        else
+        } else {
             return StabilizeIfNecessary(syntax, useKind, statements, replacement, out replacement);
+        }
     }
 
     private protected override List<BoundStatement> ExpandInterpolatedStringExpression(

--- a/src/Buckle/Compiler/CodeAnalysis/Lowering/Lowerer.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Lowering/Lowerer.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Expressions;
 using Buckle.CodeAnalysis.Binding;
 using Buckle.CodeAnalysis.CodeGeneration;
 using Buckle.CodeAnalysis.Symbols;

--- a/src/Buckle/Compiler/CodeAnalysis/Parser/LanguageParser.ScanTypeFlags.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Parser/LanguageParser.ScanTypeFlags.cs
@@ -10,6 +10,7 @@ internal sealed partial class LanguageParser {
         NonTemplateTypeOrExpression,
         AliasQualifiedName,
         NonNullableType,
+        NullableType,
         PointerOrMultiplication,
     }
 }

--- a/src/Buckle/Compiler/CodeAnalysis/Parser/LanguageParser.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Parser/LanguageParser.cs
@@ -1886,6 +1886,8 @@ internal sealed partial class LanguageParser : SyntaxParser {
             case SyntaxKind.TrueKeyword:
             case SyntaxKind.FalseKeyword:
                 return ParseBooleanLiteral();
+            case SyntaxKind.DefaultKeyword:
+                return ParseDefaultLiteral();
             case SyntaxKind.NumericLiteralToken:
                 return ParseNumericLiteral();
             case SyntaxKind.StringLiteralToken:
@@ -2055,10 +2057,19 @@ internal sealed partial class LanguageParser : SyntaxParser {
             switch (currentToken.kind) {
                 case SyntaxKind.ExclamationToken
                         when lastTokenOfType.kind is not SyntaxKind.ExclamationToken
+                                                  and not SyntaxKind.QuestionToken
                                                   and not SyntaxKind.AsteriskToken
                                                   and not SyntaxKind.AsteriskAsteriskToken:
                     lastTokenOfType = EatToken();
                     result = ScanTypeFlags.NonNullableType;
+                    break;
+                case SyntaxKind.QuestionToken
+                        when lastTokenOfType.kind is not SyntaxKind.ExclamationToken
+                                                  and not SyntaxKind.QuestionToken
+                                                  and not SyntaxKind.AsteriskToken
+                                                  and not SyntaxKind.AsteriskAsteriskToken:
+                    lastTokenOfType = EatToken();
+                    result = ScanTypeFlags.NullableType;
                     break;
                 case SyntaxKind.AsteriskToken:
                 case SyntaxKind.AsteriskAsteriskToken:
@@ -2079,6 +2090,7 @@ internal sealed partial class LanguageParser : SyntaxParser {
                     result = ScanFunctionPointerType(out lastTokenOfType);
                     break;
                 case SyntaxKind.OpenBracketToken:
+                case SyntaxKind.QuestionOpenBracketToken:
                     EatToken();
 
                     while (currentToken.kind == SyntaxKind.CommaToken)
@@ -2231,6 +2243,7 @@ done:
         switch (type) {
             case ScanTypeFlags.PointerOrMultiplication:
             case ScanTypeFlags.NonNullableType:
+            case ScanTypeFlags.NullableType:
             case ScanTypeFlags.MustBeType:
             case ScanTypeFlags.AliasQualifiedName:
                 return true;
@@ -2747,6 +2760,11 @@ done:
         return SyntaxFactory.Literal(keyword, isTrue);
     }
 
+    private ExpressionSyntax ParseDefaultLiteral() {
+        var token = Match(SyntaxKind.DefaultKeyword);
+        return SyntaxFactory.Literal(token);
+    }
+
     private ExpressionSyntax ParseStringLiteral() {
         var stringToken = Match(SyntaxKind.StringLiteralToken);
         return SyntaxFactory.Literal(stringToken);
@@ -2939,7 +2957,7 @@ done:
     private TypeSyntax ParseTypeCore(bool allowArraySize, bool allowNoFollowUp, bool allowFunctionType) {
         TypeSyntax type;
 
-        if (currentToken.kind is SyntaxKind.ExclamationToken or SyntaxKind.OpenBracketToken ||
+        if (currentToken.kind is SyntaxKind.ExclamationToken or SyntaxKind.OpenBracketToken or SyntaxKind.QuestionToken ||
             (!allowNoFollowUp && currentToken.kind == SyntaxKind.IdentifierToken &&
              Peek(1).kind is SyntaxKind.EqualsToken or SyntaxKind.SemicolonToken)) {
             type = SyntaxFactory.EmptyName();
@@ -2951,26 +2969,44 @@ done:
 
         while (IsMakingProgress(ref lastTokenPosition)) {
             switch (currentToken.kind) {
-                case SyntaxKind.ExclamationToken when CanBeNonNullable():
+                case SyntaxKind.ExclamationToken when CanBeNullable():
                     var exclamationToken = EatToken();
                     type = SyntaxFactory.NonNullableType(type, exclamationToken);
                     continue;
-
-                    bool CanBeNonNullable() {
-                        if (type.kind == SyntaxKind.NonNullableType)
-                            return false;
-
-                        return true;
-                    }
-                case SyntaxKind.OpenBracketToken:
-                    var rankSpecifiers = SyntaxListBuilder<ArrayRankSpecifierSyntax>.Create();
-
-                    do {
-                        rankSpecifiers.Add(ParseArrayRankSpecifier(allowArraySize));
-                    } while (currentToken.kind == SyntaxKind.OpenBracketToken);
-
-                    type = SyntaxFactory.ArrayType(type, rankSpecifiers.ToList());
+                case SyntaxKind.QuestionToken when CanBeNullable():
+                    var questionToken = EatToken();
+                    type = SyntaxFactory.NullableType(type, questionToken);
                     continue;
+                case SyntaxKind.OpenBracketToken: {
+                        var rankSpecifiers = SyntaxListBuilder<ArrayRankSpecifierSyntax>.Create();
+
+                        do {
+                            rankSpecifiers.Add(ParseArrayRankSpecifier(allowArraySize));
+                        } while (currentToken.kind == SyntaxKind.OpenBracketToken);
+
+                        type = SyntaxFactory.ArrayType(type, rankSpecifiers.ToList());
+                        continue;
+                    }
+                case SyntaxKind.QuestionOpenBracketToken: {
+                        var questionOpenBracketToken = EatToken();
+                        type = SyntaxFactory.NullableType(type, questionOpenBracketToken);
+
+                        var rankSpecifiers = SyntaxListBuilder<ArrayRankSpecifierSyntax>.Create();
+                        var openBracket = SyntaxFactory.Token(SyntaxKind.None);
+                        var size = (allowArraySize && currentToken.kind != SyntaxKind.CloseBracketToken)
+                            ? ParseExpression()
+                            : null;
+
+                        var closeBracket = Match(SyntaxKind.CloseBracketToken);
+
+                        rankSpecifiers.Add(SyntaxFactory.ArrayRankSpecifier(openBracket, size, closeBracket));
+
+                        while (currentToken.kind == SyntaxKind.OpenBracketToken)
+                            rankSpecifiers.Add(ParseArrayRankSpecifier(allowArraySize));
+
+                        type = SyntaxFactory.ArrayType(type, rankSpecifiers.ToList());
+                        continue;
+                    }
                 case SyntaxKind.AsteriskToken:
                     var asteriskToken = EatToken();
                     type = SyntaxFactory.PointerType(type, asteriskToken);
@@ -3054,6 +3090,13 @@ done:
         }
 
         return type;
+
+        bool CanBeNullable() {
+            if (type.kind is SyntaxKind.NonNullableType or SyntaxKind.NullableType)
+                return false;
+
+            return true;
+        }
     }
 
     private TypeSyntax ParseUnderlyingType() {

--- a/src/Buckle/Compiler/CodeAnalysis/Symbols/NamedTypeSymbol.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Symbols/NamedTypeSymbol.cs
@@ -4,6 +4,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using Buckle.CodeAnalysis.Binding;
+using Buckle.CodeAnalysis.CodeGeneration;
 using Buckle.Utilities;
 using Microsoft.CodeAnalysis.PooledObjects;
 
@@ -358,8 +359,13 @@ internal abstract class NamedTypeSymbol : TypeSymbol, INamedTypeSymbol, ISymbolW
         var thisIsOriginalDefinition = (object)this == thisOriginalDefinition;
         var otherIsOriginalDefinition = (object)other == otherOriginalDefinition;
 
-        if (thisIsOriginalDefinition && otherIsOriginalDefinition)
-            return false;
+        if (thisIsOriginalDefinition && otherIsOriginalDefinition) {
+            if (!thisOriginalDefinition.specialType.IsNumeric())
+                return false;
+
+            return CodeGenerator.NormalizeNumericType(thisOriginalDefinition.specialType) ==
+                CodeGenerator.NormalizeNumericType(otherOriginalDefinition.specialType);
+        }
 
         if ((thisIsOriginalDefinition || otherIsOriginalDefinition) &&
             (compareKind & (TypeCompareKind.IgnoreArraySizesAndLowerBounds | TypeCompareKind.IgnoreNullability)) == 0) {

--- a/src/Buckle/Compiler/CodeAnalysis/Symbols/Source/ParameterHelpers.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Symbols/Source/ParameterHelpers.cs
@@ -188,7 +188,13 @@ internal static class ParameterHelpers {
         if (expression.constantValue is not null)
             return true;
 
-        return false;
+        switch (expression.kind) {
+            case BoundKind.DefaultLiteral:
+            case BoundKind.DefaultExpression:
+                return true;
+            default:
+                return false;
+        }
     }
 
     internal static RefKind GetModifiers(SyntaxTokenList modifiers, out SyntaxToken refnessKeyword) {

--- a/src/Buckle/Compiler/CodeAnalysis/Symbols/Source/SourceDataContainerSymbol.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Symbols/Source/SourceDataContainerSymbol.cs
@@ -97,6 +97,7 @@ internal partial class SourceDataContainerSymbol : DataContainerSymbol, IAttribu
                     typeSyntax,
                     BelteDiagnosticQueue.Discarded,
                     out var result,
+                    out _,
                     out _
                 );
 
@@ -253,18 +254,21 @@ internal partial class SourceDataContainerSymbol : DataContainerSymbol, IAttribu
 
         bool isImplicitlyTyped;
         bool isNonNullable;
+        bool isNullable;
         TypeWithAnnotations declarationType;
 
         if (_typeSyntax is null) {
             isImplicitlyTyped = true;
             isNonNullable = false;
+            isNullable = false;
             declarationType = default;
         } else {
             declarationType = scopeBinder.BindTypeOrImplicitType(
                 _typeSyntax.SkipRef(out _),
                 diagnostics,
                 out isImplicitlyTyped,
-                out isNonNullable
+                out isNonNullable,
+                out isNullable
             );
         }
 
@@ -274,6 +278,9 @@ internal partial class SourceDataContainerSymbol : DataContainerSymbol, IAttribu
             if (inferredType.hasType && !inferredType.IsVoidType()) {
                 if (isNonNullable && inferredType.IsNullableType())
                     inferredType = new TypeWithAnnotations(inferredType.nullableUnderlyingTypeOrSelf);
+
+                if (isNullable && !inferredType.IsNullableType())
+                    inferredType = inferredType.SetIsAnnotated();
 
                 declarationType = inferredType;
             } else {

--- a/src/Buckle/Compiler/CodeAnalysis/Symbols/Source/SourceMemberFieldSymbolFromDeclarator.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Symbols/Source/SourceMemberFieldSymbolFromDeclarator.cs
@@ -97,7 +97,7 @@ internal partial class SourceMemberFieldSymbolFromDeclarator : SourceMemberField
 
         var typeOnly = typeSyntax.SkipRef(out var refKind);
 
-        type = binder.BindTypeOrImplicitType(typeOnly, diagnostics, out var isImplicitlyTyped, out _);
+        type = binder.BindTypeOrImplicitType(typeOnly, diagnostics, out var isImplicitlyTyped, out _, out _);
 
         if (isImplicitlyTyped) {
             var location = typeOnly is IdentifierNameSyntax

--- a/src/Buckle/Compiler/CodeAnalysis/Symbols/Source/SourceTemplateParameterSymbolBase.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Symbols/Source/SourceTemplateParameterSymbolBase.cs
@@ -193,10 +193,12 @@ internal abstract class SourceTemplateParameterSymbolBase : TemplateParameterSym
         var type = binder.BindType(syntax.type, diagnostics);
         var underlying = type.nullableUnderlyingTypeOrSelf;
 
-        // TODO This is what we want, type arguments being null breaks their use as normal types
-        // ! However this does create a weird inconsistency where this is the ONLY time types aren't nullable by default
-        if (underlying.specialType == SpecialType.Type)
+        if (underlying.specialType == SpecialType.Type) {
+            if (syntax.type.kind == SyntaxKind.NullableType)
+                diagnostics.Push(Error.CannotAnnotateTypeTemplate(syntax.type.location));
+
             return new TypeWithAnnotations(underlying);
+        }
 
         if (declaringCompilation.options.buildMode is BuildMode.CSharpTranspile or
                                                       BuildMode.Execute or

--- a/src/Buckle/Compiler/CodeAnalysis/Syntax/Syntax.xml
+++ b/src/Buckle/Compiler/CodeAnalysis/Syntax/Syntax.xml
@@ -135,9 +135,7 @@
   </Node>
   <Node Name="ArrayRankSpecifierSyntax" Base="SyntaxNode">
     <Kind Name="ArrayRankSpecifier"/>
-    <Field Name="openBracket" Type="SyntaxToken">
-      <Kind Name="OpenBracketToken"/>
-    </Field>
+    <Field Name="openBracket" Type="SyntaxToken"/>
     <Field Name="size" Type="ExpressionSyntax" Optional="true"/>
     <Field Name="closeBracket" Type="SyntaxToken">
       <Kind Name="CloseBracketToken"/>
@@ -413,6 +411,11 @@
     <Field Name="exclamationToken" Type="SyntaxToken">
       <Kind Name="ExclamationToken"/>
     </Field>
+  </Node>
+  <Node Name="NullableTypeSyntax" Base="TypeSyntax">
+    <Kind Name="NullableType"/>
+    <Field Name="type" Type="TypeSyntax"/>
+    <Field Name="questionToken" Type="SyntaxToken"/>
   </Node>
   <Node Name="PointerTypeSyntax" Base="TypeSyntax">
     <Kind Name="PointerType"/>

--- a/src/Buckle/Compiler/CodeAnalysis/Syntax/SyntaxKind.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Syntax/SyntaxKind.cs
@@ -264,6 +264,7 @@ public enum SyntaxKind : ushort {
     EmptyName,
     ArrayType,
     NonNullableType,
+    NullableType,
     PointerType,
     FunctionPointerType,
     FunctionType,

--- a/src/Buckle/Compiler/CodeAnalysis/Syntax/SyntaxNodeExtensions.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Syntax/SyntaxNodeExtensions.cs
@@ -42,6 +42,10 @@ internal static class SyntaxNodeExtensions {
                     var nullableTypeSyntax = (NonNullableTypeSyntax)type;
                     stack.Push(nullableTypeSyntax.type);
                     break;
+                case SyntaxKind.NullableType:
+                    var underlyingTypeSyntax = (NullableTypeSyntax)type;
+                    stack.Push(underlyingTypeSyntax.type);
+                    break;
                 case SyntaxKind.PointerType:
                     var pointerTypeSyntax = (PointerTypeSyntax)type;
                     stack.Push(pointerTypeSyntax.elementType);

--- a/src/Buckle/Compiler/Diagnostics/DiagnosticCode.cs
+++ b/src/Buckle/Compiler/Diagnostics/DiagnosticCode.cs
@@ -419,6 +419,10 @@ public enum DiagnosticCode : ushort {
     ERR_BadReturnType = 408,
     ERR_FunctionRefMismatch = 409,
     ERR_UnknownCallingConvention = 410,
+    ERR_CannotAnnotatePointer = 411,
+    ERR_CannotAnnotateTypeTemplate = 412,
+    ERR_CannotAnnotateTemplate = 413,
+    ERR_DefaultLiteralNoTargetType = 414,
 
     // Carving out >=9000 for unsupported errors
     UNS_IndependentCompilation = 9000,

--- a/src/Buckle/Compiler/Diagnostics/Error.cs
+++ b/src/Buckle/Compiler/Diagnostics/Error.cs
@@ -1523,7 +1523,7 @@ internal static class Error {
     }
 
     internal static BelteDiagnostic CannotAnnotateStruct(TextLocation location) {
-        var message = $"cannot use a non-nullable annotation on a struct type";
+        var message = $"cannot use a nullable or non-nullable annotation on a struct type";
         return CreateError(DiagnosticCode.ERR_CannotAnnotateStruct, location, message);
     }
 
@@ -2006,6 +2006,26 @@ internal static class Error {
     internal static BelteDiagnostic UnknownCallingConvention(TextLocation location, string text) {
         var message = $"unrecognized calling convention '{text}'; valid calling conventions are 'stdcall', 'winapi', 'fastcall', 'cdecl', and 'thiscall'";
         return CreateError(DiagnosticCode.ERR_UnknownCallingConvention, location, message);
+    }
+
+    internal static BelteDiagnostic CannotAnnotatePointer(TextLocation location) {
+        var message = $"cannot use a nullable annotation on a pointer or function pointer type";
+        return CreateError(DiagnosticCode.ERR_CannotAnnotatePointer, location, message);
+    }
+
+    internal static BelteDiagnostic CannotAnnotateTypeTemplate(TextLocation location) {
+        var message = $"type template parameters cannot be nullable";
+        return CreateError(DiagnosticCode.ERR_CannotAnnotateTypeTemplate, location, message);
+    }
+
+    internal static BelteDiagnostic CannotAnnotateTemplate(TextLocation location) {
+        var message = $"cannot use a non-nullable annotation on a template parameter type";
+        return CreateError(DiagnosticCode.ERR_CannotAnnotateTemplate, location, message);
+    }
+
+    internal static BelteDiagnostic DefaultLiteralNoTargetType(TextLocation location) {
+        var message = $"there is no target type for the default literal";
+        return CreateError(DiagnosticCode.ERR_DefaultLiteralNoTargetType, location, message);
     }
 
     private static DiagnosticInfo ErrorInfo(DiagnosticCode code) {

--- a/src/Buckle/Compiler/Libraries/Standard/StandardLibrary.cs
+++ b/src/Buckle/Compiler/Libraries/Standard/StandardLibrary.cs
@@ -335,6 +335,7 @@ internal static class StandardLibrary {
         return StaticClass("LowLevel", [
             StaticMethod("GetHashCode", SpecialType.Int, [("object", SpecialType.Object)]),
             StaticMethod("GetTypeName", SpecialType.String, [("object", SpecialType.Object)]),
+            StaticMethod("GetType", SpecialType.Type, [("value", SpecialType.Any)]),
             length,
             sort,
             sizeOf,


### PR DESCRIPTION
# !! Major Breaking Change !!

Changing the default nullability behavior for primitives to be non-nullable. Added a `?` annotation to a type to make primitives nullable.

```cs
int a = 3; // int a = 3
int? a = 3; // Nullable<int> a = new Nullable<int>(3)
```

In addition, template types now respect the template argument type directly for primitives, meaning a `List<int>` is now actually `List<int>` instead of becoming `List<Nullable<int>>`. This means `type T` cannot be set to null, and instead `default` can be used.

`default` literal added mainly to allow for setting data containers of template types to something null-ish.

```cs
int a = default; // a = 3
int? a = default; // a = null
```

Struct types now allow nullability as they already could be if used as a type template argument. Field assignment is not allowed on nullable structs as copy semantics make the assignments not do anything.

```cs
A? a = new A();
a?.a = 5;

// Would become:

A? a = new Nullable<A>(new A());
goto break unless a.get_HasValue()
var temp = a.get_Value();
temp.a = 5;
break:

// a.a is still 0 because the temp copies, hence disallowed
```
