### PR TITLE
Rw/with

### DIFF
--- a/docs/Current/ControlFlow.md
+++ b/docs/Current/ControlFlow.md
@@ -25,7 +25,7 @@
     - [2.4.4.4](#2444-enumerated-collections) Enumerated Collections
 - [2.5](#25-switch) Switch
 - [2.6](#26-exceptions) Exceptions
-- [2.7]()
+- [2.7](#27-with-expressions-and-statements) With Expressions and Statements
 
 ## 2.1 Functions
 
@@ -683,3 +683,23 @@ with (a = 6) try {
 In the case of an exception or return or other control-flow breaking circumstance within the body of the `with`, the
 reversal will not take place as the with body is not exited normally. To ensure that the reversal always takes place,
 a `try` keyword can be specified preceding the body as seen in the above example.
+
+Unlike normal blocks, the body of a with statement exposes it's locals to the enclosing scope. This is to allow values
+created inside of the block to be used in the enclosing scope:
+
+```belte
+with (a = 6) {
+  var value = SomeMethod();
+}
+
+return value;
+```
+
+Note that the body of a with statement does not have to be a block. The above example could also be written as:
+
+```belte
+with (a = 6)
+  var value = SomeMethod();
+
+return value;
+```

--- a/docs/Current/ControlFlow.md
+++ b/docs/Current/ControlFlow.md
@@ -682,24 +682,19 @@ with (a = 6) try {
 
 In the case of an exception or return or other control-flow breaking circumstance within the body of the `with`, the
 reversal will not take place as the with body is not exited normally. To ensure that the reversal always takes place,
-a `try` keyword can be specified preceding the body as seen in the above example.
+a `try` keyword can be specified preceding the body as seen in the above example which wraps the body of the with in a
+`try` block and the reversals inside a `finally` block. A warning is generated if a control-flow breaking construct is
+used without specifying `try`.
 
-Unlike normal blocks, the body of a with statement exposes it's locals to the enclosing scope. This is to allow values
-created inside of the block to be used in the enclosing scope:
-
-```belte
-with (a = 6) {
-  var value = SomeMethod();
-}
-
-return value;
-```
-
-Note that the body of a with statement does not have to be a block. The above example could also be written as:
+The with expression and statement accept multiple assignments where they are assigned in the order they are listed and
+reversed in the reverse order. For example, the following will result in the same order of reversals:
 
 ```belte
-with (a = 6)
-  var value = SomeMethod();
-
-return value;
+return with (a = 5, b = 10, c = 0) SomeMethod();
 ```
+
+```belte
+return with (a = 5) with (b = 10) with (c = 0) SomeMethod();
+```
+
+Using a single `with` where possible is preferred as the compiler can optimize it better.

--- a/docs/Current/ControlFlow.md
+++ b/docs/Current/ControlFlow.md
@@ -25,6 +25,7 @@
     - [2.4.4.4](#2444-enumerated-collections) Enumerated Collections
 - [2.5](#25-switch) Switch
 - [2.6](#26-exceptions) Exceptions
+- [2.7]()
 
 ## 2.1 Functions
 
@@ -653,3 +654,32 @@ throw new Exception();
 ```
 
 This will crash the program. Throw expressions only accept objects that are or derive from `Exception`.
+
+## 2.7 With Expressions and Statements
+
+The `with` expression or statement can be used to wrap code inside of an assignment that is reversed when done.
+
+For example:
+
+```belte
+this.a = 3;
+
+return with (a = 6) SomeMethod();
+```
+
+In the above example, `SomeMethod` is ran with the field `a` set to 6, but before returning, `a` is set back to it's
+starting value of 3.
+
+In statement form:
+
+```belte
+this.a = 3;
+
+with (a = 6) try {
+  return SomeMethod();
+}
+```
+
+In the case of an exception or return or other control-flow breaking circumstance within the body of the `with`, the
+reversal will not take place as the with body is not exited normally. To ensure that the reversal always takes place,
+a `try` keyword can be specified preceding the body as seen in the above example.

--- a/docs/Current/Overview.md
+++ b/docs/Current/Overview.md
@@ -119,6 +119,7 @@ These keywords are reserved names and cannot be used as identifiers.
 - [virtual](ClassesAndObjects.md#432-overriding-modifiers)
 - [where](ClassesAndObjects.md#451-constraint-clauses)
 - [while](ControlFlow.md#241-while-loops)
+- [with](ControlFlow.md#27-with-expressions-and-statements)
 
 The following keywords are reserved names but are not yet used:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,6 +54,7 @@
         - [2.4.4.4](Current/ControlFlow.md#2444-enumerated-collections) Enumerated Collections
     - [2.5](Current/ControlFlow.md#25-switch) Switch
     - [2.6](Current/ControlFlow.md#26-exceptions) Exceptions
+    - [2.7](Current/ControlFlow.md#27-with-expressions-and-statements) With Expressions and Statements
   - [3](Current/Data.md) Data
     - [3.1](Current/Data.md#31-data-types) Data Types
       - [3.1.1](Current/Data.md#311-casts) Casts

--- a/extensions/belte-nolsp/belte.tmLanguage.json
+++ b/extensions/belte-nolsp/belte.tmLanguage.json
@@ -29,7 +29,7 @@
             "patterns": [
                 {
                     "name": "keyword.control.belte",
-                    "match": "\\b(if|else|while|for|return|break|continue|do|try|catch|finally|throw|switch|goto|default|case)\\b"
+                    "match": "\\b(if|else|while|for|return|break|continue|do|try|catch|finally|throw|switch|goto|default|case|with)\\b"
                 },
                 {
                     "name": "keyword.other.belte",

--- a/src/Buckle/CommandLine/BuckleCommandLine.cs
+++ b/src/Buckle/CommandLine/BuckleCommandLine.cs
@@ -44,6 +44,7 @@ public static partial class BuckleCommandLine {
         new DiagnosticInfo(0289, "BU"),
         new DiagnosticInfo(0290, "BU"),
         new DiagnosticInfo(0321, "BU"),
+        new DiagnosticInfo(0425, "BU"),
     ];
 
     private static readonly DiagnosticInfo[] WarningLevel2 = [

--- a/src/Buckle/Compiler.Tests/CodeAnalysis/Evaluating/EvaluatorTests.cs
+++ b/src/Buckle/Compiler.Tests/CodeAnalysis/Evaluating/EvaluatorTests.cs
@@ -373,6 +373,13 @@ public sealed class EvaluatorTests {
     // Null-Binding statements
     [InlineData("int? a = 10; int! b = 0; if (a -> x!) { b = x; } return b;", 10)]
     [InlineData("int? a = null; int! b = 0; if (a -> x!) { b = x; } return b;", 0)]
+    // With expressions/statements
+    [InlineData("int a = 3; return with (a = 5) a + 5;", 10)]
+    [InlineData("int a = 3; int b = with (a = 5) a + 5; return b;", 10)]
+    [InlineData("int a = 3; int b = with (a = 5) a + 5; return a;", 3)]
+    [InlineData("int a = 3; with (a = 5) try { return a + 5; }", 10)]
+    [InlineData("int a = 3; int b = 0; with (a = 5) try { b = a + 5; } return b;", 10)]
+    [InlineData("int a = 3; int b = 0; with (a = 5) try { b = a + 5; } return a;", 3)]
     // Local function statements
     [InlineData("int? A() { int? B() { return 2; } return B() + 1; } return A();", 3)]
     [InlineData("int? A() { int? B() { int? A() { return 2; } return A() + 1; } return B() + 1; } return A();", 4)]

--- a/src/Buckle/Compiler.Tests/Diagnostics/DiagnosticTests.cs
+++ b/src/Buckle/Compiler.Tests/Diagnostics/DiagnosticTests.cs
@@ -5250,4 +5250,21 @@ public sealed class DiagnosticTests {
 
         AssertDiagnostics(text, diagnostics, _writer);
     }
+
+    [Fact]
+    public void Reports_Error_BU0424_WithExpressionNotAssignment() {
+        var text = @"
+            int a = 3;
+
+            with ([a]) {
+                int b = 5;
+            }
+        ";
+
+        var diagnostics = @"
+            the context expression of a with statement or with expression must be an assignment
+        ";
+
+        AssertDiagnostics(text, diagnostics, _writer);
+    }
 }

--- a/src/Buckle/Compiler.Tests/Diagnostics/DiagnosticTests.cs
+++ b/src/Buckle/Compiler.Tests/Diagnostics/DiagnosticTests.cs
@@ -5267,4 +5267,21 @@ public sealed class DiagnosticTests {
 
         AssertDiagnostics(text, diagnostics, _writer);
     }
+
+    [Fact]
+    public void Reports_Warning_BU0425_ExitingControlFlowInWith() {
+        var text = @"
+            int a = 3;
+
+            with (a = 0) {
+                [return 3;]
+            }
+        ";
+
+        var diagnostics = @"
+            exiting the with body early will result in the reversals not taking place; consider using a 'with (...) try'
+        ";
+
+        AssertDiagnostics(text, diagnostics, _writer, true);
+    }
 }

--- a/src/Buckle/Compiler/CodeAnalysis/Binding/Binder.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Binding/Binder.cs
@@ -3061,6 +3061,8 @@ internal partial class Binder {
             case SyntaxKind.ParenthesizedLambdaExpression:
             case SyntaxKind.SimpleLambdaExpression:
                 return BindAnonymousFunction((AnonymousFunctionExpressionSyntax)node, diagnostics);
+            case SyntaxKind.WithExpression:
+                return BindWithExpression((WithExpressionSyntax)node, diagnostics);
             default:
                 throw ExceptionUtilities.UnexpectedValue(node.kind);
         }
@@ -3150,6 +3152,20 @@ internal partial class Binder {
                 true
             );
         }
+    }
+
+    private BoundWithExpression BindWithExpression(WithExpressionSyntax node, BelteDiagnosticQueue diagnostics) {
+        var hasErrors = false;
+
+        if (node.expression.kind != SyntaxKind.AssignmentExpression) {
+            diagnostics.Push(Error.WithExpressionNotAssignment(node.expression.location));
+            hasErrors = true;
+        }
+
+        var expression = BindExpression(node.expression, diagnostics);
+        var body = BindExpression(node.body, diagnostics);
+
+        return new BoundWithExpression(node, expression, body, body.type, hasErrors);
     }
 
     private UnboundLambda BindAnonymousFunction(
@@ -10963,6 +10979,7 @@ symIsHidden:;
             SyntaxKind.SwitchStatement => BindSwitchStatement((SwitchStatementSyntax)node, diagnostics),
             SyntaxKind.GotoStatement => BindGotoStatement((GotoStatementSyntax)node, diagnostics),
             SyntaxKind.InlineILStatement => BindInlineILStatement((InlineILStatementSyntax)node, diagnostics),
+            SyntaxKind.WithStatement => BindWithStatement((WithStatementSyntax)node, diagnostics),
             _ => throw ExceptionUtilities.UnexpectedValue(node.kind),
         };
     }
@@ -11141,6 +11158,32 @@ symIsHidden:;
             : BindPossibleEmbeddedStatement(node.elseClause.body, diagnostics);
 
         return new BoundIfStatement(node, condition, consequence, alternative);
+    }
+
+    private BoundWithStatement BindWithStatement(WithStatementSyntax node, BelteDiagnosticQueue diagnostics) {
+        var hasErrors = false;
+
+        if (node.expression.kind != SyntaxKind.AssignmentExpression) {
+            diagnostics.Push(Error.WithExpressionNotAssignment(node.expression.location));
+            hasErrors = true;
+        }
+
+        var expression = BindExpression(node.expression, diagnostics);
+        var builder = ArrayBuilder<BoundStatement>.GetInstance();
+
+        // ? We don't create a new scope if the body is a block for with statements specifically
+        if (node.body.kind == SyntaxKind.BlockStatement) {
+            var statements = ((BlockStatementSyntax)node.body).statements;
+
+            foreach (var statement in statements)
+                builder.Add(BindStatement(statement, diagnostics));
+        } else {
+            builder.Add(BindStatement(node.body, diagnostics));
+        }
+
+        var wrapWithTry = node.tryKeyword is not null;
+
+        return new BoundWithStatement(node, expression, builder.ToImmutableAndFree(), wrapWithTry, hasErrors);
     }
 
     private BoundNullBindingStatement BindNullBindingStatement(

--- a/src/Buckle/Compiler/CodeAnalysis/Binding/Binder.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Binding/Binder.cs
@@ -3155,17 +3155,28 @@ internal partial class Binder {
     }
 
     private BoundWithExpression BindWithExpression(WithExpressionSyntax node, BelteDiagnosticQueue diagnostics) {
-        var hasErrors = false;
+        var assignments = BindAssignmentExpressionList(node.expressions, diagnostics, out var hasErrors);
+        var body = BindExpression(node.body, diagnostics);
+        return new BoundWithExpression(node, assignments, body, body.type, hasErrors);
+    }
 
-        if (node.expression.kind != SyntaxKind.AssignmentExpression) {
-            diagnostics.Push(Error.WithExpressionNotAssignment(node.expression.location));
-            hasErrors = true;
+    private ImmutableArray<BoundExpression> BindAssignmentExpressionList(
+        SeparatedSyntaxList<ExpressionSyntax> expressions,
+        BelteDiagnosticQueue diagnostics,
+        out bool hasErrors) {
+        hasErrors = false;
+        var builder = ArrayBuilder<BoundExpression>.GetInstance();
+
+        foreach (var expression in expressions) {
+            if (expression.kind != SyntaxKind.AssignmentExpression) {
+                diagnostics.Push(Error.WithExpressionNotAssignment(expression.location));
+                hasErrors = true;
+            }
+
+            builder.Add(BindExpression(expression, diagnostics));
         }
 
-        var expression = BindExpression(node.expression, diagnostics);
-        var body = BindExpression(node.body, diagnostics);
-
-        return new BoundWithExpression(node, expression, body, body.type, hasErrors);
+        return builder.ToImmutableAndFree();
     }
 
     private UnboundLambda BindAnonymousFunction(
@@ -11161,29 +11172,11 @@ symIsHidden:;
     }
 
     private BoundWithStatement BindWithStatement(WithStatementSyntax node, BelteDiagnosticQueue diagnostics) {
-        var hasErrors = false;
-
-        if (node.expression.kind != SyntaxKind.AssignmentExpression) {
-            diagnostics.Push(Error.WithExpressionNotAssignment(node.expression.location));
-            hasErrors = true;
-        }
-
-        var expression = BindExpression(node.expression, diagnostics);
-        var builder = ArrayBuilder<BoundStatement>.GetInstance();
-
-        // ? We don't create a new scope if the body is a block for with statements specifically
-        if (node.body.kind == SyntaxKind.BlockStatement) {
-            var statements = ((BlockStatementSyntax)node.body).statements;
-
-            foreach (var statement in statements)
-                builder.Add(BindStatement(statement, diagnostics));
-        } else {
-            builder.Add(BindStatement(node.body, diagnostics));
-        }
-
+        var assignments = BindAssignmentExpressionList(node.expressions, diagnostics, out var hasErrors);
         var wrapWithTry = node.tryKeyword is not null;
-
-        return new BoundWithStatement(node, expression, builder.ToImmutableAndFree(), wrapWithTry, hasErrors);
+        var binder = wrapWithTry ? this : GetBinder(node);
+        var body = binder.BindPossibleEmbeddedStatement(node.body, diagnostics);
+        return new BoundWithStatement(node, assignments, body, wrapWithTry, hasErrors);
     }
 
     private BoundNullBindingStatement BindNullBindingStatement(
@@ -12583,10 +12576,6 @@ symIsHidden:;
 
     private BoundBlockStatement BindBlockStatement(BlockStatementSyntax node, BelteDiagnosticQueue diagnostics) {
         var binder = GetBinder(node);
-
-        if (node.modifiers?.Any(t => t.kind == SyntaxKind.LowlevelKeyword) == true)
-            binder = binder.WithAdditionalFlags(BinderFlags.LowLevelContext);
-
         return binder.BindBlockParts(node, diagnostics);
     }
 
@@ -12620,6 +12609,9 @@ symIsHidden:;
             var requiredValueKind = GetRequiredReturnValueKind(refKind);
             argument = BindValue(expressionSyntax, diagnostics, requiredValueKind);
         }
+
+        if (flags.Includes(BinderFlags.InWithBody))
+            diagnostics.Push(Warning.ExitingControlFlowInWith(node.location));
 
         var returnType = GetCurrentReturnType(out var signatureRefKind);
         var hasErrors = false;

--- a/src/Buckle/Compiler/CodeAnalysis/Binding/BinderFlags.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Binding/BinderFlags.cs
@@ -18,15 +18,16 @@ internal enum BinderFlags : uint {
     ConstructorInitializer = 1 << 7,
     ObjectInitializerMember = 1 << 8,
     ConstContext = 1 << 9,
+    InWithBody = 1 << 10,
 
-    InCatchBlock = 1 << 10,
-    InFinallyBlock = 1 << 11,
-    InTryBlockOfTryCatch = 1 << 12,
-    InNestedFinallyBlock = 1 << 13,
+    InCatchBlock = 1 << 11,
+    InFinallyBlock = 1 << 12,
+    InTryBlockOfTryCatch = 1 << 13,
+    InNestedFinallyBlock = 1 << 14,
 
-    InContextualAttributeBinder = 1 << 14,
-    AttributeArgument = 1 << 15,
-    EarlyAttributeBinding = 1 << 16,
+    InContextualAttributeBinder = 1 << 15,
+    AttributeArgument = 1 << 16,
+    EarlyAttributeBinding = 1 << 17,
 
     AllClearedAtExecutableCodeBoundary = InCatchBlock | InFinallyBlock | InTryBlockOfTryCatch | InNestedFinallyBlock,
 }

--- a/src/Buckle/Compiler/CodeAnalysis/Binding/BoundTree/BoundNodes.xml
+++ b/src/Buckle/Compiler/CodeAnalysis/Binding/BoundTree/BoundNodes.xml
@@ -418,6 +418,15 @@
     <Field Name="consequence" Type="BoundStatement"/>
     <Field Name="alternative" Type="BoundStatement?"/>
   </Node>
+  <Node Name="BoundWithStatement" Base="BoundStatement">
+    <Field Name="assignment" Type="BoundExpression"/>
+    <Field Name="body" Type="ImmutableArray&lt;BoundStatement&gt;"/>
+    <Field Name="wrapWithTry" Type="bool"/>
+  </Node>
+  <Node Name="BoundWithExpression" Base="BoundExpression">
+    <Field Name="assignment" Type="BoundExpression"/>
+    <Field Name="body" Type="BoundExpression"/>
+  </Node>
   <Node Name="BoundGotoStatement" Base="BoundStatement">
     <Field Name="label" Type="LabelSymbol"/>
     <Field Name="caseExpression" Type="BoundExpression?"/>

--- a/src/Buckle/Compiler/CodeAnalysis/Binding/BoundTree/BoundNodes.xml
+++ b/src/Buckle/Compiler/CodeAnalysis/Binding/BoundTree/BoundNodes.xml
@@ -419,12 +419,12 @@
     <Field Name="alternative" Type="BoundStatement?"/>
   </Node>
   <Node Name="BoundWithStatement" Base="BoundStatement">
-    <Field Name="assignment" Type="BoundExpression"/>
-    <Field Name="body" Type="ImmutableArray&lt;BoundStatement&gt;"/>
+    <Field Name="assignments" Type="ImmutableArray&lt;BoundExpression&gt;"/>
+    <Field Name="body" Type="BoundStatement"/>
     <Field Name="wrapWithTry" Type="bool"/>
   </Node>
   <Node Name="BoundWithExpression" Base="BoundExpression">
-    <Field Name="assignment" Type="BoundExpression"/>
+    <Field Name="assignments" Type="ImmutableArray&lt;BoundExpression&gt;"/>
     <Field Name="body" Type="BoundExpression"/>
   </Node>
   <Node Name="BoundGotoStatement" Base="BoundStatement">

--- a/src/Buckle/Compiler/CodeAnalysis/Binding/BoundTree/BoundTreeExpander.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Binding/BoundTree/BoundTreeExpander.cs
@@ -71,6 +71,7 @@ internal abstract partial class BoundTreeExpander {
             BoundKind.SwitchStatement => ExpandSwitchStatement((BoundSwitchStatement)statement),
             BoundKind.InlineILStatement => ExpandInlineILStatement((BoundInlineILStatement)statement),
             BoundKind.SwitchDispatch => ExpandSwitchDispatch((BoundSwitchDispatch)statement),
+            BoundKind.WithStatement => ExpandWithStatement((BoundWithStatement)statement),
             _ => throw ExceptionUtilities.UnexpectedValue(statement.kind),
         };
     }
@@ -78,6 +79,19 @@ internal abstract partial class BoundTreeExpander {
     private protected virtual List<BoundStatement> ExpandErrorStatement(BoundErrorStatement statement) {
         // Even though there is potential for expanding the childBoundNodes, it will be an error anyways so why bother
         return [statement];
+    }
+
+    private protected virtual List<BoundStatement> ExpandWithStatement(BoundWithStatement statement) {
+        var statements = ExpandExpression(statement.assignment, out var newAssignment);
+
+        var bodyStatements = ArrayBuilder<BoundStatement>.GetInstance();
+
+        foreach (var childStatement in statement.body)
+            bodyStatements.AddRange(ExpandStatement(childStatement));
+
+        statements.Add(statement.Update(newAssignment, bodyStatements.ToImmutableAndFree(), statement.wrapWithTry));
+
+        return statements;
     }
 
     private protected virtual List<BoundStatement> ExpandSwitchStatement(BoundSwitchStatement statement) {
@@ -366,8 +380,25 @@ internal abstract partial class BoundTreeExpander {
             BoundKind.InterpolatedStringExpression => ExpandInterpolatedStringExpression((BoundInterpolatedStringExpression)expression, out replacement, useKind),
             BoundKind.FunctionLoad => ExpandFunctionLoad((BoundFunctionLoad)expression, out replacement, useKind),
             BoundKind.IsPatternExpression => ExpandIsPatternExpression((BoundIsPatternExpression)expression, out replacement, useKind),
+            BoundKind.WithExpression => ExpandWithExpression((BoundWithExpression)expression, out replacement, useKind),
             _ => throw ExceptionUtilities.UnexpectedValue(expression.kind),
         };
+    }
+
+    private protected virtual List<BoundStatement> ExpandWithExpression(
+        BoundWithExpression expression,
+        out BoundExpression replacement,
+        UseKind useKind) {
+        var statements = ExpandExpression(expression.assignment, out var newAssignment);
+        statements.AddRange(ExpandExpression(expression.body, out var newBody));
+
+        if (statements.Count != 0 || expression.assignment != newAssignment || expression.body != newBody) {
+            replacement = expression.Update(newAssignment, newBody, expression.type);
+            return statements;
+        }
+
+        replacement = expression;
+        return [];
     }
 
     private protected virtual List<BoundStatement> ExpandFunctionLoad(

--- a/src/Buckle/Compiler/CodeAnalysis/Binding/BoundTree/BoundTreeExpander.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Binding/BoundTree/BoundTreeExpander.cs
@@ -82,14 +82,17 @@ internal abstract partial class BoundTreeExpander {
     }
 
     private protected virtual List<BoundStatement> ExpandWithStatement(BoundWithStatement statement) {
-        var statements = ExpandExpression(statement.assignment, out var newAssignment);
+        var statements = ExpandExpressionList(statement.assignments, out var newAssignments);
+        var syntax = statement.syntax;
 
-        var bodyStatements = ArrayBuilder<BoundStatement>.GetInstance();
-
-        foreach (var childStatement in statement.body)
-            bodyStatements.AddRange(ExpandStatement(childStatement));
-
-        statements.Add(statement.Update(newAssignment, bodyStatements.ToImmutableAndFree(), statement.wrapWithTry));
+        statements.Add(
+            new BoundWithStatement(
+                syntax,
+                newAssignments,
+                Simplify(syntax, ExpandStatement(statement.body)),
+                statement.wrapWithTry
+            )
+        );
 
         return statements;
     }
@@ -389,11 +392,11 @@ internal abstract partial class BoundTreeExpander {
         BoundWithExpression expression,
         out BoundExpression replacement,
         UseKind useKind) {
-        var statements = ExpandExpression(expression.assignment, out var newAssignment);
+        var statements = ExpandExpressionList(expression.assignments, out var newAssignments);
         statements.AddRange(ExpandExpression(expression.body, out var newBody));
 
-        if (statements.Count != 0 || expression.assignment != newAssignment || expression.body != newBody) {
-            replacement = expression.Update(newAssignment, newBody, expression.type);
+        if (statements.Count != 0 || expression.assignments != newAssignments || expression.body != newBody) {
+            replacement = expression.Update(newAssignments, newBody, expression.type);
             return statements;
         }
 

--- a/src/Buckle/Compiler/CodeAnalysis/Binding/LocalBinderFactory.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Binding/LocalBinderFactory.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Buckle.CodeAnalysis.Symbols;
 using Buckle.CodeAnalysis.Syntax;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -101,8 +102,14 @@ internal sealed class LocalBinderFactory : SyntaxWalker {
             case SyntaxKind.IfStatement:
             case SyntaxKind.NullBindingStatement:
             case SyntaxKind.ReturnStatement:
+            case SyntaxKind.WithStatement:
                 embeddedScopeDesignator = statement;
                 return new EmbeddedStatementBinder(enclosing, statement);
+            case SyntaxKind.SwitchStatement:
+                var switchStatement = (SwitchStatementSyntax)statement;
+                embeddedScopeDesignator = switchStatement.expression;
+                return new ExpressionVariableBinder(switchStatement.expression, enclosing);
+
             default:
                 embeddedScopeDesignator = null;
                 return enclosing;
@@ -303,11 +310,27 @@ internal sealed class LocalBinderFactory : SyntaxWalker {
     }
 
     internal override void VisitBlockStatement(BlockStatementSyntax node) {
-        var blockBinder = new BlockBinder(_enclosing, node);
+        var blockBinder = node.modifiers?.Any(t => t.kind == SyntaxKind.LowlevelKeyword) == true
+            ? new BlockBinder(_enclosing, node, BinderFlags.LowLevelContext)
+            : new BlockBinder(_enclosing, node);
+
         AddToMap(node, blockBinder);
 
         foreach (var statement in node.statements)
             Visit(statement, blockBinder);
+    }
+
+    internal override void VisitWithStatement(WithStatementSyntax node) {
+        Binder enclosing;
+
+        if (node.tryKeyword is null) {
+            enclosing = _enclosing.WithAdditionalFlags(BinderFlags.InWithBody);
+            AddToMap(node, enclosing);
+        } else {
+            enclosing = _enclosing;
+        }
+
+        VisitPossibleEmbeddedStatement(node.body, enclosing);
     }
 
     internal override void VisitWhileStatement(WhileStatementSyntax node) {

--- a/src/Buckle/Compiler/CodeAnalysis/Display/DisplayText.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Display/DisplayText.cs
@@ -1216,7 +1216,7 @@ public sealed class DisplayText {
         text.Write(CreateKeyword(SyntaxKind.WithKeyword));
         text.Write(CreateSpace());
         text.Write(CreatePunctuation(SyntaxKind.OpenParenToken));
-        DisplayNode(text, node.assignment);
+        DisplayArguments(text, node.assignments);
         text.Write(CreatePunctuation(SyntaxKind.CloseParenToken));
         text.Write(CreateSpace());
         DisplayNode(text, node.body);
@@ -1226,7 +1226,7 @@ public sealed class DisplayText {
         text.Write(CreateKeyword(SyntaxKind.WithKeyword));
         text.Write(CreateSpace());
         text.Write(CreatePunctuation(SyntaxKind.OpenParenToken));
-        DisplayNode(text, node.assignment);
+        DisplayArguments(text, node.assignments);
         text.Write(CreatePunctuation(SyntaxKind.CloseParenToken));
         text.Write(CreateSpace());
 
@@ -1235,17 +1235,7 @@ public sealed class DisplayText {
             text.Write(CreateSpace());
         }
 
-        text.Write(CreatePunctuation(SyntaxKind.OpenBraceToken));
-        text.WriteLine();
-
-        text.indent++;
-
-        foreach (var statement in node.body)
-            DisplayNode(text, statement);
-
-        text.indent--;
-        text.Write(CreatePunctuation(SyntaxKind.CloseBraceToken));
-        text.WriteLine();
+        DisplayNode(text, node.body);
     }
 
     private static void DisplayAsOperator(DisplayText text, BoundAsOperator node) {

--- a/src/Buckle/Compiler/CodeAnalysis/Display/DisplayText.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Display/DisplayText.cs
@@ -167,6 +167,9 @@ public sealed class DisplayText {
             case BoundKind.ContinueStatement:
                 DisplayContinueStatement(text);
                 break;
+            case BoundKind.WithStatement:
+                DisplayWithStatement(text, (BoundWithStatement)node);
+                break;
             case BoundKind.SequencePoint:
                 DisplaySequencePoint(text, (BoundSequencePoint)node);
                 break;
@@ -341,6 +344,9 @@ public sealed class DisplayText {
                 break;
             case BoundKind.IsPatternExpression:
                 DisplayIsPatternExpression(text, (BoundIsPatternExpression)node);
+                break;
+            case BoundKind.WithExpression:
+                DisplayWithExpression(text, (BoundWithExpression)node);
                 break;
             default:
                 throw ExceptionUtilities.UnexpectedValue(node.kind);
@@ -1204,6 +1210,42 @@ public sealed class DisplayText {
         text.Write(CreateSpace());
         SymbolDisplay.AppendToDisplayText(text, node.local);
         text.Write(CreatePunctuation(SyntaxKind.CloseParenToken));
+    }
+
+    private static void DisplayWithExpression(DisplayText text, BoundWithExpression node) {
+        text.Write(CreateKeyword(SyntaxKind.WithKeyword));
+        text.Write(CreateSpace());
+        text.Write(CreatePunctuation(SyntaxKind.OpenParenToken));
+        DisplayNode(text, node.assignment);
+        text.Write(CreatePunctuation(SyntaxKind.CloseParenToken));
+        text.Write(CreateSpace());
+        DisplayNode(text, node.body);
+    }
+
+    private static void DisplayWithStatement(DisplayText text, BoundWithStatement node) {
+        text.Write(CreateKeyword(SyntaxKind.WithKeyword));
+        text.Write(CreateSpace());
+        text.Write(CreatePunctuation(SyntaxKind.OpenParenToken));
+        DisplayNode(text, node.assignment);
+        text.Write(CreatePunctuation(SyntaxKind.CloseParenToken));
+        text.Write(CreateSpace());
+
+        if (node.wrapWithTry) {
+            text.Write(CreateKeyword(SyntaxKind.TryKeyword));
+            text.Write(CreateSpace());
+        }
+
+        text.Write(CreatePunctuation(SyntaxKind.OpenBraceToken));
+        text.WriteLine();
+
+        text.indent++;
+
+        foreach (var statement in node.body)
+            DisplayNode(text, statement);
+
+        text.indent--;
+        text.Write(CreatePunctuation(SyntaxKind.CloseBraceToken));
+        text.WriteLine();
     }
 
     private static void DisplayAsOperator(DisplayText text, BoundAsOperator node) {

--- a/src/Buckle/Compiler/CodeAnalysis/Lowering/SharedExpander.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Lowering/SharedExpander.cs
@@ -7,6 +7,7 @@ using Buckle.CodeAnalysis.Syntax;
 using Buckle.Diagnostics;
 using Buckle.Libraries;
 using Buckle.Utilities;
+using Microsoft.CodeAnalysis.PooledObjects;
 using static Buckle.CodeAnalysis.Binding.BoundFactory;
 
 namespace Buckle.CodeAnalysis.Lowering;
@@ -350,5 +351,182 @@ internal class SharedExpander : BoundTreeExpander {
         }
 
         return statements;
+    }
+
+    private protected override List<BoundStatement> ExpandWithStatement(BoundWithStatement statement) {
+        /*
+
+        with (<assignment>) {
+            <body>
+        }
+
+        ---->
+
+        temp = <assignment.left>
+        <assignment>
+        <body>
+        <assignment.left> = temp
+
+        ----> surround with try
+
+        temp = <assignment.left>
+        <assignment>
+
+        try {
+            <body>
+        } finally {
+            <assignment.left> = temp
+        }
+
+        */
+        var syntax = statement.syntax;
+        var assignment = statement.assignment;
+        var left = GetLeft(assignment, out var isRef);
+
+        var temp = GenerateTempLocal(left.type);
+
+        var statements = ExpandExpression(left, out var newLeft, UseKind.Writable);
+        statements.Add(LocalDeclaration(syntax, temp, newLeft));
+        statements.AddRange(RecreateAssignment(syntax, newLeft, assignment));
+
+        if (statement.wrapWithTry) {
+            var bodyBuilder = ArrayBuilder<BoundStatement>.GetInstance();
+
+            foreach (var bodyStatement in statement.body)
+                bodyBuilder.AddRange(ExpandStatement(bodyStatement));
+
+            var finallyBody = Block(syntax,
+                new BoundExpressionStatement(syntax, Assignment(syntax, newLeft, Local(syntax, temp), isRef, temp.type))
+            );
+
+            statements.Add(
+                new BoundTryStatement(syntax, Block(syntax, bodyBuilder.ToArrayAndFree()), null, finallyBody)
+            );
+        } else {
+            foreach (var bodyStatement in statement.body)
+                statements.AddRange(ExpandStatement(bodyStatement));
+
+            statements.Add(
+                new BoundExpressionStatement(syntax, Assignment(syntax, newLeft, Local(syntax, temp), isRef, temp.type))
+            );
+        }
+
+        return statements;
+    }
+
+    private protected override List<BoundStatement> ExpandWithExpression(
+        BoundWithExpression expression,
+        out BoundExpression replacement,
+        UseKind useKind) {
+        /*
+
+        with (<assignment>) <try> <body>
+
+        ---->
+
+        temp = <assignment.left>
+        <assignment>
+        temp2 = <body>
+        <assignment.left> = temp
+        temp2
+
+        */
+        var syntax = expression.syntax;
+        var assignment = expression.assignment;
+        var body = expression.body;
+        var left = GetLeft(assignment, out var isRef);
+
+        var temp = GenerateTempLocal(left.type);
+        var temp2 = GenerateTempLocal(body.type);
+
+        var statements = ExpandExpression(left, out var newLeft, UseKind.Writable);
+        statements.Add(LocalDeclaration(syntax, temp, newLeft));
+        statements.AddRange(RecreateAssignment(syntax, newLeft, assignment));
+
+        statements.AddRange(ExpandExpression(body, out var newBody));
+        statements.Add(LocalDeclaration(syntax, temp2, newBody));
+
+        statements.Add(
+            new BoundExpressionStatement(syntax, Assignment(syntax, newLeft, Local(syntax, temp), isRef, temp.type))
+        );
+
+        replacement = Local(syntax, temp2);
+
+        return statements;
+    }
+
+    private static BoundExpression GetLeft(BoundExpression expression, out bool isRef) {
+        switch (expression.kind) {
+            case BoundKind.AssignmentOperator:
+                var assignment = (BoundAssignmentOperator)expression;
+                isRef = assignment.isRef;
+                return assignment.left;
+            case BoundKind.CompoundAssignmentOperator:
+                isRef = false;
+                return ((BoundCompoundAssignmentOperator)expression).left;
+            case BoundKind.NullCoalescingAssignmentOperator:
+                isRef = false;
+                return ((BoundNullCoalescingAssignmentOperator)expression).left;
+            default:
+                throw ExceptionUtilities.UnexpectedValue(expression.kind);
+        }
+    }
+
+    private List<BoundStatement> RecreateAssignment(
+        SyntaxNode syntax,
+        BoundExpression newLeft,
+        BoundExpression expression) {
+        switch (expression.kind) {
+            case BoundKind.AssignmentOperator: {
+                    var assignment = (BoundAssignmentOperator)expression;
+                    var newAssignment = new BoundAssignmentOperator(
+                        syntax,
+                        newLeft,
+                        assignment.right,
+                        assignment.isRef,
+                        assignment.type
+                    );
+
+                    var statements = ExpandExpression(newAssignment, out var replacement);
+                    statements.Add(new BoundExpressionStatement(syntax, replacement));
+                    return statements;
+                }
+            case BoundKind.CompoundAssignmentOperator: {
+                    var assignment = (BoundCompoundAssignmentOperator)expression;
+                    var newAssignment = new BoundCompoundAssignmentOperator(
+                        syntax,
+                        newLeft,
+                        assignment.right,
+                        assignment.op,
+                        assignment.leftPlaceholder,
+                        assignment.leftConversion,
+                        assignment.finalPlaceholder,
+                        assignment.finalConversion,
+                        assignment.resultKind,
+                        assignment.originalUserDefinedOperators,
+                        assignment.type
+                    );
+
+                    var statements = ExpandExpression(newAssignment, out var replacement);
+                    statements.Add(new BoundExpressionStatement(syntax, replacement));
+                    return statements;
+                }
+            case BoundKind.NullCoalescingAssignmentOperator: {
+                    var assignment = (BoundNullCoalescingAssignmentOperator)expression;
+                    var newAssignment = new BoundNullCoalescingAssignmentOperator(
+                        syntax,
+                        newLeft,
+                        assignment.right,
+                        assignment.isPropagation,
+                        assignment.type
+                    );
+
+                    var statements = ExpandExpression(newAssignment, out var replacement);
+                    statements.Add(new BoundExpressionStatement(syntax, replacement));
+                    return statements;
+                }
+            default:
+                throw ExceptionUtilities.UnexpectedValue(expression.kind);
+        }
     }
 }

--- a/src/Buckle/Compiler/CodeAnalysis/Lowering/SharedExpander.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Lowering/SharedExpander.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using Buckle.CodeAnalysis.Binding;
 using Buckle.CodeAnalysis.CodeGeneration;
@@ -356,59 +357,49 @@ internal class SharedExpander : BoundTreeExpander {
     private protected override List<BoundStatement> ExpandWithStatement(BoundWithStatement statement) {
         /*
 
-        with (<assignment>) {
+        with (<assignments>) {
             <body>
         }
 
         ---->
 
-        temp = <assignment.left>
+        temp0 = <assignment.left>
         <assignment>
+        ...
+
         <body>
-        <assignment.left> = temp
+
+        <assignment.left> = temp0
+        ...
 
         ----> surround with try
 
-        temp = <assignment.left>
+        temp0 = <assignment.left>
         <assignment>
+        ...
 
         try {
             <body>
         } finally {
-            <assignment.left> = temp
+            <assignment.left> = temp0
+            ...
         }
 
         */
         var syntax = statement.syntax;
-        var assignment = statement.assignment;
-        var left = GetLeft(assignment, out var isRef);
 
-        var temp = GenerateTempLocal(left.type);
+        var lefts = statement.assignments.SelectAsArray(a => GetLeft(a));
+        var temps = lefts.SelectAsArray(l => GenerateTempLocal(l.Item1.type) as DataContainerSymbol);
 
-        var statements = ExpandExpression(left, out var newLeft, UseKind.Writable);
-        statements.Add(LocalDeclaration(syntax, temp, newLeft));
-        statements.AddRange(RecreateAssignment(syntax, newLeft, assignment));
+        var statements = CreateWithPrologue(syntax, lefts, temps, statement.assignments, out var newLefts);
 
         if (statement.wrapWithTry) {
-            var bodyBuilder = ArrayBuilder<BoundStatement>.GetInstance();
-
-            foreach (var bodyStatement in statement.body)
-                bodyBuilder.AddRange(ExpandStatement(bodyStatement));
-
-            var finallyBody = Block(syntax,
-                new BoundExpressionStatement(syntax, Assignment(syntax, newLeft, Local(syntax, temp), isRef, temp.type))
-            );
-
-            statements.Add(
-                new BoundTryStatement(syntax, Block(syntax, bodyBuilder.ToArrayAndFree()), null, finallyBody)
-            );
+            var tryBody = Block(syntax, ExpandStatement(statement.body).ToArray());
+            var finallyBody = Block(syntax, CreateWithEpilogue(syntax, newLefts, temps).ToArray());
+            statements.Add(new BoundTryStatement(syntax, tryBody, null, finallyBody));
         } else {
-            foreach (var bodyStatement in statement.body)
-                statements.AddRange(ExpandStatement(bodyStatement));
-
-            statements.Add(
-                new BoundExpressionStatement(syntax, Assignment(syntax, newLeft, Local(syntax, temp), isRef, temp.type))
-            );
+            statements.AddRange(ExpandStatement(statement.body));
+            statements.AddRange(CreateWithEpilogue(syntax, lefts, temps));
         }
 
         return statements;
@@ -424,49 +415,89 @@ internal class SharedExpander : BoundTreeExpander {
 
         ---->
 
-        temp = <assignment.left>
+        temp0 = <assignment.left>
         <assignment>
-        temp2 = <body>
-        <assignment.left> = temp
-        temp2
+        ...
+
+        tempN = <body>
+
+        <assignment.left> = temp0
+        ...
+
+        tempN
 
         */
         var syntax = expression.syntax;
-        var assignment = expression.assignment;
         var body = expression.body;
-        var left = GetLeft(assignment, out var isRef);
 
-        var temp = GenerateTempLocal(left.type);
-        var temp2 = GenerateTempLocal(body.type);
+        var lefts = expression.assignments.SelectAsArray(a => GetLeft(a));
+        var temps = lefts.SelectAsArray(l => GenerateTempLocal(l.Item1.type) as DataContainerSymbol);
 
-        var statements = ExpandExpression(left, out var newLeft, UseKind.Writable);
-        statements.Add(LocalDeclaration(syntax, temp, newLeft));
-        statements.AddRange(RecreateAssignment(syntax, newLeft, assignment));
+        var tempN = GenerateTempLocal(body.type);
+
+        var statements = CreateWithPrologue(syntax, lefts, temps, expression.assignments, out var newLefts);
 
         statements.AddRange(ExpandExpression(body, out var newBody));
-        statements.Add(LocalDeclaration(syntax, temp2, newBody));
+        statements.Add(LocalDeclaration(syntax, tempN, newBody));
 
-        statements.Add(
-            new BoundExpressionStatement(syntax, Assignment(syntax, newLeft, Local(syntax, temp), isRef, temp.type))
-        );
+        statements.AddRange(CreateWithEpilogue(syntax, lefts, temps));
 
-        replacement = Local(syntax, temp2);
+        replacement = Local(syntax, tempN);
+        return statements;
+    }
+
+    private List<BoundStatement> CreateWithPrologue(
+        SyntaxNode syntax,
+        ImmutableArray<(BoundExpression, bool)> lefts,
+        ImmutableArray<DataContainerSymbol> temps,
+        ImmutableArray<BoundExpression> assignments,
+        out ImmutableArray<(BoundExpression, bool)> newLefts) {
+        var statements = new List<BoundStatement>();
+        var builder = ArrayBuilder<(BoundExpression, bool)>.GetInstance(lefts.Length);
+
+        for (var i = 0; i < assignments.Length; i++) {
+            var (left, isRef) = lefts[i];
+            var temp = temps[i];
+            var assignment = assignments[i];
+
+            statements.AddRange(ExpandExpression(left, out var newLeft, UseKind.Writable));
+            statements.Add(LocalDeclaration(syntax, temp, newLeft));
+            statements.AddRange(RecreateAssignment(syntax, newLeft, assignment));
+
+            builder.Add((newLeft, isRef));
+        }
+
+        newLefts = builder.ToImmutableAndFree();
+        return statements;
+    }
+
+    private List<BoundStatement> CreateWithEpilogue(
+        SyntaxNode syntax,
+        ImmutableArray<(BoundExpression, bool)> lefts,
+        ImmutableArray<DataContainerSymbol> temps) {
+        var statements = new List<BoundStatement>();
+
+        for (var i = temps.Length - 1; i >= 0; i--) {
+            var (left, isRef) = lefts[i];
+            var temp = temps[i];
+
+            statements.Add(
+                new BoundExpressionStatement(syntax, Assignment(syntax, left, Local(syntax, temp), isRef, temp.type))
+            );
+        }
 
         return statements;
     }
 
-    private static BoundExpression GetLeft(BoundExpression expression, out bool isRef) {
+    private static (BoundExpression, bool) GetLeft(BoundExpression expression) {
         switch (expression.kind) {
             case BoundKind.AssignmentOperator:
                 var assignment = (BoundAssignmentOperator)expression;
-                isRef = assignment.isRef;
-                return assignment.left;
+                return (assignment.left, assignment.isRef);
             case BoundKind.CompoundAssignmentOperator:
-                isRef = false;
-                return ((BoundCompoundAssignmentOperator)expression).left;
+                return (((BoundCompoundAssignmentOperator)expression).left, false);
             case BoundKind.NullCoalescingAssignmentOperator:
-                isRef = false;
-                return ((BoundNullCoalescingAssignmentOperator)expression).left;
+                return (((BoundNullCoalescingAssignmentOperator)expression).left, false);
             default:
                 throw ExceptionUtilities.UnexpectedValue(expression.kind);
         }

--- a/src/Buckle/Compiler/CodeAnalysis/Parser/LanguageParser.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Parser/LanguageParser.cs
@@ -1632,7 +1632,7 @@ internal sealed partial class LanguageParser : SyntaxParser {
     private WithStatementSyntax ParseWithStatement() {
         var keyword = EatToken();
         var openParenthesis = Match(SyntaxKind.OpenParenToken);
-        var expression = ParseAssignmentExpression();
+        var expressions = ParseAssignmentExpressionList();
         var closeParenthesis = Match(SyntaxKind.CloseParenToken);
 
         var tryKeyword = currentToken.kind == SyntaxKind.TryKeyword ? EatToken() : null;
@@ -1642,11 +1642,30 @@ internal sealed partial class LanguageParser : SyntaxParser {
         return SyntaxFactory.WithStatement(
             keyword,
             openParenthesis,
-            expression,
+            expressions,
             closeParenthesis,
             tryKeyword,
             body
         );
+    }
+
+    private SeparatedSyntaxList<ExpressionSyntax> ParseAssignmentExpressionList() {
+        var nodesAndSeparators = SyntaxListBuilder<BelteSyntaxNode>.Create();
+        var parseNextItem = true;
+
+        while (parseNextItem && currentToken.kind is not SyntaxKind.EndOfFileToken and not SyntaxKind.CloseParenToken) {
+            var expression = ParseAssignmentExpression();
+            nodesAndSeparators.Add(expression);
+
+            if (currentToken.kind == SyntaxKind.CommaToken) {
+                var comma = EatToken();
+                nodesAndSeparators.Add(comma);
+            } else {
+                parseNextItem = false;
+            }
+        }
+
+        return new SeparatedSyntaxList<ExpressionSyntax>(nodesAndSeparators.ToList());
     }
 
     private StatementSyntax ParseExpressionStatement() {
@@ -2028,14 +2047,14 @@ internal sealed partial class LanguageParser : SyntaxParser {
     private WithExpressionSyntax ParseWithExpression() {
         var keyword = EatToken();
         var openParenthesis = Match(SyntaxKind.OpenParenToken);
-        var expression = ParseAssignmentExpression();
+        var expressions = ParseAssignmentExpressionList();
         var closeParenthesis = Match(SyntaxKind.CloseParenToken);
         var body = ParseExpression();
 
         return SyntaxFactory.WithExpression(
             keyword,
             openParenthesis,
-            expression,
+            expressions,
             closeParenthesis,
             body
         );

--- a/src/Buckle/Compiler/CodeAnalysis/Parser/LanguageParser.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Parser/LanguageParser.cs
@@ -1120,6 +1120,8 @@ internal sealed partial class LanguageParser : SyntaxParser {
                 return ParseSwitchStatement();
             case SyntaxKind.GotoKeyword:
                 return ParseGotoStatement();
+            case SyntaxKind.WithKeyword:
+                return ParseWithStatement();
             case SyntaxKind.ILKeyword:
                 return ParseInlineILStatement();
         }
@@ -1627,6 +1629,26 @@ internal sealed partial class LanguageParser : SyntaxParser {
         return SyntaxFactory.ElseClause(keyword, statement);
     }
 
+    private WithStatementSyntax ParseWithStatement() {
+        var keyword = EatToken();
+        var openParenthesis = Match(SyntaxKind.OpenParenToken);
+        var expression = ParseAssignmentExpression();
+        var closeParenthesis = Match(SyntaxKind.CloseParenToken);
+
+        var tryKeyword = currentToken.kind == SyntaxKind.TryKeyword ? EatToken() : null;
+
+        var body = ParseStatement();
+
+        return SyntaxFactory.WithStatement(
+            keyword,
+            openParenthesis,
+            expression,
+            closeParenthesis,
+            tryKeyword,
+            body
+        );
+    }
+
     private StatementSyntax ParseExpressionStatement() {
         var diagnosticCount = currentToken.GetDiagnostics().Length;
         var expression = ParseExpression(allowEmpty: true);
@@ -1988,6 +2010,8 @@ internal sealed partial class LanguageParser : SyntaxParser {
                 return ParseAliasQualifiedName();
             case SyntaxKind.PeriodToken:
                 return ParseImplicitEnumFieldExpression();
+            case SyntaxKind.WithKeyword:
+                return ParseWithExpression();
             case SyntaxKind.IdentifierToken:
             case SyntaxKind.GlobalKeyword:
             default:
@@ -1999,6 +2023,22 @@ internal sealed partial class LanguageParser : SyntaxParser {
         var period = EatToken();
         var identifier = Match(SyntaxKind.IdentifierToken);
         return SyntaxFactory.ImplicitEnumFieldExpression(period, identifier);
+    }
+
+    private WithExpressionSyntax ParseWithExpression() {
+        var keyword = EatToken();
+        var openParenthesis = Match(SyntaxKind.OpenParenToken);
+        var expression = ParseAssignmentExpression();
+        var closeParenthesis = Match(SyntaxKind.CloseParenToken);
+        var body = ParseExpression();
+
+        return SyntaxFactory.WithExpression(
+            keyword,
+            openParenthesis,
+            expression,
+            closeParenthesis,
+            body
+        );
     }
 
     private ExpressionSyntax ParsePrimaryExpression(int parentPrecedence = 0, ExpressionSyntax left = null) {

--- a/src/Buckle/Compiler/CodeAnalysis/Syntax/Syntax.xml
+++ b/src/Buckle/Compiler/CodeAnalysis/Syntax/Syntax.xml
@@ -941,7 +941,7 @@
     <Field Name="openParenthesis" Type="SyntaxToken">
       <Kind Name="OpenParenToken"/>
     </Field>
-    <Field Name="expression" Type="ExpressionSyntax"/>
+    <Field Name="expressions" Type="SeparatedSyntaxList&lt;ExpressionSyntax&gt;"/>
     <Field Name="closeParenthesis" Type="SyntaxToken">
       <Kind Name="CloseParenToken"/>
     </Field>
@@ -1375,7 +1375,7 @@
     <Field Name="openParenthesis" Type="SyntaxToken">
       <Kind Name="OpenParenToken"/>
     </Field>
-    <Field Name="expression" Type="ExpressionSyntax"/>
+    <Field Name="expressions" Type="SeparatedSyntaxList&lt;ExpressionSyntax&gt;"/>
     <Field Name="closeParenthesis" Type="SyntaxToken">
       <Kind Name="CloseParenToken"/>
     </Field>

--- a/src/Buckle/Compiler/CodeAnalysis/Syntax/Syntax.xml
+++ b/src/Buckle/Compiler/CodeAnalysis/Syntax/Syntax.xml
@@ -933,6 +933,23 @@
     <Field Name="then" Type="StatementSyntax" Override="true"/>
     <Field Name="elseClause" Type="ElseClauseSyntax" Optional="true" Override="true"/>
   </Node>
+  <Node Name="WithStatementSyntax" Base="StatementSyntax">
+    <Kind Name="WithStatement"/>
+    <Field Name="keyword" Type="SyntaxToken">
+      <Kind Name="WithKeyword"/>
+    </Field>
+    <Field Name="openParenthesis" Type="SyntaxToken">
+      <Kind Name="OpenParenToken"/>
+    </Field>
+    <Field Name="expression" Type="ExpressionSyntax"/>
+    <Field Name="closeParenthesis" Type="SyntaxToken">
+      <Kind Name="CloseParenToken"/>
+    </Field>
+    <Field Name="tryKeyword" Type="SyntaxToken" Optional="true">
+      <Kind Name="TryKeyword"/>
+    </Field>
+    <Field Name="body" Type="StatementSyntax"/>
+  </Node>
   <Node Name="ElseClauseSyntax" Base="SyntaxNode">
     <Kind Name="ElseClause"/>
     <Field Name="keyword" Type="SyntaxToken">
@@ -1344,10 +1361,24 @@
     <Field Name="type" Type="TypeSyntax"/>
   </Node>
   <Node Name="ThrowExpressionSyntax" Base="ExpressionSyntax">
-    <Kind Name="ThrowExpression" />
+    <Kind Name="ThrowExpression"/>
     <Field Name="throwKeyword" Type="SyntaxToken">
       <Kind Name="ThrowKeyword"/>
     </Field>
     <Field Name="expression" Type="ExpressionSyntax"/>
+  </Node>
+  <Node Name="WithExpressionSyntax" Base="ExpressionSyntax">
+    <Kind Name="WithExpression"/>
+    <Field Name="keyword" Type="SyntaxToken">
+      <Kind Name="WithKeyword"/>
+    </Field>
+    <Field Name="openParenthesis" Type="SyntaxToken">
+      <Kind Name="OpenParenToken"/>
+    </Field>
+    <Field Name="expression" Type="ExpressionSyntax"/>
+    <Field Name="closeParenthesis" Type="SyntaxToken">
+      <Kind Name="CloseParenToken"/>
+    </Field>
+    <Field Name="body" Type="ExpressionSyntax"/>
   </Node>
 </Tree>

--- a/src/Buckle/Compiler/CodeAnalysis/Syntax/SyntaxFacts.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Syntax/SyntaxFacts.cs
@@ -222,6 +222,7 @@ public static class SyntaxFacts {
             "handle" => SyntaxKind.HandleKeyword,
             "out" => SyntaxKind.OutKeyword,
             "union" => SyntaxKind.UnionKeyword,
+            "with" => SyntaxKind.WithKeyword,
             _ => SyntaxKind.IdentifierToken,
         };
     }
@@ -380,6 +381,7 @@ public static class SyntaxFacts {
             SyntaxKind.HandleKeyword => "handle",
             SyntaxKind.OutKeyword => "out",
             SyntaxKind.UnionKeyword => "union",
+            SyntaxKind.WithKeyword => "with",
             _ => null,
         };
     }

--- a/src/Buckle/Compiler/CodeAnalysis/Syntax/SyntaxKind.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Syntax/SyntaxKind.cs
@@ -153,6 +153,7 @@ public enum SyntaxKind : ushort {
     InKeyword,
     OutKeyword,
     UnionKeyword,
+    WithKeyword,
     HandleKeyword,
 
     // Trivia
@@ -178,6 +179,7 @@ public enum SyntaxKind : ushort {
     BaseExpression,
     ThrowExpression,
     DeclarationExpression,
+    WithExpression,
 
     // Operator expressions
     TernaryExpression,
@@ -232,6 +234,7 @@ public enum SyntaxKind : ushort {
     TryStatement,
     SwitchStatement,
     GotoStatement,
+    WithStatement,
     NullBindingStatement,
 
     // Statement Parts

--- a/src/Buckle/Compiler/Diagnostics/DiagnosticCode.cs
+++ b/src/Buckle/Compiler/Diagnostics/DiagnosticCode.cs
@@ -433,6 +433,7 @@ public enum DiagnosticCode : ushort {
     ERR_PatternCannotHandleTypes = 422,
     ERR_FieldNoDefaultValue = 423,
     ERR_WithExpressionNotAssignment = 424,
+    WRN_ExitingControlFlowInWith = 425,
 
     // Carving out >=9000 for unsupported errors
     UNS_IndependentCompilation = 9000,

--- a/src/Buckle/Compiler/Diagnostics/DiagnosticCode.cs
+++ b/src/Buckle/Compiler/Diagnostics/DiagnosticCode.cs
@@ -432,6 +432,7 @@ public enum DiagnosticCode : ushort {
     ERR_CannotAnnotateTypePattern = 421,
     ERR_PatternCannotHandleTypes = 422,
     ERR_FieldNoDefaultValue = 423,
+    ERR_WithExpressionNotAssignment = 424,
 
     // Carving out >=9000 for unsupported errors
     UNS_IndependentCompilation = 9000,

--- a/src/Buckle/Compiler/Diagnostics/Error.cs
+++ b/src/Buckle/Compiler/Diagnostics/Error.cs
@@ -2079,6 +2079,11 @@ internal static class Error {
         return CreateError(DiagnosticCode.ERR_PatternCannotHandleTypes, location, message);
     }
 
+    internal static BelteDiagnostic WithExpressionNotAssignment(TextLocation location) {
+        var message = $"the context expression of a with statement or with expression must be an assignment";
+        return CreateError(DiagnosticCode.ERR_WithExpressionNotAssignment, location, message);
+    }
+
     private static DiagnosticInfo ErrorInfo(DiagnosticCode code) {
         return new DiagnosticInfo((int)code, "BU", DiagnosticSeverity.Error);
     }

--- a/src/Buckle/Compiler/Diagnostics/Warning.cs
+++ b/src/Buckle/Compiler/Diagnostics/Warning.cs
@@ -165,6 +165,11 @@ internal static class Warning {
         return CreateWarning(DiagnosticCode.WRN_UnusedUsingDirective, location, message);
     }
 
+    internal static BelteDiagnostic ExitingControlFlowInWith(TextLocation location) {
+        var message = $"exiting the with body early will result in the reversals not taking place; consider using a 'with (...) try'";
+        return CreateWarning(DiagnosticCode.WRN_ExitingControlFlowInWith, location, message);
+    }
+
     private static BelteDiagnostic CreateWarning(DiagnosticCode code, TextLocation location, string message) {
         return CreateWarning(code, location, message, []);
     }


### PR DESCRIPTION
# Description

Copied from docs:


The `with` expression or statement can be used to wrap code inside of an assignment that is reversed when done.

For example:

```belte
this.a = 3;

return with (a = 6) SomeMethod();
```

In the above example, `SomeMethod` is ran with the field `a` set to 6, but before returning, `a` is set back to it's
starting value of 3.

In statement form:

```belte
this.a = 3;

with (a = 6) try {
  return SomeMethod();
}
```

In the case of an exception or return or other control-flow breaking circumstance within the body of the `with`, the
reversal will not take place as the with body is not exited normally. To ensure that the reversal always takes place,
a `try` keyword can be specified preceding the body as seen in the above example which wraps the body of the with in a
`try` block and the reversals inside a `finally` block. A warning is generated if a control-flow breaking construct is
used without specifying `try`.

The with expression and statement accept multiple assignments where they are assigned in the order they are listed and
reversed in the reverse order. For example, the following will result in the same order of reversals:

```belte
return with (a = 5, b = 10, c = 0) SomeMethod();
```

```belte
return with (a = 5) with (b = 10) with (c = 0) SomeMethod();
```

Using a single `with` where possible is preferred as the compiler can optimize it better.
