### PR TITLE
Rw/nontypetemplates

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,15 +8,11 @@
             "preLaunchTask": "build compiler debug",
             "program": "${workspaceFolder}/src/Buckle/CommandLine/bin/Debug/net10.0/CommandLine.dll",
             "args": [
-                // "-r",
-                // "--clearsubmissions",
-                ".tmp/test.blt",
-                // "--nostdlib",
-                "--verbose",
-                "--vpath=.tmp"
+                "-r",
+                "--clearsubmissions",
             ],
             "cwd": "${workspaceFolder}",
-            "console": "integratedTerminal",
+            "console": "externalTerminal",
             "stopAtEntry": false,
         },
         {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,11 +8,15 @@
             "preLaunchTask": "build compiler debug",
             "program": "${workspaceFolder}/src/Buckle/CommandLine/bin/Debug/net10.0/CommandLine.dll",
             "args": [
-                "-r",
-                "--clearsubmissions",
+                // "-r",
+                // "--clearsubmissions",
+                ".tmp/test.blt",
+                // "--nostdlib",
+                "--verbose",
+                "--vpath=.tmp"
             ],
             "cwd": "${workspaceFolder}",
-            "console": "externalTerminal",
+            "console": "integratedTerminal",
             "stopAtEntry": false,
         },
         {

--- a/docs/Current/Overview.md
+++ b/docs/Current/Overview.md
@@ -78,7 +78,6 @@ implemented.
 | Feature | Evaluator | Executor | IL Emitter | Explanation |
 | - | - | - | - | - |
 | `--type=graphics` projects | ✓ | ✓ | ✕ | Standalone graphics DLL under development |
-| Non-type templates | ✓ | ✕ | ✕ | Not supported by the .NET runtime |
 | Non-integral enums | ✓ | ✕ | ✕ | Not supported by the .NET runtime |
 | Pointers | ✕ | ✓ | ✓ | Partially supported the Evaluator but not stable due to internal memory structure |
 | Function pointers | ✕ | ✓ | ✓ | Disallowed in the Evaluator due to internal memory structure |

--- a/src/Buckle/Compiler.Tests/CodeAnalysis/Evaluating/EvaluatorTests.cs
+++ b/src/Buckle/Compiler.Tests/CodeAnalysis/Evaluating/EvaluatorTests.cs
@@ -1427,13 +1427,38 @@ public sealed class EvaluatorTests {
         A a = new D();
         D d = (D)a;
         return d.B();", 10)]
+    // Non-Type Templates
+    [InlineData(@"
+        class A<int a> {
+            public const int GetA() {
+                return a;
+            }
+        }
+        var a = new A<3>();
+        var b = new A<5>();
+        return a.GetA();", 3)]
+    [InlineData(@"
+        class A<int a> {
+            public const int GetA() {
+                return a;
+            }
+        }
+        var a = new A<3>();
+        var b = new A<5>();
+        return b.GetA();", 5)]
+    [InlineData(@"
+        class A<int a, int b> {
+            public static int Test() {
+                return a + b;
+            }
+        }
+        return A<2,3>.Test();", 5)]
     public void Evaluator_Computes_CorrectValues(string text, object? expectedValue) {
         AssertValue(text, expectedValue, evaluator: true, executor: true);
     }
 
     [Theory]
     // Non-Type Templates
-    [InlineData("class A<int a, int b> { public static int Test() { return a + b; } } return A<2,3>.Test();", 5)]
     [InlineData("int Test<int a, int b>() { return a + b; } return Test<2, 3>();", 5)]
     [InlineData("string Test<string a>() { return a; } return Test<\"test\">();", "test")]
     // Runtime Defined SizeOf

--- a/src/Buckle/Compiler.Tests/CodeAnalysis/Evaluating/EvaluatorTests.cs
+++ b/src/Buckle/Compiler.Tests/CodeAnalysis/Evaluating/EvaluatorTests.cs
@@ -1479,14 +1479,33 @@ public sealed class EvaluatorTests {
         }
         A<3>[] arr = new A<3>[1] { new () };
         return arr[0].GetA();", 3)]
+    [InlineData(@"
+        class A {
+            public static int Test<int a, int b>() {
+                return a + b;
+            }
+        }
+        return A.Test<2, 3>();", 5)]
+    [InlineData(@"
+        class A {
+            public static string Test<string a>() {
+                return a;
+            }
+        }
+        return A.Test<""test"">();", "test")]
+    [InlineData(@"
+        class A {
+            public static int Test<int a, int b>() {
+                return a + b;
+            }
+        }
+        int() test = A.Test<3, 5>;
+        return test();", 8)]
     public void Evaluator_Computes_CorrectValues(string text, object? expectedValue) {
         AssertValue(text, expectedValue, evaluator: true, executor: true);
     }
 
     [Theory]
-    // Non-Type Templates
-    [InlineData("int Test<int a, int b>() { return a + b; } return Test<2, 3>();", 5)]
-    [InlineData("string Test<string a>() { return a; } return Test<\"test\">();", "test")]
     // Runtime Defined SizeOf
     [InlineData("struct A { int32 a; bool b; } return sizeof(A);", 8)]
     [InlineData("class A { int32 a = default; bool b = default; } return sizeof(A);", 8)]

--- a/src/Buckle/Compiler.Tests/CodeAnalysis/Evaluating/EvaluatorTests.cs
+++ b/src/Buckle/Compiler.Tests/CodeAnalysis/Evaluating/EvaluatorTests.cs
@@ -1471,6 +1471,14 @@ public sealed class EvaluatorTests {
         var a = new A<3, bool>();
         var b = new A<5, int>();
         return b.GetA(4);", 5)]
+    [InlineData(@"
+        class A<int a> {
+            public const int GetA() {
+                return a;
+            }
+        }
+        A<3>[] arr = new A<3>[1] { new () };
+        return arr[0].GetA();", 3)]
     public void Evaluator_Computes_CorrectValues(string text, object? expectedValue) {
         AssertValue(text, expectedValue, evaluator: true, executor: true);
     }

--- a/src/Buckle/Compiler.Tests/CodeAnalysis/Evaluating/EvaluatorTests.cs
+++ b/src/Buckle/Compiler.Tests/CodeAnalysis/Evaluating/EvaluatorTests.cs
@@ -1453,6 +1453,24 @@ public sealed class EvaluatorTests {
             }
         }
         return A<2,3>.Test();", 5)]
+    [InlineData(@"
+        class A<int a, type T> {
+            public const int GetA(T t) {
+                return a;
+            }
+        }
+        var a = new A<3, bool>();
+        var b = new A<5, int>();
+        return a.GetA(true);", 3)]
+    [InlineData(@"
+        class A<int a, type T> {
+            public const int GetA(T t) {
+                return a;
+            }
+        }
+        var a = new A<3, bool>();
+        var b = new A<5, int>();
+        return b.GetA(4);", 5)]
     public void Evaluator_Computes_CorrectValues(string text, object? expectedValue) {
         AssertValue(text, expectedValue, evaluator: true, executor: true);
     }

--- a/src/Buckle/Compiler.Tests/CodeAnalysis/Evaluating/ExecutorTests.cs
+++ b/src/Buckle/Compiler.Tests/CodeAnalysis/Evaluating/ExecutorTests.cs
@@ -114,6 +114,15 @@ public sealed class ExecutorTests {
         var str = LowLevel.ReadLPCWSTR(text);
         return str;
     ", "num is\r\n    10")]
+    [InlineData(@"
+        class A {
+            public static int Test<int a, int b>() {
+                return a + b;
+            }
+        }
+        int()* test = &A.Test<3, 5>;
+        return test();
+    ", 8)]
     public void Executor_Computes_CorrectValues(string text, object? expectedValue) {
         AssertValue(text, expectedValue, evaluator: false, executor: true);
     }

--- a/src/Buckle/Compiler/BuildModeExtensions.cs
+++ b/src/Buckle/Compiler/BuildModeExtensions.cs
@@ -9,4 +9,8 @@ internal static class BuildModeExtensions {
     internal static bool Emitting(this BuildMode buildMode) {
         return buildMode is BuildMode.Execute or BuildMode.Dotnet;
     }
+
+    internal static bool PermitsNonTypeTemplates(this BuildMode buildMode) {
+        return buildMode.Evaluating();
+    }
 }

--- a/src/Buckle/Compiler/CodeAnalysis/Binding/Binder.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Binding/Binder.cs
@@ -3289,7 +3289,7 @@ internal partial class Binder {
 
         if (operand is BoundMethodGroup group) {
             // TODO Error checking
-            var method = group.methods.FirstOrDefault();
+            var method = group.methods.FirstOrDefault().ConstructIfTemplate(group.templateArguments);
             var paramRefKinds = method.parameterRefKinds.IsDefault
                 ? method.parameterTypesWithAnnotations.Select(p => RefKind.None).ToImmutableArray()
                 : method.parameterRefKinds;
@@ -3314,7 +3314,7 @@ internal partial class Binder {
 
             return new BoundFunctionPointerLoad(
                 node,
-                group.methods.FirstOrDefault(),
+                method,
                 null,
                 functionPointerType,
                 operand.hasErrors

--- a/src/Buckle/Compiler/CodeAnalysis/Binding/BoundProgram.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Binding/BoundProgram.cs
@@ -154,13 +154,13 @@ internal sealed partial class BoundProgram {
             if (t.originalDefinition is PENamedTypeSymbol)
                 continue;
 
-            if (TemplateExpander.IsNonTypeTemplateType(t))
+            if (!TemplateExpander.ShouldEmit(namedType))
                 continue;
 
             var wellKnownType = WellKnownTypes.GetTypeFromMetadataName(namedType);
 
             if (wellKnownType.ShouldEmit(includeGraphicsWellKnownTypes))
-                builder.Add((NamedTypeSymbol)t);
+                builder.Add(namedType);
         }
 
         return builder.ToImmutableAndFree();

--- a/src/Buckle/Compiler/CodeAnalysis/Binding/BoundProgram.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Binding/BoundProgram.cs
@@ -145,14 +145,22 @@ internal sealed partial class BoundProgram {
             if (t is not NamedTypeSymbol namedType)
                 continue;
 
+            if (t.containingSymbol.kind != SymbolKind.Namespace)
+                continue;
+
+            if (t.specialType != SpecialType.None)
+                continue;
+
+            if (t.originalDefinition is PENamedTypeSymbol)
+                continue;
+
+            if (TemplateExpander.IsNonTypeTemplateType(t))
+                continue;
+
             var wellKnownType = WellKnownTypes.GetTypeFromMetadataName(namedType);
 
-            if (t.containingSymbol.kind == SymbolKind.Namespace &&
-                t.specialType is SpecialType.None &&
-                wellKnownType.ShouldEmit(includeGraphicsWellKnownTypes) &&
-                t.originalDefinition is not PENamedTypeSymbol) {
+            if (wellKnownType.ShouldEmit(includeGraphicsWellKnownTypes))
                 builder.Add((NamedTypeSymbol)t);
-            }
         }
 
         return builder.ToImmutableAndFree();

--- a/src/Buckle/Compiler/CodeAnalysis/Compilation/BoundProgram.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Compilation/BoundProgram.cs
@@ -135,6 +135,23 @@ internal sealed partial class BoundProgram {
         return builder.ToImmutableAndFree();
     }
 
+    internal ImmutableArray<(MethodSymbol, BoundBlockStatement)> GetMethodsToEmit() {
+        var methods = GetAllMethodBodies();
+        var length = methods.Length;
+        var builder = ArrayBuilder<(MethodSymbol, BoundBlockStatement)>.GetInstance(length);
+
+        for (var i = 0; i < length; i++) {
+            var (method, body) = methods[i];
+
+            if (!TemplateExpander.ShouldEmit(method))
+                continue;
+
+            builder.Add((method, body));
+        }
+
+        return builder.ToImmutableAndFree();
+    }
+
     internal ImmutableArray<NamedTypeSymbol> GetTypesToEmit(bool includeGraphicsWellKnownTypes) {
         var types = GetAllTypes();
         var length = types.Length;

--- a/src/Buckle/Compiler/CodeAnalysis/Compilation/BoundProgram.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Compilation/BoundProgram.cs
@@ -1,11 +1,12 @@
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
+using Buckle.CodeAnalysis.Binding;
 using Buckle.CodeAnalysis.Lowering;
 using Buckle.CodeAnalysis.Symbols;
 using Microsoft.CodeAnalysis.PooledObjects;
 
-namespace Buckle.CodeAnalysis.Binding;
+namespace Buckle.CodeAnalysis;
 
 internal sealed partial class BoundProgram {
     private ImmutableDictionary<MethodSymbol, BoundBlockStatement> _lazyOriginalDefinitions;

--- a/src/Buckle/Compiler/CodeAnalysis/Compilation/MethodCompiler.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Compilation/MethodCompiler.cs
@@ -220,13 +220,17 @@ internal sealed partial class MethodCompiler : SymbolVisitor<TypeCompilationStat
         ImmutableArray<NamedTypeSymbol> types;
 
         if (_lazyExpandedTemplateTypes is not null && _lazyExpandedTemplateTypes.Any()) {
-            _lazyExpandedTemplateMethods.AddRange(_methodBodies);
             _types.AddRange(_lazyExpandedTemplateTypes.Cast<NamedTypeSymbol>());
-            methodBodies = _lazyExpandedTemplateMethods.ToImmutableDictionary();
             types = _types.ToImmutableAndFree();
         } else {
-            methodBodies = _methodBodies.ToImmutableDictionary();
             types = _types.ToImmutableAndFree();
+        }
+
+        if (_lazyExpandedTemplateMethods is not null && _lazyExpandedTemplateMethods.Any()) {
+            _lazyExpandedTemplateMethods.AddRange(_methodBodies);
+            methodBodies = _lazyExpandedTemplateMethods.ToImmutableDictionary();
+        } else {
+            methodBodies = _methodBodies.ToImmutableDictionary();
         }
 
         return new BoundProgram(
@@ -345,10 +349,10 @@ internal sealed partial class MethodCompiler : SymbolVisitor<TypeCompilationStat
 
         if (_lazyExpandedTemplateTypes.Any()) {
             _lazyExpandedTemplateMethods ??= ImmutableDictionary.CreateBuilder<MethodSymbol, BoundBlockStatement>();
-            var methodMap = templateExpander.GetMethodMap();
+            var methodMap = templateExpander.GetTypeMethodMap();
 
             foreach (var templateType in _lazyExpandedTemplateTypes) {
-                TemplateTypeRewriter.Rewrite(
+                TemplateTypeRewriter<NamedTypeSymbol>.Rewrite(
                     templateType.underlyingNamedType,
                     templateType,
                     _methodBodies,
@@ -356,6 +360,18 @@ internal sealed partial class MethodCompiler : SymbolVisitor<TypeCompilationStat
                     methodMap
                 );
             }
+        }
+
+        var templateMethods = templateExpander.GetMethodMap();
+
+        foreach (var (key, value) in templateMethods) {
+            _lazyExpandedTemplateMethods ??= ImmutableDictionary.CreateBuilder<MethodSymbol, BoundBlockStatement>();
+
+            var body = _lazyExpandedTemplateMethods.TryGetValue(key.originalDefinition, out var originalBody)
+                ? originalBody
+                : _methodBodies[key.originalDefinition];
+
+            TemplateTypeRewriter<MethodSymbol>.Rewrite(value, body, _lazyExpandedTemplateMethods);
         }
     }
 
@@ -613,8 +629,8 @@ internal sealed partial class MethodCompiler : SymbolVisitor<TypeCompilationStat
             _compilation.previousAnalyses,
             currentDiagnostics,
             ref _entryPoint,
-            out var sawCompileTimeExpression,
-            out var sawNonTypeTemplate
+            sawCompileTimeExpression: out var sawCompileTimeExpression,
+            sawNonTypeTemplate: out var sawNonTypeTemplate
         );
 
         if (method.methodKind == MethodKind.Ordinary && method.containingType.IsEnumType())

--- a/src/Buckle/Compiler/CodeAnalysis/Compilation/MethodCompiler.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Compilation/MethodCompiler.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using Buckle.CodeAnalysis.Binding;
@@ -36,10 +37,13 @@ internal sealed partial class MethodCompiler : SymbolVisitor<TypeCompilationStat
     private ManualResetEventSlim _done;
 
     private ImmutableDictionary<FieldSymbol, NamedTypeSymbol>.Builder _lazyFixedImplementationTypes;
+    private ImmutableDictionary<MethodSymbol, BoundBlockStatement>.Builder _lazyExpandedTemplateMethods;
+    private ArrayBuilder<SynthesizedTemplateType> _lazyExpandedTemplateTypes;
     private MethodSymbol _entryPoint;
     private MethodSymbol _updatePoint;
 
-    private bool _sawCompileTimeExpression;
+    private volatile bool _sawCompileTimeExpression;
+    private volatile bool _sawNonTypeTemplate;
 
     private MethodCompiler(
         Compilation compilation,
@@ -144,8 +148,13 @@ internal sealed partial class MethodCompiler : SymbolVisitor<TypeCompilationStat
             methodCompiler.CompileNamespace(globalNamespace);
         }
 
-        if (!diagnostics.AnyErrors() && methodCompiler._sawCompileTimeExpression)
-            methodCompiler.ComputeCompileTimeExpressions();
+        if (!diagnostics.AnyErrors()) {
+            if (methodCompiler._sawCompileTimeExpression)
+                methodCompiler.ComputeCompileTimeExpressions();
+
+            if (methodCompiler._sawNonTypeTemplate && !compilation.options.buildMode.PermitsNonTypeTemplates())
+                methodCompiler.ExpandTemplates();
+        }
 
         if (compilation.options.isScript && methodCompiler._updatePoint is null)
             methodCompiler._updatePoint = compilation.GetLateScriptUpdatePoint(methodCompiler._methodBodies);
@@ -207,11 +216,24 @@ internal sealed partial class MethodCompiler : SymbolVisitor<TypeCompilationStat
     }
 
     private BoundProgram CreateBoundProgram() {
+        ImmutableDictionary<MethodSymbol, BoundBlockStatement> methodBodies;
+        ImmutableArray<NamedTypeSymbol> types;
+
+        if (_lazyExpandedTemplateTypes is not null && _lazyExpandedTemplateTypes.Any()) {
+            _lazyExpandedTemplateMethods.AddRange(_methodBodies);
+            _types.AddRange(_lazyExpandedTemplateTypes.Cast<NamedTypeSymbol>());
+            methodBodies = _lazyExpandedTemplateMethods.ToImmutableDictionary();
+            types = _types.ToImmutableAndFree();
+        } else {
+            methodBodies = _methodBodies.ToImmutableDictionary();
+            types = _types.ToImmutableAndFree();
+        }
+
         return new BoundProgram(
             _compilation,
-            _methodBodies.ToImmutableDictionary(),
+            methodBodies,
             _methodLayouts.ToImmutableDictionary(),
-            _types.ToImmutableAndFree(),
+            types,
             _typeLayouts.ToImmutable(),
             _synthesizedNestedTypes,
             _lazyFixedImplementationTypes is null ? [] : _lazyFixedImplementationTypes.ToImmutable(),
@@ -284,6 +306,55 @@ internal sealed partial class MethodCompiler : SymbolVisitor<TypeCompilationStat
                 );
 
                 _methodBodies[method] = (BoundBlockStatement)loweredBody;
+            }
+        }
+    }
+
+    private void ExpandTemplates() {
+        // Expand each non-type template instantiation into a new type
+        // Expanded template types don't need evaluator slot layouts because the evaluator supports non-type templates
+
+        // TODO This might be parallelizable
+
+        var templateExpander = new TemplateExpander(
+            _lazyExpandedTemplateTypes = ArrayBuilder<SynthesizedTemplateType>.GetInstance()
+        );
+
+        var secondaryMethodsMapBuilder = ImmutableDictionary.CreateBuilder<MethodSymbol, MethodSymbol>();
+
+        foreach (var (method, _) in _methodBodies) {
+            if (templateExpander.RewriteMethodSymbol(method, out var newMethod)) {
+                Debug.Assert(newMethod is not null && method != newMethod);
+                secondaryMethodsMapBuilder.Add(method, newMethod);
+            }
+        }
+
+        templateExpander.SetSecondaryMethodMap(secondaryMethodsMapBuilder.ToImmutable());
+
+        foreach (var (method, body) in _methodBodies) {
+            if (body is not null && templateExpander.Expand(method, body, out var newMethod, out var newBody)) {
+                if (newMethod is null) {
+                    if (!_methodBodies.TryUpdate(method, newBody, body))
+                        throw ExceptionUtilities.Unreachable();
+                } else {
+                    _lazyExpandedTemplateMethods ??= ImmutableDictionary.CreateBuilder<MethodSymbol, BoundBlockStatement>();
+                    _lazyExpandedTemplateMethods.Add(newMethod, newBody);
+                }
+            }
+        }
+
+        if (_lazyExpandedTemplateTypes.Any()) {
+            _lazyExpandedTemplateMethods ??= ImmutableDictionary.CreateBuilder<MethodSymbol, BoundBlockStatement>();
+            var methodMap = templateExpander.GetMethodMap();
+
+            foreach (var templateType in _lazyExpandedTemplateTypes) {
+                TemplateTypeRewriter.Rewrite(
+                    templateType.underlyingNamedType,
+                    templateType,
+                    _methodBodies,
+                    _lazyExpandedTemplateMethods,
+                    methodMap
+                );
             }
         }
     }
@@ -542,13 +613,15 @@ internal sealed partial class MethodCompiler : SymbolVisitor<TypeCompilationStat
             _compilation.previousAnalyses,
             currentDiagnostics,
             ref _entryPoint,
-            out var sawCompileTimeExpression
+            out var sawCompileTimeExpression,
+            out var sawNonTypeTemplate
         );
 
         if (method.methodKind == MethodKind.Ordinary && method.containingType.IsEnumType())
             method = GetEnumMethod(method.containingType, method);
 
         _sawCompileTimeExpression |= sawCompileTimeExpression;
+        _sawNonTypeTemplate |= sawNonTypeTemplate;
 
         var controlFlowGraph = ControlFlowGraph.Create(method, loweredBody);
         var assignments = controlFlowGraph.CheckDefiniteAssignment(currentDiagnostics);
@@ -615,7 +688,8 @@ internal sealed partial class MethodCompiler : SymbolVisitor<TypeCompilationStat
         List<LocalFunctionRewriter.Analysis> previousAnalyses,
         BelteDiagnosticQueue currentDiagnostics,
         ref MethodSymbol entryPoint,
-        out bool sawCompileTimeExpression) {
+        out bool sawCompileTimeExpression,
+        out bool sawNonTypeTemplate) {
         try {
             var loweredBody = Lowerer.Lower(
                 this,
@@ -624,23 +698,28 @@ internal sealed partial class MethodCompiler : SymbolVisitor<TypeCompilationStat
                 body,
                 entryPoint?.containingType,
                 currentDiagnostics,
-                out sawCompileTimeExpression
+                sawCompileTimeExpression: out sawCompileTimeExpression,
+                sawNonTypeTemplate: out sawNonTypeTemplate,
+                sawLambda: out var sawLambda,
+                sawLocalFunction: out var sawLocalFunction
             );
 
             if (!transpiling) {
-                loweredBody = LocalFunctionRewriter.Rewrite(
-                    loweredBody,
-                    state.type,
-                    method.thisParameter,
-                    method,
-                    methodOrdinal,
-                    null,
-                    state,
-                    previousAnalyses,
-                    currentDiagnostics,
-                    null, // TODO When do we want to use this?
-                    ref entryPoint
-                );
+                if (sawLambda || sawLocalFunction) {
+                    loweredBody = LocalFunctionRewriter.Rewrite(
+                        loweredBody,
+                        state.type,
+                        method.thisParameter,
+                        method,
+                        methodOrdinal,
+                        substitutedSourceMethod: null,
+                        state,
+                        previousAnalyses,
+                        currentDiagnostics,
+                        assignLocals: null,
+                        ref entryPoint
+                    );
+                }
 
                 loweredBody = Optimizer.RemoveDeadCode(method, loweredBody, currentDiagnostics);
             }
@@ -649,6 +728,7 @@ internal sealed partial class MethodCompiler : SymbolVisitor<TypeCompilationStat
         } catch (BoundTreeVisitor.CancelledByStackGuardException ex) {
             ex.AddAnError(currentDiagnostics);
             sawCompileTimeExpression = false;
+            sawNonTypeTemplate = false;
 
             return new BoundBlockStatement(
                 body.syntax,

--- a/src/Buckle/Compiler/CodeAnalysis/ConstantValue.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/ConstantValue.cs
@@ -97,7 +97,7 @@ internal partial class ConstantValue {
     }
 
     public override int GetHashCode() {
-        return RuntimeHelpers.GetHashCode(this);
+        return value?.GetHashCode() ?? RuntimeHelpers.GetHashCode(this);
     }
 
     public override bool Equals(object obj) {

--- a/src/Buckle/Compiler/CodeAnalysis/Display/SymbolDisplay.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Display/SymbolDisplay.cs
@@ -633,7 +633,10 @@ public static class SymbolDisplay {
         else
             text.Write(CreateIdentifier(method.name));
 
-        DisplayTemplateParameters(text, method.templateParameters, format);
+        if ((object)method.constructedFrom == method)
+            DisplayTemplateParameters(text, method.templateParameters, format);
+        else
+            DisplayTemplateArguments(text, method.templateArguments, format);
 
         if ((format.memberOptions & SymbolDisplayMemberOptions.IncludeParameters) != 0) {
             text.Write(CreatePunctuation(SyntaxKind.OpenParenToken));

--- a/src/Buckle/Compiler/CodeAnalysis/Evaluating/Evaluator.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Evaluating/Evaluator.cs
@@ -46,6 +46,9 @@ internal sealed class Evaluator {
     private bool _insideUpdate;
     private bool _insideExpressionEvaluation;
 
+    // These are used if layouts need to be computed while evaluating if the precomputed layout maps are incomplete
+    // This should only happen when reusing the same cor compilation for multiple programs because normally each program
+    // always computes layouts even if not evaluating
     private ImmutableDictionary<NamedTypeSymbol, EvaluatorSlotManager>.Builder _lazyTypeLayouts;
     private Dictionary<MethodSymbol, (BoundBlockStatement, EvaluatorSlotManager)> _lazyMethodLayouts;
 

--- a/src/Buckle/Compiler/CodeAnalysis/Evaluating/Executor.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Evaluating/Executor.cs
@@ -112,7 +112,7 @@ internal sealed partial class Executor : ModuleBuilder {
             linearBuilder.AddRange(set.Value);
 
         _linearNestedTypes = linearBuilder.ToImmutable();
-        _methodBodies = program.GetAllMethodBodies().ToImmutableDictionary(pair => pair.Item1, pair => pair.Item2);
+        _methodBodies = program.GetMethodsToEmit().ToImmutableDictionary(pair => pair.Item1, pair => pair.Item2);
 
         _entryPoint = _program.entryPoint;
     }

--- a/src/Buckle/Compiler/CodeAnalysis/Lowering/LocalFunctionRewriter/MethodToClassRewriter.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Lowering/LocalFunctionRewriter/MethodToClassRewriter.cs
@@ -143,7 +143,6 @@ internal abstract partial class MethodToClassRewriter : BoundTreeRewriterWithSta
         return _templateMap.SubstituteType(type)?.type?.type;
     }
 
-
     internal override BoundNode VisitCallExpression(BoundCallExpression node) {
         var rewrittenMethodSymbol = VisitMethodSymbol(node.method);
         var rewrittenReceiver = (BoundExpression)Visit(node.receiver);

--- a/src/Buckle/Compiler/CodeAnalysis/Lowering/Lowerer.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Lowering/Lowerer.cs
@@ -30,6 +30,9 @@ internal sealed class Lowerer : BoundTreeRewriterWithStackGuard {
     private readonly BelteDiagnosticQueue _diagnostics;
 
     private bool _sawCompileTimeExpression;
+    private bool _sawNonTypeTemplate;
+    private bool _sawLambda;
+    private bool _sawLocalFunction;
 
     private Lowerer(
         MethodCompiler methodCompiler,
@@ -53,7 +56,10 @@ internal sealed class Lowerer : BoundTreeRewriterWithStackGuard {
         BoundBlockStatement statement,
         NamedTypeSymbol entryType,
         BelteDiagnosticQueue diagnostics,
-        out bool sawCompileTimeExpression) {
+        out bool sawCompileTimeExpression,
+        out bool sawNonTypeTemplate,
+        out bool sawLambda,
+        out bool sawLocalFunction) {
         var lowerer = new Lowerer(methodCompiler, method, entryType, diagnostics);
         var optimize = optimizationLevel == OptimizationLevel.Release && !methodCompiler.transpiling;
 
@@ -77,6 +83,9 @@ internal sealed class Lowerer : BoundTreeRewriterWithStackGuard {
             rewrittenStatement = (BoundBlockStatement)Optimizer.Optimize(rewrittenStatement);
 
         sawCompileTimeExpression = lowerer._sawCompileTimeExpression;
+        sawNonTypeTemplate = lowerer._sawNonTypeTemplate;
+        sawLambda = lowerer._sawLambda;
+        sawLocalFunction = lowerer._sawLocalFunction || TemplateExpander.IsNonTypeTemplateType(method.containingType);
 
         return rewrittenStatement;
     }
@@ -91,9 +100,26 @@ internal sealed class Lowerer : BoundTreeRewriterWithStackGuard {
         return base.Visit(node);
     }
 
+    internal override TypeSymbol VisitType(TypeSymbol type) {
+        if (type is not null && TemplateExpander.IsNonTypeTemplateType(type))
+            _sawNonTypeTemplate = true;
+
+        return base.VisitType(type);
+    }
+
     internal override BoundNode VisitCompileTimeExpression(BoundCompileTimeExpression node) {
         _sawCompileTimeExpression = true;
         return base.VisitCompileTimeExpression(node);
+    }
+
+    internal override BoundNode VisitLambda(BoundLambda node) {
+        _sawLambda = true;
+        return base.VisitLambda(node);
+    }
+
+    internal override BoundNode VisitLocalFunctionStatement(BoundLocalFunctionStatement node) {
+        _sawLocalFunction = true;
+        return base.VisitLocalFunctionStatement(node);
     }
 
     internal override BoundNode VisitBlockStatement(BoundBlockStatement node) {
@@ -1111,8 +1137,6 @@ internal sealed class Lowerer : BoundTreeRewriterWithStackGuard {
 
         if (node.conversion.kind is ConversionKind.ObjectCreation or ConversionKind.ConditionalExpression)
             return Visit(node.operand);
-
-        Debug.Assert(node.conversion.exists);
 
         return base.VisitCastExpression(node);
     }

--- a/src/Buckle/Compiler/CodeAnalysis/Lowering/Lowerer.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Lowering/Lowerer.cs
@@ -83,9 +83,9 @@ internal sealed class Lowerer : BoundTreeRewriterWithStackGuard {
             rewrittenStatement = (BoundBlockStatement)Optimizer.Optimize(rewrittenStatement);
 
         sawCompileTimeExpression = lowerer._sawCompileTimeExpression;
-        sawNonTypeTemplate = lowerer._sawNonTypeTemplate;
+        sawNonTypeTemplate = lowerer._sawNonTypeTemplate || TemplateExpander.IsNonTypeTemplateMethod(method);
         sawLambda = lowerer._sawLambda;
-        sawLocalFunction = lowerer._sawLocalFunction || TemplateExpander.IsNonTypeTemplateType(method.containingType);
+        sawLocalFunction = lowerer._sawLocalFunction;
 
         return rewrittenStatement;
     }

--- a/src/Buckle/Compiler/CodeAnalysis/Lowering/SequencePointInjector.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Lowering/SequencePointInjector.cs
@@ -70,7 +70,11 @@ internal sealed class SequencePointInjector : BoundTreeRewriter {
                         var end = ctorDecl.body.openBrace.span.end;
                         location = FromBounds(syntax, start, end);
                     } else {
-                        location = CreateLocation(ctorDecl.modifiers, ctorDecl.constructorKeyword, ctorDecl.parameterList.closeParenthesis);
+                        location = CreateLocation(
+                            ctorDecl.modifiers,
+                            ctorDecl.constructorKeyword,
+                            ctorDecl.parameterList.closeParenthesis
+                        );
                     }
 
                     return new BoundSequencePointWithLocation(ctorDecl, node, location);
@@ -78,7 +82,11 @@ internal sealed class SequencePointInjector : BoundTreeRewriter {
                     return new BoundSequencePointWithLocation(
                         ctorInit,
                         node,
-                        FromBounds(syntax, ctorInit.thisOrBaseKeyword.span.start, ctorInit.argumentList.closeParenthesis.span.end)
+                        FromBounds(
+                            syntax,
+                            ctorInit.thisOrBaseKeyword.span.start,
+                            ctorInit.argumentList.closeParenthesis.span.end
+                        )
                     );
                 case TypeDeclarationSyntax typeDecl:
                     return new BoundSequencePointWithLocation(

--- a/src/Buckle/Compiler/CodeAnalysis/Lowering/SharedExpander.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Lowering/SharedExpander.cs
@@ -641,8 +641,10 @@ internal class SharedExpander : BoundTreeExpander {
                 if (replacementContent.StrippedType().specialType == SpecialType.String) {
                     right = replacementContent;
                 } else if (replacementContent.Type().isValueType && !replacementContent.Type().IsStructType()) {
+                    var conversions = TypeConversions.GetInstance();
+
                     if (!replacementContent.Type().IsNullableType()) {
-                        var conversion = Conversion.Classify(replacementContent.Type(), stringType);
+                        var conversion = conversions.ClassifyConversionFromExpression(replacementContent, stringType);
 
                         if (!conversion.exists) {
                             _diagnostics.Push(
@@ -652,7 +654,7 @@ internal class SharedExpander : BoundTreeExpander {
 
                         right = Cast(syntax, stringType, replacementContent, conversion, null);
                     } else {
-                        var conversion = Conversion.Classify(replacementContent.StrippedType(), stringType);
+                        var conversion = conversions.ClassifyConversionFromExpression(replacementContent, stringType);
 
                         if (!conversion.exists) {
                             _diagnostics.Push(

--- a/src/Buckle/Compiler/CodeAnalysis/Lowering/TemplateExpander/ISynthesizedTemplate.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Lowering/TemplateExpander/ISynthesizedTemplate.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using Buckle.CodeAnalysis.Symbols;
+
+namespace Buckle.CodeAnalysis.Lowering;
+
+internal interface ISynthesizedTemplate<T> where T : ISymbolWithTemplates {
+    T unexpandedSymbol { get; }
+
+    Dictionary<TemplateParameterSymbol, TemplateParameterSymbol> replacementTemplateParameters { get; }
+}

--- a/src/Buckle/Compiler/CodeAnalysis/Lowering/TemplateExpander/SynthesizedTemplateMethod.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Lowering/TemplateExpander/SynthesizedTemplateMethod.cs
@@ -1,0 +1,146 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using Buckle.CodeAnalysis.Binding;
+using Buckle.CodeAnalysis.Symbols;
+using Buckle.CodeAnalysis.Syntax;
+using Buckle.Utilities;
+using Microsoft.CodeAnalysis.PooledObjects;
+
+namespace Buckle.CodeAnalysis.Lowering;
+
+internal sealed class SynthesizedTemplateMethod : WrappedMethodSymbol, ISynthesizedTemplate<MethodSymbol> {
+    private readonly ConstructedMethodSymbol _originalMethod;
+    private readonly TypeWithAnnotations _returnType;
+    private readonly ImmutableArray<ParameterSymbol> _parameters;
+    private readonly Dictionary<TemplateParameterSymbol, TemplateParameterSymbol> _replacementTemplateParameters;
+
+    private int _hashCode;
+
+    internal SynthesizedTemplateMethod(
+        Symbol containingSymbol,
+        ConstructedMethodSymbol originalMethod)
+        : base(originalMethod.constructedFrom) {
+        _originalMethod = originalMethod;
+        name = GeneratedNames.MakeTemplateTypeOrMethodName(originalMethod);
+
+        var i = 0;
+        templateParameters = originalMethod.templateParameters
+            .Where(t => t.underlyingType.specialType == SpecialType.Type)
+            .Select(t => new SynthesizedTemplateTypeParameter(this, t, i++))
+            .ToImmutableArray<TemplateParameterSymbol>();
+
+        i = 0;
+        templateSubstitution = new TemplateMap(
+            originalMethod.constructedFrom.containingType,
+            originalMethod.templateParameters,
+            originalMethod.templateArguments.ZipAsArray(
+                originalMethod.constructedFrom.templateParameters,
+                i,
+                (typeOrConstant, templateParameter, i, arg) => {
+                    if (templateParameter.underlyingType.specialType == SpecialType.Type) {
+                        return new TypeOrConstant(templateParameters[templateParameter.ordinal - i]);
+                    } else {
+                        i++;
+                        return typeOrConstant;
+                    }
+                }
+            )
+        );
+
+        _replacementTemplateParameters = [];
+
+        i = 0;
+        foreach (var templateParameter in originalMethod.constructedFrom.templateParameters) {
+            if (templateParameter.underlyingType.specialType == SpecialType.Type)
+                _replacementTemplateParameters.Add(templateParameter, templateParameters[i++]);
+        }
+
+        this.containingSymbol = containingSymbol;
+
+        _returnType = TemplateTypeReplacer<TemplateParameterSymbol, TemplateParameterSymbol, TemplateParameterSymbol>
+            .Replace(originalMethod.returnTypeWithAnnotations, _replacementTemplateParameters);
+
+        var builder = ArrayBuilder<ParameterSymbol>.GetInstance(originalMethod.parameterCount);
+
+        foreach (var parameter in originalMethod.parameters) {
+            var newType = TemplateTypeReplacer<TemplateParameterSymbol, TemplateParameterSymbol, TemplateParameterSymbol>
+                .Replace(parameter.typeWithAnnotations, _replacementTemplateParameters);
+
+            builder.Add(new TypeSubstitutedParameterSymbol(parameter, newType));
+        }
+
+        _parameters = builder.ToImmutableAndFree();
+    }
+
+    public override string name { get; }
+
+    public override ImmutableArray<TemplateParameterSymbol> templateParameters { get; }
+
+    public override ImmutableArray<TypeOrConstant> templateArguments => GetTemplateParametersAsTemplateArguments();
+
+    public override ImmutableArray<BoundExpression> templateConstraints => underlyingMethod.templateConstraints;
+
+    public override int arity => templateParameters.Length;
+
+    public override TemplateMap templateSubstitution { get; }
+
+    internal override TypeWithAnnotations returnTypeWithAnnotations => _returnType;
+
+    internal override ImmutableArray<ParameterSymbol> parameters => _parameters;
+
+    internal override int parameterCount => _parameters.Length;
+
+    internal override MethodSymbol originalDefinition => this;
+
+    internal override MethodSymbol constructedFrom => this;
+
+    internal override Symbol containingSymbol { get; }
+
+    internal override bool isExplicitInterfaceImplementation => underlyingMethod.isExplicitInterfaceImplementation;
+
+    internal override ImmutableArray<MethodSymbol> explicitInterfaceImplementations => [];
+
+    internal MethodSymbol unexpandedSymbol => _originalMethod;
+
+    internal Dictionary<TemplateParameterSymbol, TemplateParameterSymbol> replacementTemplateParameters
+        => _replacementTemplateParameters;
+
+    internal override int CalculateLocalSyntaxOffset(int localPosition, SyntaxTree localTree) {
+        throw ExceptionUtilities.Unreachable();
+    }
+
+    internal override DllImportData GetDllImportData() {
+        return underlyingMethod.GetDllImportData();
+    }
+
+    internal override UnmanagedCallersOnlyAttributeData GetUnmanagedCallersOnlyAttributeData(bool forceComplete) {
+        return underlyingMethod.GetUnmanagedCallersOnlyAttributeData(forceComplete);
+    }
+
+    public override int GetHashCode() {
+        if (_hashCode == 0)
+            _hashCode = ComputeHashCode();
+
+        return _hashCode;
+    }
+
+    private int ComputeHashCode() {
+        var baseHashCode = base.GetHashCode();
+        var newHashCode = baseHashCode;
+
+        foreach (var templateArgument in _originalMethod.templateArguments) {
+            if (templateArgument.isConstant)
+                newHashCode = Hash.Combine(templateArgument.constant, newHashCode);
+        }
+
+        Debug.Assert(baseHashCode != newHashCode);
+        return newHashCode;
+    }
+
+    MethodSymbol ISynthesizedTemplate<MethodSymbol>.unexpandedSymbol => _originalMethod;
+
+    Dictionary<TemplateParameterSymbol, TemplateParameterSymbol> ISynthesizedTemplate<MethodSymbol>.replacementTemplateParameters
+        => _replacementTemplateParameters;
+}

--- a/src/Buckle/Compiler/CodeAnalysis/Lowering/TemplateExpander/SynthesizedTemplateType.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Lowering/TemplateExpander/SynthesizedTemplateType.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using Buckle.CodeAnalysis.Binding;
+using Buckle.CodeAnalysis.Symbols;
+using Buckle.Utilities;
+
+namespace Buckle.CodeAnalysis.Lowering;
+
+internal sealed class SynthesizedTemplateType : WrappedNamedTypeSymbol {
+    private readonly ConstructedNamedTypeSymbol _originalType;
+
+    private int _hashCode;
+
+    internal SynthesizedTemplateType(
+        Symbol containingSymbol,
+        ConstructedNamedTypeSymbol originalType)
+        : base(originalType.constructedFrom, null) {
+        _originalType = originalType;
+        name = GeneratedNames.MakeTemplateTypeName(originalType);
+        templateParameters = originalType.templateParameters
+            .WhereAsArray(t => t.underlyingType.specialType == SpecialType.Type);
+
+        templateSubstitution = new TemplateMap(
+            originalType.constructedFrom.containingType,
+            originalType.templateParameters,
+            originalType.templateArguments.ZipAsArray(
+                originalType.constructedFrom.templateParameters,
+                this,
+                (typeOrConstant, templateParameter, i, arg) => {
+                    if (templateParameter.underlyingType.specialType == SpecialType.Type)
+                        return new TypeOrConstant(templateParameter);
+                    else
+                        return typeOrConstant;
+                }
+            )
+        );
+
+        this.containingSymbol = containingSymbol;
+    }
+
+    public override string name { get; }
+
+    public override ImmutableArray<TemplateParameterSymbol> templateParameters { get; }
+
+    public override ImmutableArray<TypeOrConstant> templateArguments => GetTemplateParametersAsTemplateArguments();
+
+    public override ImmutableArray<BoundExpression> templateConstraints => underlyingNamedType.templateConstraints;
+
+    public override int arity => templateParameters.Length;
+
+    public override TemplateMap templateSubstitution { get; }
+
+    internal override NamedTypeSymbol originalDefinition => this;
+
+    internal override NamedTypeSymbol baseType => underlyingNamedType.baseType;
+
+    internal override NamedTypeSymbol constructedFrom => this;
+
+    internal override Symbol containingSymbol { get; }
+
+    internal override IEnumerable<string> memberNames => [];
+
+    internal NamedTypeSymbol unexpandedType => _originalType;
+
+    internal override LexicalSortKey GetLexicalSortKey() {
+        return LexicalSortKey.NotInSource;
+    }
+
+    internal override NamedTypeSymbol GetDeclaredBaseType(ConsList<TypeSymbol> basesBeingResolved) {
+        return baseType;
+    }
+
+    internal override ImmutableArray<NamedTypeSymbol> GetDeclaredInterfaces(ConsList<TypeSymbol> basesBeingResolved) {
+        return [];
+    }
+
+    internal override ImmutableArray<NamedTypeSymbol> Interfaces(ConsList<TypeSymbol> basesBeingResolved = null) {
+        return [];
+    }
+
+    internal override ImmutableArray<Symbol> GetMembers() {
+        return [];
+    }
+
+    internal override ImmutableArray<Symbol> GetMembers(string name) {
+        return [];
+    }
+
+    internal override ImmutableArray<NamedTypeSymbol> GetTypeMembers() {
+        return [];
+    }
+
+    internal override ImmutableArray<NamedTypeSymbol> GetTypeMembers(ReadOnlyMemory<char> name) {
+        return [];
+    }
+
+    internal sealed override IEnumerable<(MethodSymbol Body, MethodSymbol Implemented)> SynthesizedInterfaceMethodImpls() {
+        return SpecializedCollections.EmptyEnumerable<(MethodSymbol Body, MethodSymbol Implemented)>();
+    }
+
+    private protected override NamedTypeSymbol WithTupleDataCore(TupleExtraData newData) {
+        throw ExceptionUtilities.Unreachable();
+    }
+
+    public override int GetHashCode() {
+        if (_hashCode == 0)
+            _hashCode = ComputeHashCode();
+
+        return _hashCode;
+    }
+
+    internal new int ComputeHashCode() {
+        var baseHashCode = base.GetHashCode();
+        var newHashCode = baseHashCode;
+
+        foreach (var templateArgument in _originalType.templateArguments) {
+            if (templateArgument.isConstant)
+                newHashCode = Hash.Combine(templateArgument.constant, newHashCode);
+        }
+
+        Debug.Assert(baseHashCode != newHashCode);
+        return newHashCode;
+    }
+}

--- a/src/Buckle/Compiler/CodeAnalysis/Lowering/TemplateExpander/SynthesizedTemplateType.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Lowering/TemplateExpander/SynthesizedTemplateType.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Linq;
 using Buckle.CodeAnalysis.Binding;
 using Buckle.CodeAnalysis.Symbols;
 using Buckle.Utilities;
@@ -19,23 +20,38 @@ internal sealed class SynthesizedTemplateType : WrappedNamedTypeSymbol {
         : base(originalType.constructedFrom, null) {
         _originalType = originalType;
         name = GeneratedNames.MakeTemplateTypeName(originalType);
-        templateParameters = originalType.templateParameters
-            .WhereAsArray(t => t.underlyingType.specialType == SpecialType.Type);
 
+        var i = 0;
+        templateParameters = originalType.templateParameters
+            .Where(t => t.underlyingType.specialType == SpecialType.Type)
+            .Select(t => new SynthesizedTemplateTypeParameter(this, t, i++))
+            .ToImmutableArray<TemplateParameterSymbol>();
+
+        i = 0;
         templateSubstitution = new TemplateMap(
             originalType.constructedFrom.containingType,
             originalType.templateParameters,
             originalType.templateArguments.ZipAsArray(
                 originalType.constructedFrom.templateParameters,
-                this,
+                i,
                 (typeOrConstant, templateParameter, i, arg) => {
-                    if (templateParameter.underlyingType.specialType == SpecialType.Type)
-                        return new TypeOrConstant(templateParameter);
-                    else
+                    if (templateParameter.underlyingType.specialType == SpecialType.Type) {
+                        return new TypeOrConstant(templateParameters[templateParameter.ordinal - i]);
+                    } else {
+                        i++;
                         return typeOrConstant;
+                    }
                 }
             )
         );
+
+        replacementTemplateParameters = [];
+
+        i = 0;
+        foreach (var templateParameter in originalType.constructedFrom.templateParameters) {
+            if (templateParameter.underlyingType.specialType == SpecialType.Type)
+                replacementTemplateParameters.Add(templateParameter, templateParameters[i++]);
+        }
 
         this.containingSymbol = containingSymbol;
     }
@@ -63,6 +79,8 @@ internal sealed class SynthesizedTemplateType : WrappedNamedTypeSymbol {
     internal override IEnumerable<string> memberNames => [];
 
     internal NamedTypeSymbol unexpandedType => _originalType;
+
+    internal Dictionary<TemplateParameterSymbol, TemplateParameterSymbol> replacementTemplateParameters { get; }
 
     internal override LexicalSortKey GetLexicalSortKey() {
         return LexicalSortKey.NotInSource;

--- a/src/Buckle/Compiler/CodeAnalysis/Lowering/TemplateExpander/SynthesizedTemplateType.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Lowering/TemplateExpander/SynthesizedTemplateType.cs
@@ -9,8 +9,9 @@ using Buckle.Utilities;
 
 namespace Buckle.CodeAnalysis.Lowering;
 
-internal sealed class SynthesizedTemplateType : WrappedNamedTypeSymbol {
+internal sealed class SynthesizedTemplateType : WrappedNamedTypeSymbol, ISynthesizedTemplate<NamedTypeSymbol> {
     private readonly ConstructedNamedTypeSymbol _originalType;
+    private readonly Dictionary<TemplateParameterSymbol, TemplateParameterSymbol> _replacementTemplateParameters;
 
     private int _hashCode;
 
@@ -19,7 +20,7 @@ internal sealed class SynthesizedTemplateType : WrappedNamedTypeSymbol {
         ConstructedNamedTypeSymbol originalType)
         : base(originalType.constructedFrom, null) {
         _originalType = originalType;
-        name = GeneratedNames.MakeTemplateTypeName(originalType);
+        name = GeneratedNames.MakeTemplateTypeOrMethodName(originalType);
 
         var i = 0;
         templateParameters = originalType.templateParameters
@@ -45,12 +46,12 @@ internal sealed class SynthesizedTemplateType : WrappedNamedTypeSymbol {
             )
         );
 
-        replacementTemplateParameters = [];
+        _replacementTemplateParameters = [];
 
         i = 0;
         foreach (var templateParameter in originalType.constructedFrom.templateParameters) {
             if (templateParameter.underlyingType.specialType == SpecialType.Type)
-                replacementTemplateParameters.Add(templateParameter, templateParameters[i++]);
+                _replacementTemplateParameters.Add(templateParameter, templateParameters[i++]);
         }
 
         this.containingSymbol = containingSymbol;
@@ -78,9 +79,10 @@ internal sealed class SynthesizedTemplateType : WrappedNamedTypeSymbol {
 
     internal override IEnumerable<string> memberNames => [];
 
-    internal NamedTypeSymbol unexpandedType => _originalType;
+    internal NamedTypeSymbol unexpandedSymbol => _originalType;
 
-    internal Dictionary<TemplateParameterSymbol, TemplateParameterSymbol> replacementTemplateParameters { get; }
+    internal Dictionary<TemplateParameterSymbol, TemplateParameterSymbol> replacementTemplateParameters
+        => _replacementTemplateParameters;
 
     internal override LexicalSortKey GetLexicalSortKey() {
         return LexicalSortKey.NotInSource;
@@ -141,4 +143,9 @@ internal sealed class SynthesizedTemplateType : WrappedNamedTypeSymbol {
         Debug.Assert(baseHashCode != newHashCode);
         return newHashCode;
     }
+
+    NamedTypeSymbol ISynthesizedTemplate<NamedTypeSymbol>.unexpandedSymbol => _originalType;
+
+    Dictionary<TemplateParameterSymbol, TemplateParameterSymbol> ISynthesizedTemplate<NamedTypeSymbol>.replacementTemplateParameters
+        => _replacementTemplateParameters;
 }

--- a/src/Buckle/Compiler/CodeAnalysis/Lowering/TemplateExpander/SynthesizedTemplateTypeMethod.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Lowering/TemplateExpander/SynthesizedTemplateTypeMethod.cs
@@ -17,15 +17,13 @@ internal sealed class SynthesizedTemplateTypeMethod : WrappedMethodSymbol {
     internal SynthesizedTemplateTypeMethod(SynthesizedTemplateType newOwner, MethodSymbol method)
         : base(method) {
         _containingType = newOwner;
-        _returnType = TemplateTypeReplacer<TemplateParameterSymbol>.Replace(
-            method.returnTypeWithAnnotations,
-            newOwner.replacementTemplateParameters
-        );
+        _returnType = TemplateTypeReplacer<TemplateParameterSymbol, TemplateParameterSymbol, TemplateParameterSymbol>
+            .Replace(method.returnTypeWithAnnotations, newOwner.replacementTemplateParameters);
 
         var builder = ArrayBuilder<ParameterSymbol>.GetInstance(method.parameterCount);
 
         foreach (var parameter in method.parameters) {
-            var newType = TemplateTypeReplacer<TemplateParameterSymbol>
+            var newType = TemplateTypeReplacer<TemplateParameterSymbol, TemplateParameterSymbol, TemplateParameterSymbol>
                 .Replace(parameter.typeWithAnnotations, newOwner.replacementTemplateParameters);
 
             builder.Add(new TypeSubstitutedParameterSymbol(parameter, newType));

--- a/src/Buckle/Compiler/CodeAnalysis/Lowering/TemplateExpander/SynthesizedTemplateTypeMethod.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Lowering/TemplateExpander/SynthesizedTemplateTypeMethod.cs
@@ -1,0 +1,66 @@
+using System.Collections.Immutable;
+using Buckle.CodeAnalysis.Binding;
+using Buckle.CodeAnalysis.Symbols;
+using Buckle.CodeAnalysis.Syntax;
+using Buckle.Utilities;
+
+namespace Buckle.CodeAnalysis.Lowering;
+
+internal sealed class SynthesizedTemplateTypeMethod : WrappedMethodSymbol {
+    private readonly SynthesizedTemplateType _containingType;
+
+    private int _hashCode;
+
+    internal SynthesizedTemplateTypeMethod(SynthesizedTemplateType newOwner, MethodSymbol method)
+        : base(method) {
+        _containingType = newOwner;
+    }
+
+    internal override Symbol containingSymbol => _containingType;
+
+    public override ImmutableArray<TemplateParameterSymbol> templateParameters => underlyingMethod.templateParameters;
+
+    public override ImmutableArray<BoundExpression> templateConstraints => underlyingMethod.templateConstraints;
+
+    public override ImmutableArray<TypeOrConstant> templateArguments => underlyingMethod.templateArguments;
+
+    internal override TypeWithAnnotations returnTypeWithAnnotations => underlyingMethod.returnTypeWithAnnotations;
+
+    internal override ImmutableArray<ParameterSymbol> parameters => underlyingMethod.parameters;
+
+    internal override int parameterCount => underlyingMethod.parameterCount;
+
+    internal override bool isExplicitInterfaceImplementation => underlyingMethod.isExplicitInterfaceImplementation;
+
+    internal override ImmutableArray<MethodSymbol> explicitInterfaceImplementations => [];
+
+    internal override int CalculateLocalSyntaxOffset(int localPosition, SyntaxTree localTree) {
+        throw ExceptionUtilities.Unreachable();
+    }
+
+    internal override DllImportData GetDllImportData() {
+        return underlyingMethod.GetDllImportData();
+    }
+
+    internal override UnmanagedCallersOnlyAttributeData GetUnmanagedCallersOnlyAttributeData(bool forceComplete) {
+        return underlyingMethod.GetUnmanagedCallersOnlyAttributeData(forceComplete);
+    }
+
+    public override int GetHashCode() {
+        if (_hashCode == 0)
+            _hashCode = ComputeHashCode();
+
+        return _hashCode;
+    }
+
+    private int ComputeHashCode() {
+        var code = System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(this);
+        var containingHashCode = containingType.GetHashCode();
+        code = Hash.Combine(containingHashCode, code);
+
+        if (code == 0)
+            code++;
+
+        return code;
+    }
+}

--- a/src/Buckle/Compiler/CodeAnalysis/Lowering/TemplateExpander/SynthesizedTemplateTypeMethod.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Lowering/TemplateExpander/SynthesizedTemplateTypeMethod.cs
@@ -3,17 +3,35 @@ using Buckle.CodeAnalysis.Binding;
 using Buckle.CodeAnalysis.Symbols;
 using Buckle.CodeAnalysis.Syntax;
 using Buckle.Utilities;
+using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Buckle.CodeAnalysis.Lowering;
 
 internal sealed class SynthesizedTemplateTypeMethod : WrappedMethodSymbol {
     private readonly SynthesizedTemplateType _containingType;
+    private readonly TypeWithAnnotations _returnType;
+    private readonly ImmutableArray<ParameterSymbol> _parameters;
 
     private int _hashCode;
 
     internal SynthesizedTemplateTypeMethod(SynthesizedTemplateType newOwner, MethodSymbol method)
         : base(method) {
         _containingType = newOwner;
+        _returnType = TemplateTypeReplacer<TemplateParameterSymbol>.Replace(
+            method.returnTypeWithAnnotations,
+            newOwner.replacementTemplateParameters
+        );
+
+        var builder = ArrayBuilder<ParameterSymbol>.GetInstance(method.parameterCount);
+
+        foreach (var parameter in method.parameters) {
+            var newType = TemplateTypeReplacer<TemplateParameterSymbol>
+                .Replace(parameter.typeWithAnnotations, newOwner.replacementTemplateParameters);
+
+            builder.Add(new TypeSubstitutedParameterSymbol(parameter, newType));
+        }
+
+        _parameters = builder.ToImmutableAndFree();
     }
 
     internal override Symbol containingSymbol => _containingType;
@@ -24,11 +42,11 @@ internal sealed class SynthesizedTemplateTypeMethod : WrappedMethodSymbol {
 
     public override ImmutableArray<TypeOrConstant> templateArguments => underlyingMethod.templateArguments;
 
-    internal override TypeWithAnnotations returnTypeWithAnnotations => underlyingMethod.returnTypeWithAnnotations;
+    internal override TypeWithAnnotations returnTypeWithAnnotations => _returnType;
 
-    internal override ImmutableArray<ParameterSymbol> parameters => underlyingMethod.parameters;
+    internal override ImmutableArray<ParameterSymbol> parameters => _parameters;
 
-    internal override int parameterCount => underlyingMethod.parameterCount;
+    internal override int parameterCount => _parameters.Length;
 
     internal override bool isExplicitInterfaceImplementation => underlyingMethod.isExplicitInterfaceImplementation;
 

--- a/src/Buckle/Compiler/CodeAnalysis/Lowering/TemplateExpander/SynthesizedTemplateTypeParameter.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Lowering/TemplateExpander/SynthesizedTemplateTypeParameter.cs
@@ -1,0 +1,37 @@
+using System.Collections.Immutable;
+using Buckle.CodeAnalysis.Symbols;
+
+namespace Buckle.CodeAnalysis.Lowering;
+
+internal sealed class SynthesizedTemplateTypeParameter : WrappedTemplateParameterSymbol {
+    private readonly Symbol _containingSymbol;
+
+    internal SynthesizedTemplateTypeParameter(
+        Symbol containingSymbol,
+        TemplateParameterSymbol originalParameter,
+        int ordinal)
+        : base(originalParameter) {
+        _containingSymbol = containingSymbol;
+        this.ordinal = ordinal;
+    }
+
+    internal override Symbol containingSymbol => _containingSymbol;
+
+    internal override int ordinal { get; }
+
+    internal override ImmutableArray<TypeWithAnnotations> GetConstraintTypes(ConsList<TemplateParameterSymbol> inProgress) {
+        return underlyingTemplateParameter.GetConstraintTypes(inProgress);
+    }
+
+    internal override TypeSymbol GetDeducedBaseType(ConsList<TemplateParameterSymbol> inProgress) {
+        return underlyingTemplateParameter.GetDeducedBaseType(inProgress);
+    }
+
+    internal override NamedTypeSymbol GetEffectiveBaseClass(ConsList<TemplateParameterSymbol> inProgress) {
+        return underlyingTemplateParameter.GetEffectiveBaseClass(inProgress);
+    }
+
+    internal override ImmutableArray<NamedTypeSymbol> GetInterfaces(ConsList<TemplateParameterSymbol> inProgress) {
+        return underlyingTemplateParameter.GetInterfaces(inProgress);
+    }
+}

--- a/src/Buckle/Compiler/CodeAnalysis/Lowering/TemplateExpander/TemplateExpander.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Lowering/TemplateExpander/TemplateExpander.cs
@@ -91,6 +91,13 @@ internal sealed class TemplateExpander : BoundTreeRewriterWithStackGuard {
         return type is NamedTypeSymbol named && !IsGenericOnlyType(named);
     }
 
+    internal static bool ShouldEmit(NamedTypeSymbol type) {
+        if (type.templateParameters.Any(t => t.underlyingType.specialType != SpecialType.Type))
+            return false;
+
+        return true;
+    }
+
     private static bool IsGenericOnlyType(NamedTypeSymbol type) {
         foreach (var templateParameter in type.templateParameters) {
             if (templateParameter.underlyingType.specialType != SpecialType.Type)
@@ -118,19 +125,48 @@ internal sealed class TemplateExpander : BoundTreeRewriterWithStackGuard {
         return true;
     }
 
-    private SynthesizedTemplateTypeMethod NoteMethod(SynthesizedTemplateType newOwner, MethodSymbol method) {
-        if (_methodsMap.TryGetValue((newOwner, method), out var result))
-            return result;
+    private MethodSymbol NoteMethod(NamedTypeSymbol newOwner, MethodSymbol method) {
+        var templateOwner = newOwner.originalDefinition as SynthesizedTemplateType;
+        Debug.Assert(templateOwner is not null);
 
-        var templateMethod = new SynthesizedTemplateTypeMethod(newOwner, method);
-        _methodsMap.Add((newOwner, method), templateMethod);
-        return templateMethod;
+        var originalDefinition = method.originalDefinition;
+
+        if (_methodsMap.TryGetValue((templateOwner, originalDefinition), out var result))
+            return ConstructIfApplicable(result);
+
+        var templateMethod = new SynthesizedTemplateTypeMethod(templateOwner, originalDefinition);
+        _methodsMap.Add((templateOwner, originalDefinition), templateMethod);
+        return ConstructIfApplicable(templateMethod);
+
+        MethodSymbol ConstructIfApplicable(MethodSymbol synthesizedMethod) {
+            if (newOwner is ConstructedNamedTypeSymbol)
+                return synthesizedMethod.AsMember(newOwner);
+
+            return synthesizedMethod;
+        }
     }
 
-    private bool TypeIsUnexpandedTemplate(TypeSymbol type, out SynthesizedTemplateType templateType) {
+    private bool TypeIsUnexpandedTemplate(TypeSymbol type, out NamedTypeSymbol templateType) {
         if (NoteType(type)) {
-            if (_typesMap.TryGetValue((ConstructedNamedTypeSymbol)type, out templateType))
+            var constructedType = (ConstructedNamedTypeSymbol)type;
+
+            if (_typesMap.TryGetValue(constructedType, out var unconstructedType)) {
+                if (unconstructedType.arity == 0) {
+                    templateType = unconstructedType;
+                    return true;
+                }
+
+                var builder = ArrayBuilder<TypeOrConstant>.GetInstance(unconstructedType.arity);
+
+                foreach (var templateArgument in constructedType.templateArguments) {
+                    if (templateArgument.isType)
+                        builder.Add(templateArgument);
+                }
+
+                Debug.Assert(builder.Count == unconstructedType.arity);
+                templateType = unconstructedType.Construct(builder.ToImmutableAndFree());
                 return true;
+            }
         }
 
         templateType = null;
@@ -230,7 +266,7 @@ internal sealed class TemplateExpander : BoundTreeRewriterWithStackGuard {
 
         if (TypeIsUnexpandedTemplate(node.type, out var templateType)) {
             node = node.Update(
-                NoteMethod(templateType, node.constructor.originalDefinition),
+                NoteMethod(templateType, node.constructor),
                 node.arguments,
                 node.argumentRefKinds,
                 node.argsToParams,
@@ -259,7 +295,7 @@ internal sealed class TemplateExpander : BoundTreeRewriterWithStackGuard {
         if (TypeIsUnexpandedTemplate(node.method.containingType, out var templateType)) {
             node = node.Update(
                 node.receiver,
-                NoteMethod(templateType, node.method.originalDefinition),
+                NoteMethod(templateType, node.method),
                 node.arguments,
                 node.argumentRefKinds,
                 node.defaultArguments,
@@ -283,7 +319,7 @@ internal sealed class TemplateExpander : BoundTreeRewriterWithStackGuard {
         if (TypeIsUnexpandedTemplate(node.targetMethod.containingType, out var templateType)) {
             node = node.Update(
                 node.receiver,
-                NoteMethod(templateType, node.targetMethod.originalDefinition),
+                NoteMethod(templateType, node.targetMethod),
                 node.type
             );
         }

--- a/src/Buckle/Compiler/CodeAnalysis/Lowering/TemplateExpander/TemplateExpander.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Lowering/TemplateExpander/TemplateExpander.cs
@@ -15,9 +15,11 @@ internal sealed class TemplateExpander : BoundTreeRewriterWithStackGuard {
     private readonly ArrayBuilder<SynthesizedTemplateType> _typesBuilder;
     private readonly Dictionary<ConstructedNamedTypeSymbol, SynthesizedTemplateType> _typesMap = [];
     // Used for methods contained within an expanded template type
-    private readonly Dictionary<(SynthesizedTemplateType, MethodSymbol), SynthesizedTemplateTypeMethod> _methodsMap = [];
+    private readonly Dictionary<(SynthesizedTemplateType, MethodSymbol), SynthesizedTemplateTypeMethod> _typeMethodsMap = [];
     // Used for methods with an expanded template return type or parameter type
     private ImmutableDictionary<MethodSymbol, MethodSymbol> _secondaryMethodsMap;
+    // Used for methods needing expanding because they directly have non-type templates
+    private readonly Dictionary<MethodSymbol, SynthesizedTemplateMethod> _methodsMap = [];
     private readonly Dictionary<DataContainerSymbol, DataContainerSymbol> _localMap = [];
 
     private MethodSymbol _currentMethod;
@@ -64,7 +66,11 @@ internal sealed class TemplateExpander : BoundTreeRewriterWithStackGuard {
         _secondaryMethodsMap = methodMap;
     }
 
-    internal ImmutableDictionary<(SynthesizedTemplateType, MethodSymbol), SynthesizedTemplateTypeMethod> GetMethodMap() {
+    internal ImmutableDictionary<(SynthesizedTemplateType, MethodSymbol), SynthesizedTemplateTypeMethod> GetTypeMethodMap() {
+        return _typeMethodsMap.ToImmutableDictionary();
+    }
+
+    internal ImmutableDictionary<MethodSymbol, SynthesizedTemplateMethod> GetMethodMap() {
         return _methodsMap.ToImmutableDictionary();
     }
 
@@ -87,22 +93,26 @@ internal sealed class TemplateExpander : BoundTreeRewriterWithStackGuard {
     }
 
     internal static bool IsNonTypeTemplateTypeConstructed(TypeSymbol type) {
-        return type is ConstructedNamedTypeSymbol constructed && !IsGenericOnlyType(constructed);
+        return type is ConstructedNamedTypeSymbol constructed && !IsGenericOnly(constructed);
     }
 
     internal static bool IsNonTypeTemplateType(TypeSymbol type) {
-        return type is NamedTypeSymbol named && !IsGenericOnlyType(named);
+        return type is NamedTypeSymbol named && !IsGenericOnly(named);
     }
 
-    internal static bool ShouldEmit(NamedTypeSymbol type) {
+    internal static bool IsNonTypeTemplateMethod(MethodSymbol method) {
+        return !IsGenericOnly(method);
+    }
+
+    internal static bool ShouldEmit(ISymbolWithTemplates type) {
         if (type.templateParameters.Any(t => t.underlyingType.specialType != SpecialType.Type))
             return false;
 
         return true;
     }
 
-    private static bool IsGenericOnlyType(NamedTypeSymbol type) {
-        foreach (var templateParameter in type.templateParameters) {
+    private static bool IsGenericOnly(ISymbolWithTemplates symbol) {
+        foreach (var templateParameter in symbol.templateParameters) {
             if (templateParameter.underlyingType.specialType != SpecialType.Type)
                 return false;
         }
@@ -111,7 +121,7 @@ internal sealed class TemplateExpander : BoundTreeRewriterWithStackGuard {
     }
 
     private bool NoteType(TypeSymbol type) {
-        if (type is not ConstructedNamedTypeSymbol constructed || IsGenericOnlyType(constructed))
+        if (type is not ConstructedNamedTypeSymbol constructed || IsGenericOnly(constructed))
             return false;
 
         if (_typesMap.ContainsKey(constructed))
@@ -128,16 +138,16 @@ internal sealed class TemplateExpander : BoundTreeRewriterWithStackGuard {
         return true;
     }
 
-    private MethodSymbol NoteMethod(NamedTypeSymbol newOwner, MethodSymbol method) {
+    private MethodSymbol ReplaceMethodOwner(NamedTypeSymbol newOwner, MethodSymbol method) {
         // This is for when rewriting method calls on a template type directly
         if (newOwner.originalDefinition is SynthesizedTemplateType templateOwner) {
             var originalDefinition = method.originalDefinition;
 
-            if (_methodsMap.TryGetValue((templateOwner, originalDefinition), out var result))
+            if (_typeMethodsMap.TryGetValue((templateOwner, originalDefinition), out var result))
                 return ConstructIfApplicable(result);
 
             var templateMethod = new SynthesizedTemplateTypeMethod(templateOwner, originalDefinition);
-            _methodsMap.Add((templateOwner, originalDefinition), templateMethod);
+            _typeMethodsMap.Add((templateOwner, originalDefinition), templateMethod);
             return ConstructIfApplicable(templateMethod);
         }
         // This is for when rewriting a method call not on a template type that contains template types (via return or param types)
@@ -160,6 +170,24 @@ internal sealed class TemplateExpander : BoundTreeRewriterWithStackGuard {
         if (TypeSymbol.Equals(type, replacedType, TypeCompareKind.ConsiderEverything))
             return false;
 
+        return true;
+    }
+
+    private bool MethodContainsUnexpandedTemplate(MethodSymbol method, out MethodSymbol replacedMethod) {
+        if (method is not ConstructedMethodSymbol constructed || IsGenericOnly(constructed)) {
+            replacedMethod = null;
+            return false;
+        }
+
+        if (_methodsMap.TryGetValue(method, out var templateMethod)) {
+            replacedMethod = templateMethod;
+            return true;
+        }
+
+        var synthesizedMethod = new SynthesizedTemplateMethod(method.containingSymbol, constructed);
+        _methodsMap.Add(constructed, synthesizedMethod);
+
+        replacedMethod = synthesizedMethod;
         return true;
     }
 
@@ -285,7 +313,7 @@ internal sealed class TemplateExpander : BoundTreeRewriterWithStackGuard {
 
         if (TypeContainsUnexpandedTemplate(node.type, out var templateType)) {
             node = node.Update(
-                NoteMethod((NamedTypeSymbol)templateType, node.constructor),
+                ReplaceMethodOwner((NamedTypeSymbol)templateType, node.constructor),
                 node.arguments,
                 node.argumentRefKinds,
                 node.argsToParams,
@@ -314,12 +342,24 @@ internal sealed class TemplateExpander : BoundTreeRewriterWithStackGuard {
         if (TypeContainsUnexpandedTemplate(node.method.containingType, out var templateType)) {
             node = node.Update(
                 node.receiver,
-                NoteMethod((NamedTypeSymbol)templateType, node.method),
+                ReplaceMethodOwner((NamedTypeSymbol)templateType, node.method),
                 node.arguments,
                 node.argumentRefKinds,
                 node.defaultArguments,
                 node.resultKind,
                 node.type
+            );
+        }
+
+        if (MethodContainsUnexpandedTemplate(node.method, out var templateMethod)) {
+            node = node.Update(
+                node.receiver,
+                templateMethod,
+                node.arguments,
+                node.argumentRefKinds,
+                node.defaultArguments,
+                node.resultKind,
+                templateMethod.returnType
             );
         }
 
@@ -338,11 +378,47 @@ internal sealed class TemplateExpander : BoundTreeRewriterWithStackGuard {
         if (TypeContainsUnexpandedTemplate(node.targetMethod.containingType, out var templateType)) {
             node = node.Update(
                 node.receiver,
-                NoteMethod((NamedTypeSymbol)templateType, node.targetMethod),
+                ReplaceMethodOwner((NamedTypeSymbol)templateType, node.targetMethod),
+                node.type
+            );
+        }
+
+        if (MethodContainsUnexpandedTemplate(node.targetMethod, out var templateMethod)) {
+            node = node.Update(
+                node.receiver,
+                templateMethod,
                 node.type
             );
         }
 
         return base.VisitFunctionLoad(node);
+    }
+
+    internal override BoundNode VisitFunctionPointerLoad(BoundFunctionPointerLoad node) {
+        if (_secondaryMethodsMap.TryGetValue(node.targetMethod, out var replacementMethod)) {
+            node = node.Update(
+                replacementMethod,
+                node.constrainedToType,
+                node.type
+            );
+        }
+
+        if (TypeContainsUnexpandedTemplate(node.targetMethod.containingType, out var templateType)) {
+            node = node.Update(
+                ReplaceMethodOwner((NamedTypeSymbol)templateType, node.targetMethod),
+                node.constrainedToType,
+                node.type
+            );
+        }
+
+        if (MethodContainsUnexpandedTemplate(node.targetMethod, out var templateMethod)) {
+            node = node.Update(
+                templateMethod,
+                node.constrainedToType,
+                node.type
+            );
+        }
+
+        return base.VisitFunctionPointerLoad(node);
     }
 }

--- a/src/Buckle/Compiler/CodeAnalysis/Lowering/TemplateExpander/TemplateExpander.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Lowering/TemplateExpander/TemplateExpander.cs
@@ -8,6 +8,9 @@ using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Buckle.CodeAnalysis.Lowering;
 
+/// <summary>
+/// Rewrites method signatures and bodies if they contain instantiations of non-type template types
+/// </summary>
 internal sealed class TemplateExpander : BoundTreeRewriterWithStackGuard {
     private readonly ArrayBuilder<SynthesizedTemplateType> _typesBuilder;
     private readonly Dictionary<ConstructedNamedTypeSymbol, SynthesizedTemplateType> _typesMap = [];
@@ -32,11 +35,11 @@ internal sealed class TemplateExpander : BoundTreeRewriterWithStackGuard {
 
         if (IsNonTypeTemplateTypeConstructed(returnType) ||
             method.parameterTypesWithAnnotations.Any(p => IsNonTypeTemplateTypeConstructed(p.type))) {
-            var newReturnType = TypeIsUnexpandedTemplate(returnType, out var newType) ? newType : returnType;
+            var newReturnType = VisitType(returnType);
             var builder = ArrayBuilder<ParameterSymbol>.GetInstance(method.parameterCount);
 
             foreach (var parameter in method.parameters) {
-                var newParameter = TypeIsUnexpandedTemplate(parameter.type, out var newParamType)
+                var newParameter = TypeContainsUnexpandedTemplate(parameter.type, out var newParamType)
                     ? new TypeSubstitutedParameterSymbol(parameter, new TypeWithAnnotations(newParamType))
                     : parameter;
 
@@ -126,17 +129,22 @@ internal sealed class TemplateExpander : BoundTreeRewriterWithStackGuard {
     }
 
     private MethodSymbol NoteMethod(NamedTypeSymbol newOwner, MethodSymbol method) {
-        var templateOwner = newOwner.originalDefinition as SynthesizedTemplateType;
-        Debug.Assert(templateOwner is not null);
+        // This is for when rewriting method calls on a template type directly
+        if (newOwner.originalDefinition is SynthesizedTemplateType templateOwner) {
+            var originalDefinition = method.originalDefinition;
 
-        var originalDefinition = method.originalDefinition;
+            if (_methodsMap.TryGetValue((templateOwner, originalDefinition), out var result))
+                return ConstructIfApplicable(result);
 
-        if (_methodsMap.TryGetValue((templateOwner, originalDefinition), out var result))
-            return ConstructIfApplicable(result);
-
-        var templateMethod = new SynthesizedTemplateTypeMethod(templateOwner, originalDefinition);
-        _methodsMap.Add((templateOwner, originalDefinition), templateMethod);
-        return ConstructIfApplicable(templateMethod);
+            var templateMethod = new SynthesizedTemplateTypeMethod(templateOwner, originalDefinition);
+            _methodsMap.Add((templateOwner, originalDefinition), templateMethod);
+            return ConstructIfApplicable(templateMethod);
+        }
+        // This is for when rewriting a method call not on a template type that contains template types (via return or param types)
+        else {
+            Debug.Assert(newOwner is ConstructedNamedTypeSymbol);
+            return method.originalDefinition.AsMember(newOwner);
+        }
 
         MethodSymbol ConstructIfApplicable(MethodSymbol synthesizedMethod) {
             if (newOwner is ConstructedNamedTypeSymbol)
@@ -146,31 +154,13 @@ internal sealed class TemplateExpander : BoundTreeRewriterWithStackGuard {
         }
     }
 
-    private bool TypeIsUnexpandedTemplate(TypeSymbol type, out NamedTypeSymbol templateType) {
-        if (NoteType(type)) {
-            var constructedType = (ConstructedNamedTypeSymbol)type;
+    private bool TypeContainsUnexpandedTemplate(TypeSymbol type, out TypeSymbol replacedType) {
+        replacedType = VisitType(type);
 
-            if (_typesMap.TryGetValue(constructedType, out var unconstructedType)) {
-                if (unconstructedType.arity == 0) {
-                    templateType = unconstructedType;
-                    return true;
-                }
+        if (TypeSymbol.Equals(type, replacedType, TypeCompareKind.ConsiderEverything))
+            return false;
 
-                var builder = ArrayBuilder<TypeOrConstant>.GetInstance(unconstructedType.arity);
-
-                foreach (var templateArgument in constructedType.templateArguments) {
-                    if (templateArgument.isType)
-                        builder.Add(templateArgument);
-                }
-
-                Debug.Assert(builder.Count == unconstructedType.arity);
-                templateType = unconstructedType.Construct(builder.ToImmutableAndFree());
-                return true;
-            }
-        }
-
-        templateType = null;
-        return false;
+        return true;
     }
 
     private ImmutableArray<DataContainerSymbol> RewriteLocals(ImmutableArray<DataContainerSymbol> locals) {
@@ -206,10 +196,39 @@ internal sealed class TemplateExpander : BoundTreeRewriterWithStackGuard {
     }
 
     internal override TypeSymbol VisitType(TypeSymbol type) {
-        if (type is not null && TypeIsUnexpandedTemplate(type, out var newType))
-            return newType;
+        if (type is not null) {
+            type.VisitType(VisitTypePredicate, this);
+
+            return TemplateTypeReplacer<ConstructedNamedTypeSymbol, SynthesizedTemplateType, NamedTypeSymbol>.Replace(
+                type,
+                _typesMap,
+                ConstructIfApplicable
+            );
+        }
 
         return type;
+
+        static bool VisitTypePredicate(TypeSymbol type, TemplateExpander argument, bool canDigThroughNullable = true) {
+            argument.NoteType(type);
+            return false;
+        }
+
+        static NamedTypeSymbol ConstructIfApplicable(
+            ConstructedNamedTypeSymbol source,
+            SynthesizedTemplateType replacement) {
+            if (replacement.arity == 0)
+                return replacement;
+
+            var builder = ArrayBuilder<TypeOrConstant>.GetInstance(replacement.arity);
+
+            foreach (var templateArgument in source.templateArguments) {
+                if (templateArgument.isType)
+                    builder.Add(templateArgument);
+            }
+
+            Debug.Assert(builder.Count == replacement.arity);
+            return replacement.Construct(builder.ToImmutableAndFree());
+        }
     }
 
     internal override BoundNode VisitBlockStatement(BoundBlockStatement node) {
@@ -264,9 +283,9 @@ internal sealed class TemplateExpander : BoundTreeRewriterWithStackGuard {
             );
         }
 
-        if (TypeIsUnexpandedTemplate(node.type, out var templateType)) {
+        if (TypeContainsUnexpandedTemplate(node.type, out var templateType)) {
             node = node.Update(
-                NoteMethod(templateType, node.constructor),
+                NoteMethod((NamedTypeSymbol)templateType, node.constructor),
                 node.arguments,
                 node.argumentRefKinds,
                 node.argsToParams,
@@ -292,10 +311,10 @@ internal sealed class TemplateExpander : BoundTreeRewriterWithStackGuard {
             );
         }
 
-        if (TypeIsUnexpandedTemplate(node.method.containingType, out var templateType)) {
+        if (TypeContainsUnexpandedTemplate(node.method.containingType, out var templateType)) {
             node = node.Update(
                 node.receiver,
-                NoteMethod(templateType, node.method),
+                NoteMethod((NamedTypeSymbol)templateType, node.method),
                 node.arguments,
                 node.argumentRefKinds,
                 node.defaultArguments,
@@ -316,10 +335,10 @@ internal sealed class TemplateExpander : BoundTreeRewriterWithStackGuard {
             );
         }
 
-        if (TypeIsUnexpandedTemplate(node.targetMethod.containingType, out var templateType)) {
+        if (TypeContainsUnexpandedTemplate(node.targetMethod.containingType, out var templateType)) {
             node = node.Update(
                 node.receiver,
-                NoteMethod(templateType, node.targetMethod),
+                NoteMethod((NamedTypeSymbol)templateType, node.targetMethod),
                 node.type
             );
         }

--- a/src/Buckle/Compiler/CodeAnalysis/Lowering/TemplateExpander/TemplateExpander.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Lowering/TemplateExpander/TemplateExpander.cs
@@ -1,0 +1,293 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using Buckle.CodeAnalysis.Binding;
+using Buckle.CodeAnalysis.Symbols;
+using Microsoft.CodeAnalysis.PooledObjects;
+
+namespace Buckle.CodeAnalysis.Lowering;
+
+internal sealed class TemplateExpander : BoundTreeRewriterWithStackGuard {
+    private readonly ArrayBuilder<SynthesizedTemplateType> _typesBuilder;
+    private readonly Dictionary<ConstructedNamedTypeSymbol, SynthesizedTemplateType> _typesMap = [];
+    // Used for methods contained within an expanded template type
+    private readonly Dictionary<(SynthesizedTemplateType, MethodSymbol), SynthesizedTemplateTypeMethod> _methodsMap = [];
+    // Used for methods with an expanded template return type or parameter type
+    private ImmutableDictionary<MethodSymbol, MethodSymbol> _secondaryMethodsMap;
+    private readonly Dictionary<DataContainerSymbol, DataContainerSymbol> _localMap = [];
+
+    private MethodSymbol _currentMethod;
+    private MethodSymbol _replacementMethod;
+
+    internal TemplateExpander(ArrayBuilder<SynthesizedTemplateType> typesBuilder) {
+        _typesBuilder = typesBuilder;
+    }
+
+    internal bool RewriteMethodSymbol(MethodSymbol method, out MethodSymbol newMethod) {
+        // All methods should be rewritten before the main pass
+        Debug.Assert(_secondaryMethodsMap is null);
+
+        var returnType = method.returnType;
+
+        if (IsNonTypeTemplateTypeConstructed(returnType) ||
+            method.parameterTypesWithAnnotations.Any(p => IsNonTypeTemplateTypeConstructed(p.type))) {
+            var newReturnType = TypeIsUnexpandedTemplate(returnType, out var newType) ? newType : returnType;
+            var builder = ArrayBuilder<ParameterSymbol>.GetInstance(method.parameterCount);
+
+            foreach (var parameter in method.parameters) {
+                var newParameter = TypeIsUnexpandedTemplate(parameter.type, out var newParamType)
+                    ? new TypeSubstitutedParameterSymbol(parameter, new TypeWithAnnotations(newParamType))
+                    : parameter;
+
+                builder.Add(newParameter);
+            }
+
+            newMethod = new TypeSubstitutedMethodSymbol(
+                method,
+                new TypeWithAnnotations(newReturnType),
+                builder.ToImmutableAndFree()
+            );
+
+            return true;
+        }
+
+        newMethod = null;
+        return false;
+    }
+
+    internal void SetSecondaryMethodMap(ImmutableDictionary<MethodSymbol, MethodSymbol> methodMap) {
+        Debug.Assert(_secondaryMethodsMap is null);
+        _secondaryMethodsMap = methodMap;
+    }
+
+    internal ImmutableDictionary<(SynthesizedTemplateType, MethodSymbol), SynthesizedTemplateTypeMethod> GetMethodMap() {
+        return _methodsMap.ToImmutableDictionary();
+    }
+
+    internal bool Expand(
+        MethodSymbol method,
+        BoundBlockStatement body,
+        out MethodSymbol newMethod,
+        out BoundBlockStatement newBody) {
+        Debug.Assert(_secondaryMethodsMap is not null);
+
+        _currentMethod = method;
+
+        if (_secondaryMethodsMap.TryGetValue(method, out var value))
+            _replacementMethod = value;
+
+        newBody = (BoundBlockStatement)VisitBlockStatement(body);
+        newMethod = _replacementMethod;
+
+        return newBody != body;
+    }
+
+    internal static bool IsNonTypeTemplateTypeConstructed(TypeSymbol type) {
+        return type is ConstructedNamedTypeSymbol constructed && !IsGenericOnlyType(constructed);
+    }
+
+    internal static bool IsNonTypeTemplateType(TypeSymbol type) {
+        return type is NamedTypeSymbol named && !IsGenericOnlyType(named);
+    }
+
+    private static bool IsGenericOnlyType(NamedTypeSymbol type) {
+        foreach (var templateParameter in type.templateParameters) {
+            if (templateParameter.underlyingType.specialType != SpecialType.Type)
+                return false;
+        }
+
+        return true;
+    }
+
+    private bool NoteType(TypeSymbol type) {
+        if (type is not ConstructedNamedTypeSymbol constructed || IsGenericOnlyType(constructed))
+            return false;
+
+        if (_typesMap.ContainsKey(constructed))
+            return true;
+
+        var containingSymbol = constructed.containingSymbol is TypeSymbol containingType
+            ? VisitType(containingType)
+            : constructed.containingSymbol;
+
+        var synthesizedType = new SynthesizedTemplateType(containingSymbol, constructed);
+        _typesMap.Add(constructed, synthesizedType);
+        _typesBuilder.Add(synthesizedType);
+
+        return true;
+    }
+
+    private SynthesizedTemplateTypeMethod NoteMethod(SynthesizedTemplateType newOwner, MethodSymbol method) {
+        if (_methodsMap.TryGetValue((newOwner, method), out var result))
+            return result;
+
+        var templateMethod = new SynthesizedTemplateTypeMethod(newOwner, method);
+        _methodsMap.Add((newOwner, method), templateMethod);
+        return templateMethod;
+    }
+
+    private bool TypeIsUnexpandedTemplate(TypeSymbol type, out SynthesizedTemplateType templateType) {
+        if (NoteType(type)) {
+            if (_typesMap.TryGetValue((ConstructedNamedTypeSymbol)type, out templateType))
+                return true;
+        }
+
+        templateType = null;
+        return false;
+    }
+
+    private ImmutableArray<DataContainerSymbol> RewriteLocals(ImmutableArray<DataContainerSymbol> locals) {
+        var newLocals = ArrayBuilder<DataContainerSymbol>.GetInstance();
+
+        foreach (var local in locals) {
+            if (TryRewriteLocal(local, out var newLocal))
+                newLocals.Add(newLocal);
+        }
+
+        return newLocals.ToImmutableAndFree();
+    }
+
+    private bool TryRewriteLocal(DataContainerSymbol local, out DataContainerSymbol newLocal) {
+        if (_localMap.TryGetValue(local, out newLocal))
+            return true;
+
+        var newType = VisitType(local.type);
+
+        if (TypeSymbol.Equals(newType, local.type, TypeCompareKind.ConsiderEverything) && _replacementMethod is null) {
+            newLocal = local;
+        } else {
+            newLocal = new TypeSubstitutedLocalSymbol(
+                local,
+                new TypeWithAnnotations(newType),
+                _replacementMethod ?? _currentMethod
+            );
+
+            _localMap.Add(local, newLocal);
+        }
+
+        return true;
+    }
+
+    internal override TypeSymbol VisitType(TypeSymbol type) {
+        if (type is not null && TypeIsUnexpandedTemplate(type, out var newType))
+            return newType;
+
+        return type;
+    }
+
+    internal override BoundNode VisitBlockStatement(BoundBlockStatement node) {
+        var newLocals = RewriteLocals(node.locals);
+        var newLocalFunctions = node.localFunctions;
+        var newStatements = VisitList(node.statements);
+        return node.Update(newStatements, newLocals, newLocalFunctions);
+    }
+
+    internal override BoundNode VisitDataContainerExpression(BoundDataContainerExpression node) {
+        if (_localMap.TryGetValue(node.dataContainer, out var replacementLocal)) {
+            return node.Update(
+                replacementLocal,
+                node.constantValue,
+                replacementLocal.type
+            );
+        }
+
+        return base.VisitDataContainerExpression(node);
+    }
+
+    internal override BoundNode VisitDataContainerDeclaration(BoundDataContainerDeclaration node) {
+        if (_localMap.TryGetValue(node.dataContainer, out var replacementLocal)) {
+            node = node.Update(
+                replacementLocal,
+                node.initializer
+            );
+        }
+
+        return base.VisitDataContainerDeclaration(node);
+    }
+
+    internal override BoundNode VisitParameterExpression(BoundParameterExpression node) {
+        if (_replacementMethod is not null) {
+            var newParameter = _replacementMethod.parameters[node.parameter.ordinal];
+            node = node.Update(newParameter, node.constantValue, newParameter.type);
+        }
+
+        return base.VisitParameterExpression(node);
+    }
+
+    internal override BoundNode VisitObjectCreationExpression(BoundObjectCreationExpression node) {
+        if (_secondaryMethodsMap.TryGetValue(node.constructor, out var replacementMethod)) {
+            node = node.Update(
+                replacementMethod,
+                node.arguments,
+                node.argumentRefKinds,
+                node.argsToParams,
+                node.defaultArguments,
+                node.wasTargetTyped,
+                node.type
+            );
+        }
+
+        if (TypeIsUnexpandedTemplate(node.type, out var templateType)) {
+            node = node.Update(
+                NoteMethod(templateType, node.constructor.originalDefinition),
+                node.arguments,
+                node.argumentRefKinds,
+                node.argsToParams,
+                node.defaultArguments,
+                node.wasTargetTyped,
+                templateType
+            );
+        }
+
+        return base.VisitObjectCreationExpression(node);
+    }
+
+    internal override BoundNode VisitCallExpression(BoundCallExpression node) {
+        if (_secondaryMethodsMap.TryGetValue(node.method, out var replacementMethod)) {
+            node = node.Update(
+                node.receiver,
+                replacementMethod,
+                node.arguments,
+                node.argumentRefKinds,
+                node.defaultArguments,
+                node.resultKind,
+                replacementMethod.returnType
+            );
+        }
+
+        if (TypeIsUnexpandedTemplate(node.method.containingType, out var templateType)) {
+            node = node.Update(
+                node.receiver,
+                NoteMethod(templateType, node.method.originalDefinition),
+                node.arguments,
+                node.argumentRefKinds,
+                node.defaultArguments,
+                node.resultKind,
+                node.type
+            );
+        }
+
+        return base.VisitCallExpression(node);
+    }
+
+    internal override BoundNode VisitFunctionLoad(BoundFunctionLoad node) {
+        if (_secondaryMethodsMap.TryGetValue(node.targetMethod, out var replacementMethod)) {
+            node = node.Update(
+                node.receiver,
+                replacementMethod,
+                node.type
+            );
+        }
+
+        if (TypeIsUnexpandedTemplate(node.targetMethod.containingType, out var templateType)) {
+            node = node.Update(
+                node.receiver,
+                NoteMethod(templateType, node.targetMethod.originalDefinition),
+                node.type
+            );
+        }
+
+        return base.VisitFunctionLoad(node);
+    }
+}

--- a/src/Buckle/Compiler/CodeAnalysis/Lowering/TemplateExpander/TemplateTypeReplacer.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Lowering/TemplateExpander/TemplateTypeReplacer.cs
@@ -1,0 +1,206 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Buckle.CodeAnalysis.Symbols;
+using Microsoft.CodeAnalysis.PooledObjects;
+
+namespace Buckle.CodeAnalysis.Lowering;
+
+internal sealed class TemplateTypeReplacer<T> where T : TypeSymbol {
+    private readonly Dictionary<T, T> _map;
+
+    private TemplateTypeReplacer(Dictionary<T, T> map) {
+        _map = map;
+    }
+
+    internal static TypeWithAnnotations Replace(TypeWithAnnotations source, Dictionary<T, T> map) {
+        var replacer = new TemplateTypeReplacer<T>(map);
+        return replacer.ReplaceTypeWithAnnotations(source);
+    }
+
+    private TypeSymbol ReplaceType(TypeSymbol source) {
+        if (source is T t && _map.TryGetValue(t, out var replacement))
+            return replacement;
+
+        TypeSymbol result;
+
+        switch (source.kind) {
+            case SymbolKind.NamedType:
+                result = ReplaceNamedType((NamedTypeSymbol)source);
+                break;
+            case SymbolKind.TemplateParameter:
+                result = source;
+                break;
+            case SymbolKind.ArrayType:
+                result = ReplaceArrayType((ArrayTypeSymbol)source);
+                break;
+            case SymbolKind.PointerType:
+                result = ReplacePointerType((PointerTypeSymbol)source);
+                break;
+            case SymbolKind.FunctionPointerType:
+                result = ReplaceFunctionPointerType((FunctionPointerTypeSymbol)source);
+                break;
+            case SymbolKind.FunctionType:
+                result = ReplaceFunctionType((FunctionTypeSymbol)source);
+                break;
+            case SymbolKind.ErrorType:
+            default:
+                result = source;
+                break;
+        }
+
+        return result;
+    }
+
+    private NamedTypeSymbol ReplaceNamedType(NamedTypeSymbol source) {
+        if (source is null)
+            return null;
+
+        var oldConstructedFrom = source.constructedFrom;
+        var newConstructedFrom = ReplaceTypeDeclaration(oldConstructedFrom);
+
+        var oldTemplateArguments = source.templateArguments;
+        var changed = !ReferenceEquals(oldConstructedFrom, newConstructedFrom);
+        var newTypeArguments = ArrayBuilder<TypeOrConstant>.GetInstance(oldTemplateArguments.Length);
+
+        for (var i = 0; i < oldTemplateArguments.Length; i++) {
+            var oldArgument = oldTemplateArguments[i];
+
+            if (oldArgument.isConstant) {
+                newTypeArguments.Add(oldArgument);
+                continue;
+            }
+
+            var newArgument = ReplaceTypeWithAnnotations(oldArgument.type);
+
+            if (!changed && !oldArgument.type.IsSameAs(newArgument))
+                changed = true;
+
+            newTypeArguments.Add(new TypeOrConstant(newArgument));
+        }
+
+        if (!changed)
+            return source;
+
+        return newConstructedFrom.ConstructIfGeneric(newTypeArguments.ToImmutableAndFree()).WithTupleDataFrom(source);
+    }
+
+    private TypeWithAnnotations ReplaceTypeWithAnnotations(TypeWithAnnotations typeWithAnnotations) {
+        var type = typeWithAnnotations.type;
+        var typeSymbol = type.StrippedType();
+        var newType = new TypeWithAnnotations(ReplaceType(typeSymbol));
+
+        if (type.IsNullableType() && !newType.IsNullableType())
+            newType = newType.SetIsAnnotated();
+
+        if (!typeSymbol.IsTemplateParameter()) {
+            if (typeSymbol.Equals(newType.type, TypeCompareKind.ConsiderEverything))
+                return typeWithAnnotations;
+            else if (typeSymbol.IsNullableType() && typeWithAnnotations.isNullable)
+                return newType;
+
+            return new TypeWithAnnotations(newType.type, typeWithAnnotations.isNullable);
+        }
+
+        if ((object)newType == (TemplateParameterSymbol)typeSymbol)
+            return typeWithAnnotations;
+        else if ((object)this == (TemplateParameterSymbol)typeSymbol)
+            return new TypeWithAnnotations(newType.type);
+
+        return new TypeWithAnnotations(newType.type, typeWithAnnotations.isNullable || newType.isNullable);
+    }
+
+    private NamedTypeSymbol ReplaceTypeDeclaration(NamedTypeSymbol previous) {
+        var newContainingType = ReplaceNamedType(previous.containingType);
+
+        if ((object)newContainingType is null)
+            return previous;
+
+        return previous.originalDefinition.AsMember(newContainingType);
+    }
+
+    private ArrayTypeSymbol ReplaceArrayType(ArrayTypeSymbol previous) {
+        var oldElement = previous.elementTypeWithAnnotations;
+        var element = ReplaceTypeWithAnnotations(oldElement);
+
+        if (element.IsSameAs(oldElement))
+            return previous;
+
+        if (previous.isSZArray)
+            return ArrayTypeSymbol.CreateSZArray(element, previous.baseType);
+
+        return ArrayTypeSymbol.CreateMDArray(
+            element,
+            previous.rank,
+            previous.sizes,
+            previous.lowerBounds,
+            previous.baseType
+        );
+    }
+
+    private PointerTypeSymbol ReplacePointerType(PointerTypeSymbol t) {
+        var oldPointedAtType = t.pointedAtTypeWithAnnotations;
+        var pointedAtType = ReplaceTypeWithAnnotations(oldPointedAtType);
+
+        if (pointedAtType.IsSameAs(oldPointedAtType))
+            return t;
+
+        return new PointerTypeSymbol(pointedAtType);
+    }
+
+    private FunctionPointerTypeSymbol ReplaceFunctionPointerType(FunctionPointerTypeSymbol f) {
+        var substitutedReturnType = ReplaceTypeWithAnnotations(f.signature.returnTypeWithAnnotations);
+
+        var parameterTypesWithAnnotations = f.signature.parameterTypesWithAnnotations;
+        var replacedParamTypes = ReplaceTypes(parameterTypesWithAnnotations);
+
+        if (!CollectionsEqual(replacedParamTypes, parameterTypesWithAnnotations) ||
+            !f.signature.returnTypeWithAnnotations.IsSameAs(substitutedReturnType)) {
+            f = f.ReplaceTypeSymbol(substitutedReturnType, replacedParamTypes);
+        }
+
+        return f;
+    }
+
+    private FunctionTypeSymbol ReplaceFunctionType(FunctionTypeSymbol f) {
+        var substitutedReturnType = ReplaceTypeWithAnnotations(f.signature.returnTypeWithAnnotations);
+
+        var parameterTypesWithAnnotations = f.signature.parameterTypesWithAnnotations;
+        var replacedParamTypes = ReplaceTypes(parameterTypesWithAnnotations);
+
+        if (!CollectionsEqual(replacedParamTypes, parameterTypesWithAnnotations) ||
+            !f.signature.returnTypeWithAnnotations.IsSameAs(substitutedReturnType)) {
+            f = f.ReplaceTypeSymbol(substitutedReturnType, replacedParamTypes);
+        }
+
+        return f;
+    }
+
+    private ImmutableArray<TypeWithAnnotations> ReplaceTypes(ImmutableArray<TypeWithAnnotations> original) {
+        if (original.IsDefault)
+            return default;
+
+        var result = ArrayBuilder<TypeWithAnnotations>.GetInstance(original.Length);
+
+        foreach (var type in original)
+            result.Add(ReplaceTypeWithAnnotations(type));
+
+        return result.ToImmutableAndFree();
+    }
+
+    private static bool CollectionsEqual(
+        ImmutableArray<TypeWithAnnotations> collection1,
+        ImmutableArray<TypeWithAnnotations> collection2) {
+        if (collection1.Length != collection2.Length)
+            return false;
+
+        for (var i = 0; i < collection1.Length; i++) {
+            var typeWithAnnotations1 = collection1[i];
+            var typeWithAnnotations2 = collection2[i];
+
+            if (!typeWithAnnotations1.Equals(typeWithAnnotations2))
+                return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Buckle/Compiler/CodeAnalysis/Lowering/TemplateExpander/TemplateTypeReplacer.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Lowering/TemplateExpander/TemplateTypeReplacer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using Buckle.CodeAnalysis.Symbols;
@@ -5,21 +6,41 @@ using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Buckle.CodeAnalysis.Lowering;
 
-internal sealed class TemplateTypeReplacer<T> where T : TypeSymbol {
-    private readonly Dictionary<T, T> _map;
+internal sealed class TemplateTypeReplacer<TKey, TValue, TReturn>
+    where TKey : TypeSymbol
+    where TValue : TypeSymbol
+    where TReturn : TypeSymbol {
+    private readonly Dictionary<TKey, TValue> _map;
+    private readonly Func<TKey, TValue, TReturn> _afterFoundTransformation;
 
-    private TemplateTypeReplacer(Dictionary<T, T> map) {
+    private TemplateTypeReplacer(Dictionary<TKey, TValue> map, Func<TKey, TValue, TReturn> afterFoundTransformation) {
         _map = map;
+        _afterFoundTransformation = afterFoundTransformation;
     }
 
-    internal static TypeWithAnnotations Replace(TypeWithAnnotations source, Dictionary<T, T> map) {
-        var replacer = new TemplateTypeReplacer<T>(map);
+    internal static TypeWithAnnotations Replace(
+        TypeWithAnnotations source,
+        Dictionary<TKey, TValue> map,
+        Func<TKey, TValue, TReturn> afterFoundTransformation = null) {
+        var replacer = new TemplateTypeReplacer<TKey, TValue, TReturn>(map, afterFoundTransformation);
         return replacer.ReplaceTypeWithAnnotations(source);
     }
 
+    internal static TypeSymbol Replace(
+        TypeSymbol source,
+        Dictionary<TKey, TValue> map,
+        Func<TKey, TValue, TReturn> afterFoundTransformation = null) {
+        var replacer = new TemplateTypeReplacer<TKey, TValue, TReturn>(map, afterFoundTransformation);
+        return replacer.ReplaceType(source);
+    }
+
     private TypeSymbol ReplaceType(TypeSymbol source) {
-        if (source is T t && _map.TryGetValue(t, out var replacement))
+        if (source is TKey t && _map.TryGetValue(t, out var replacement)) {
+            if (_afterFoundTransformation is not null)
+                return _afterFoundTransformation(t, replacement);
+
             return replacement;
+        }
 
         TypeSymbol result;
 

--- a/src/Buckle/Compiler/CodeAnalysis/Lowering/TemplateExpander/TemplateTypeRewriter.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Lowering/TemplateExpander/TemplateTypeRewriter.cs
@@ -8,13 +8,21 @@ namespace Buckle.CodeAnalysis.Lowering;
 /// <summary>
 /// Synthesizes definitions for each instantiated non-type template type found by the <see cref="TemplateExpander" />.
 /// </summary>
-internal sealed class TemplateTypeRewriter : BoundTreeRewriterWithStackGuard {
-    private readonly NamedTypeSymbol _originalType;
-    private readonly SynthesizedTemplateType _instantiatedType;
+internal sealed class TemplateTypeRewriter<T> : BoundTreeRewriterWithStackGuard
+    where T : ISymbolWithTemplates {
+    private readonly ISynthesizedTemplate<T> _instantiatedSymbol;
 
-    private TemplateTypeRewriter(NamedTypeSymbol originalType, SynthesizedTemplateType instantiatedType) {
-        _originalType = originalType;
-        _instantiatedType = instantiatedType;
+    private TemplateTypeRewriter(ISynthesizedTemplate<T> instantiatedType) {
+        _instantiatedSymbol = instantiatedType;
+    }
+
+    internal static void Rewrite(
+        SynthesizedTemplateMethod instantiatedMethod,
+        BoundBlockStatement body,
+        ImmutableDictionary<MethodSymbol, BoundBlockStatement>.Builder builder) {
+        var rewriter = new TemplateTypeRewriter<MethodSymbol>(instantiatedMethod);
+        var newBody = (BoundBlockStatement)rewriter.Visit(body);
+        builder.Add(instantiatedMethod, newBody);
     }
 
     internal static void Rewrite(
@@ -23,7 +31,7 @@ internal sealed class TemplateTypeRewriter : BoundTreeRewriterWithStackGuard {
         ConcurrentDictionary<MethodSymbol, BoundBlockStatement> allMethods,
         ImmutableDictionary<MethodSymbol, BoundBlockStatement>.Builder builder,
         ImmutableDictionary<(SynthesizedTemplateType, MethodSymbol), SynthesizedTemplateTypeMethod> methodMap) {
-        var rewriter = new TemplateTypeRewriter(originalType, instantiatedType);
+        var rewriter = new TemplateTypeRewriter<NamedTypeSymbol>(instantiatedType);
 
         foreach (var (method, body) in allMethods) {
             if (method.containingType.originalDefinition.Equals(originalType)) {
@@ -39,7 +47,7 @@ internal sealed class TemplateTypeRewriter : BoundTreeRewriterWithStackGuard {
     internal override BoundNode VisitTypeExpression(BoundTypeExpression node) {
         if (node.type is TemplateParameterSymbol templateParameter) {
             if (templateParameter.underlyingType.specialType != SpecialType.Type) {
-                var typeOrConstant = _instantiatedType.unexpandedType.templateSubstitution
+                var typeOrConstant = _instantiatedSymbol.unexpandedSymbol.templateSubstitution
                     .SubstituteType(templateParameter);
 
                 if (typeOrConstant.isConstant) {
@@ -50,7 +58,7 @@ internal sealed class TemplateTypeRewriter : BoundTreeRewriterWithStackGuard {
                     );
                 }
             } else {
-                if (_instantiatedType.replacementTemplateParameters.TryGetValue(templateParameter, out var value))
+                if (_instantiatedSymbol.replacementTemplateParameters.TryGetValue(templateParameter, out var value))
                     return new BoundTypeExpression(node.syntax, null, null, value);
             }
         }

--- a/src/Buckle/Compiler/CodeAnalysis/Lowering/TemplateExpander/TemplateTypeRewriter.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Lowering/TemplateExpander/TemplateTypeRewriter.cs
@@ -5,6 +5,9 @@ using Buckle.CodeAnalysis.Symbols;
 
 namespace Buckle.CodeAnalysis.Lowering;
 
+/// <summary>
+/// Synthesizes definitions for each instantiated non-type template type found by the <see cref="TemplateExpander" />.
+/// </summary>
 internal sealed class TemplateTypeRewriter : BoundTreeRewriterWithStackGuard {
     private readonly NamedTypeSymbol _originalType;
     private readonly SynthesizedTemplateType _instantiatedType;

--- a/src/Buckle/Compiler/CodeAnalysis/Lowering/TemplateExpander/TemplateTypeRewriter.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Lowering/TemplateExpander/TemplateTypeRewriter.cs
@@ -34,17 +34,21 @@ internal sealed class TemplateTypeRewriter : BoundTreeRewriterWithStackGuard {
     }
 
     internal override BoundNode VisitTypeExpression(BoundTypeExpression node) {
-        if (node.type is TemplateParameterSymbol templateParameter &&
-            templateParameter.underlyingType.specialType != SpecialType.Type) {
-            var typeOrConstant = _instantiatedType.unexpandedType.templateSubstitution
-                .SubstituteType(templateParameter);
+        if (node.type is TemplateParameterSymbol templateParameter) {
+            if (templateParameter.underlyingType.specialType != SpecialType.Type) {
+                var typeOrConstant = _instantiatedType.unexpandedType.templateSubstitution
+                    .SubstituteType(templateParameter);
 
-            if (typeOrConstant.isConstant) {
-                return new BoundLiteralExpression(
-                    node.syntax,
-                    typeOrConstant.constant,
-                    templateParameter.underlyingType.type
-                );
+                if (typeOrConstant.isConstant) {
+                    return new BoundLiteralExpression(
+                        node.syntax,
+                        typeOrConstant.constant,
+                        templateParameter.underlyingType.type
+                    );
+                }
+            } else {
+                if (_instantiatedType.replacementTemplateParameters.TryGetValue(templateParameter, out var value))
+                    return new BoundTypeExpression(node.syntax, null, null, value);
             }
         }
 

--- a/src/Buckle/Compiler/CodeAnalysis/Lowering/TemplateExpander/TemplateTypeRewriter.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Lowering/TemplateExpander/TemplateTypeRewriter.cs
@@ -1,0 +1,53 @@
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+using Buckle.CodeAnalysis.Binding;
+using Buckle.CodeAnalysis.Symbols;
+
+namespace Buckle.CodeAnalysis.Lowering;
+
+internal sealed class TemplateTypeRewriter : BoundTreeRewriterWithStackGuard {
+    private readonly NamedTypeSymbol _originalType;
+    private readonly SynthesizedTemplateType _instantiatedType;
+
+    private TemplateTypeRewriter(NamedTypeSymbol originalType, SynthesizedTemplateType instantiatedType) {
+        _originalType = originalType;
+        _instantiatedType = instantiatedType;
+    }
+
+    internal static void Rewrite(
+        NamedTypeSymbol originalType,
+        SynthesizedTemplateType instantiatedType,
+        ConcurrentDictionary<MethodSymbol, BoundBlockStatement> allMethods,
+        ImmutableDictionary<MethodSymbol, BoundBlockStatement>.Builder builder,
+        ImmutableDictionary<(SynthesizedTemplateType, MethodSymbol), SynthesizedTemplateTypeMethod> methodMap) {
+        var rewriter = new TemplateTypeRewriter(originalType, instantiatedType);
+
+        foreach (var (method, body) in allMethods) {
+            if (method.containingType.originalDefinition.Equals(originalType)) {
+                if (!methodMap.TryGetValue((instantiatedType, method), out var newMethod))
+                    newMethod = new SynthesizedTemplateTypeMethod(instantiatedType, method);
+
+                var newBody = (BoundBlockStatement)rewriter.Visit(body);
+                builder.Add(newMethod, newBody);
+            }
+        }
+    }
+
+    internal override BoundNode VisitTypeExpression(BoundTypeExpression node) {
+        if (node.type is TemplateParameterSymbol templateParameter &&
+            templateParameter.underlyingType.specialType != SpecialType.Type) {
+            var typeOrConstant = _instantiatedType.unexpandedType.templateSubstitution
+                .SubstituteType(templateParameter);
+
+            if (typeOrConstant.isConstant) {
+                return new BoundLiteralExpression(
+                    node.syntax,
+                    typeOrConstant.constant,
+                    templateParameter.underlyingType.type
+                );
+            }
+        }
+
+        return base.VisitTypeExpression(node);
+    }
+}

--- a/src/Buckle/Compiler/CodeAnalysis/Lowering/TemplateExpander/TypeSubstitutedMethodSymbol.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Lowering/TemplateExpander/TypeSubstitutedMethodSymbol.cs
@@ -1,0 +1,50 @@
+using System.Collections.Immutable;
+using Buckle.CodeAnalysis.Binding;
+using Buckle.CodeAnalysis.Symbols;
+using Buckle.CodeAnalysis.Syntax;
+
+namespace Buckle.CodeAnalysis.Lowering;
+
+internal sealed class TypeSubstitutedMethodSymbol : WrappedMethodSymbol {
+    private readonly TypeWithAnnotations _returnType;
+    private readonly ImmutableArray<ParameterSymbol> _parameters;
+
+    internal TypeSubstitutedMethodSymbol(
+        MethodSymbol originalMethod,
+        TypeWithAnnotations newReturnType,
+        ImmutableArray<ParameterSymbol> newParameters)
+        : base(originalMethod) {
+        _returnType = newReturnType;
+        _parameters = newParameters;
+    }
+
+    public override ImmutableArray<TemplateParameterSymbol> templateParameters => underlyingMethod.templateParameters;
+
+    public override ImmutableArray<BoundExpression> templateConstraints => underlyingMethod.templateConstraints;
+
+    public override ImmutableArray<TypeOrConstant> templateArguments => underlyingMethod.templateArguments;
+
+    internal override Symbol containingSymbol => underlyingMethod.containingSymbol;
+
+    internal override TypeWithAnnotations returnTypeWithAnnotations => _returnType;
+
+    internal override ImmutableArray<ParameterSymbol> parameters => _parameters;
+
+    internal override int parameterCount => _parameters.Length;
+
+    internal override bool isExplicitInterfaceImplementation => underlyingMethod.isExplicitInterfaceImplementation;
+
+    internal override ImmutableArray<MethodSymbol> explicitInterfaceImplementations => [];
+
+    internal override int CalculateLocalSyntaxOffset(int localPosition, SyntaxTree localTree) {
+        return underlyingMethod.CalculateLocalSyntaxOffset(localPosition, localTree);
+    }
+
+    internal override DllImportData GetDllImportData() {
+        return underlyingMethod.GetDllImportData();
+    }
+
+    internal override UnmanagedCallersOnlyAttributeData GetUnmanagedCallersOnlyAttributeData(bool forceComplete) {
+        return underlyingMethod.GetUnmanagedCallersOnlyAttributeData(forceComplete);
+    }
+}

--- a/src/Buckle/Compiler/CodeAnalysis/Lowering/TemplateExpander/TypeSubstitutedParameterSymbol.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Lowering/TemplateExpander/TypeSubstitutedParameterSymbol.cs
@@ -1,0 +1,20 @@
+using Buckle.CodeAnalysis.Symbols;
+
+namespace Buckle.CodeAnalysis.Lowering;
+
+internal sealed class TypeSubstitutedParameterSymbol : WrappedParameterSymbol {
+    private readonly ParameterSymbol _originalParameter;
+    private readonly TypeWithAnnotations _type;
+
+    internal TypeSubstitutedParameterSymbol(
+        ParameterSymbol originalParameter,
+        TypeWithAnnotations type) : base(originalParameter) {
+        _originalParameter = originalParameter;
+        _type = type;
+    }
+
+    // TODO This technically points to an obsolete method so this might need to change
+    internal override Symbol containingSymbol => _originalParameter.containingSymbol;
+
+    internal override TypeWithAnnotations typeWithAnnotations => _type;
+}

--- a/src/Buckle/Compiler/CodeAnalysis/Symbols/ConstraintsHelpers.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Symbols/ConstraintsHelpers.cs
@@ -828,6 +828,7 @@ hasRelatedInterfaces:
     }
 
     private static bool IsEncompassedBy(TypeSymbol a, TypeSymbol b) {
+        // TODO This should use ConversionsBase not Conversion
         return Conversion.HasIdentityOrImplicitConversion(a, b) || Conversion.HasBoxingConversion(a, b);
     }
 

--- a/src/Buckle/Compiler/CodeAnalysis/Symbols/FunctionMethodSymbol.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Symbols/FunctionMethodSymbol.cs
@@ -182,6 +182,17 @@ internal sealed class FunctionMethodSymbol : MethodSymbol {
         );
     }
 
+    internal FunctionMethodSymbol ReplaceParameterSymbols(
+        TypeWithAnnotations replacedReturnType,
+        ImmutableArray<TypeWithAnnotations> replacedParameterTypes) {
+        return new FunctionMethodSymbol(
+            refKind,
+            replacedReturnType,
+            parameters,
+            replacedParameterTypes.SelectAsArray(t => new TypeOrConstant(t))
+        );
+    }
+
     internal override bool Equals(Symbol other, TypeCompareKind compareKind) {
         if (!(other is FunctionMethodSymbol method)) {
             return false;

--- a/src/Buckle/Compiler/CodeAnalysis/Symbols/FunctionPointerMethodSymbol.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Symbols/FunctionPointerMethodSymbol.cs
@@ -230,6 +230,18 @@ internal sealed class FunctionPointerMethodSymbol : MethodSymbol {
         );
     }
 
+    internal FunctionPointerMethodSymbol ReplaceParameterSymbols(
+        TypeWithAnnotations replacedReturnType,
+        ImmutableArray<TypeWithAnnotations> replacedParameterTypes) {
+        return new FunctionPointerMethodSymbol(
+            callingConvention,
+            refKind,
+            replacedReturnType,
+            parameters,
+            replacedParameterTypes.SelectAsArray(t => new TypeOrConstant(t))
+        );
+    }
+
     internal override bool Equals(Symbol other, TypeCompareKind compareKind) {
         if (!(other is FunctionPointerMethodSymbol method)) {
             return false;

--- a/src/Buckle/Compiler/CodeAnalysis/Symbols/FunctionPointerTypeSymbol.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Symbols/FunctionPointerTypeSymbol.cs
@@ -70,6 +70,14 @@ internal sealed class FunctionPointerTypeSymbol : TypeSymbol {
         );
     }
 
+    internal FunctionPointerTypeSymbol ReplaceTypeSymbol(
+        TypeWithAnnotations replacedReturnType,
+        ImmutableArray<TypeWithAnnotations> replacedParameterTypes) {
+        return new FunctionPointerTypeSymbol(
+            signature.ReplaceParameterSymbols(replacedReturnType, replacedParameterTypes)
+        );
+    }
+
     internal FunctionPointerMethodSymbol signature { get; }
 
     public override bool isReferenceType => false;

--- a/src/Buckle/Compiler/CodeAnalysis/Symbols/FunctionTypeSymbol.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Symbols/FunctionTypeSymbol.cs
@@ -60,6 +60,14 @@ internal sealed class FunctionTypeSymbol : TypeSymbol {
         );
     }
 
+    internal FunctionTypeSymbol ReplaceTypeSymbol(
+        TypeWithAnnotations replacedReturnType,
+        ImmutableArray<TypeWithAnnotations> replacedParameterTypes) {
+        return new FunctionTypeSymbol(
+            signature.ReplaceParameterSymbols(replacedReturnType, replacedParameterTypes)
+        );
+    }
+
     internal FunctionMethodSymbol signature { get; }
 
     public override bool isReferenceType => true;

--- a/src/Buckle/Compiler/CodeAnalysis/Symbols/GeneratedNames.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Symbols/GeneratedNames.cs
@@ -1,6 +1,5 @@
 using System.Collections.Immutable;
 using System.Linq;
-using Buckle.Building;
 using Buckle.CodeAnalysis.Display;
 using Buckle.CodeAnalysis.Lowering;
 using Microsoft.CodeAnalysis.PooledObjects;
@@ -56,22 +55,22 @@ internal static class GeneratedNames {
         return "<" + methodName + ">a__Reversible";
     }
 
-    internal static string MakeTemplateTypeName(NamedTypeSymbol type) {
+    internal static string MakeTemplateTypeOrMethodName(ISymbolWithTemplates symbol) {
         var result = PooledStringBuilder.GetInstance();
         var builder = result.Builder;
-        builder.Append(type.name);
+        builder.Append(symbol.name);
         builder.Append('<');
 
         var first = true;
 
-        for (var i = 0; i < type.templateParameters.Length; i++) {
-            if (type.templateParameters[i].underlyingType.specialType != SpecialType.Type) {
+        for (var i = 0; i < symbol.templateParameters.Length; i++) {
+            if (symbol.templateParameters[i].underlyingType.specialType != SpecialType.Type) {
                 if (first)
                     first = false;
                 else
                     builder.Append(',');
 
-                builder.Append(DisplayText.FormatLiteral(type.templateArguments[i].constant.value));
+                builder.Append(DisplayText.FormatLiteral(symbol.templateArguments[i].constant.value));
             }
         }
 

--- a/src/Buckle/Compiler/CodeAnalysis/Symbols/GeneratedNames.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Symbols/GeneratedNames.cs
@@ -1,5 +1,7 @@
 using System.Collections.Immutable;
 using System.Linq;
+using Buckle.Building;
+using Buckle.CodeAnalysis.Display;
 using Buckle.CodeAnalysis.Lowering;
 using Microsoft.CodeAnalysis.PooledObjects;
 
@@ -52,6 +54,30 @@ internal static class GeneratedNames {
 
     internal static string MakeStateMethodName(string methodName) {
         return "<" + methodName + ">a__Reversible";
+    }
+
+    internal static string MakeTemplateTypeName(NamedTypeSymbol type) {
+        var result = PooledStringBuilder.GetInstance();
+        var builder = result.Builder;
+        builder.Append(type.name);
+        builder.Append('<');
+
+        var first = true;
+
+        for (var i = 0; i < type.templateParameters.Length; i++) {
+            if (type.templateParameters[i].underlyingType.specialType != SpecialType.Type) {
+                if (first)
+                    first = false;
+                else
+                    builder.Append(',');
+
+                builder.Append(DisplayText.FormatLiteral(type.templateArguments[i].constant.value));
+            }
+        }
+
+        builder.Append('>');
+
+        return result.ToStringAndFree();
     }
 
     internal static string MakeClosureName(

--- a/src/Buckle/Compiler/CodeAnalysis/Symbols/NamedTypeSymbol.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Symbols/NamedTypeSymbol.cs
@@ -475,8 +475,8 @@ internal abstract partial class NamedTypeSymbol : TypeSymbol, INamedTypeSymbol, 
                         return false;
 
                     if (!typeParameters[i].Equals(
-                             typeArguments[i].type.type.originalDefinition,
-                             TypeCompareKind.ConsiderEverything)) {
+                            typeArguments[i].type.type.originalDefinition,
+                            TypeCompareKind.ConsiderEverything)) {
                         return false;
                     }
                 }

--- a/src/Buckle/Compiler/CodeAnalysis/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Symbols/Source/LocalFunctionSymbol.cs
@@ -181,6 +181,8 @@ internal sealed class LocalFunctionSymbol : SourceMethodSymbol {
         GetReturnTypeAttributes();
 
         addTo.PushRange(_declarationDiagnostics);
+
+        TemplateChecks(addTo);
     }
 
     internal void ComputeReturnType() {
@@ -320,5 +322,14 @@ internal sealed class LocalFunctionSymbol : SourceMethodSymbol {
 
     internal override int CalculateLocalSyntaxOffset(int localPosition, SyntaxTree localTree) {
         throw ExceptionUtilities.Unreachable();
+    }
+
+    private void TemplateChecks(BelteDiagnosticQueue diagnostics) {
+        foreach (var templateParameter in templateParameters) {
+            if (templateParameter.underlyingType.specialType != SpecialType.Type) {
+                diagnostics.Push(Error.Unsupported.NonTypeTemplateFunction(templateParameter.location));
+                break;
+            }
+        }
     }
 }

--- a/src/Buckle/Compiler/CodeAnalysis/Symbols/Source/SourceTemplateParameterSymbolBase.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Symbols/Source/SourceTemplateParameterSymbolBase.cs
@@ -222,12 +222,6 @@ internal abstract class SourceTemplateParameterSymbolBase : TemplateParameterSym
             return new TypeWithAnnotations(underlying);
         }
 
-        if (declaringCompilation.options.buildMode is BuildMode.CSharpTranspile or
-                                                      BuildMode.Execute or
-                                                      BuildMode.Dotnet) {
-            diagnostics.Push(Error.Unsupported.NonTypeTemplate(syntax.location));
-        }
-
         // TODO This seems wrong/unnecessary:
         if (hasNotNullConstraint)
             return new TypeWithAnnotations(underlying);

--- a/src/Buckle/Compiler/CodeAnalysis/Symbols/Substituted/SubstitutedMethodSymbol.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Symbols/Substituted/SubstitutedMethodSymbol.cs
@@ -244,6 +244,9 @@ internal class SubstitutedMethodSymbol : WrappedMethodSymbol {
             var templateParameters = method.originalDefinition.templateParameters;
 
             for (var i = 0; i < templateArguments.Length; i++) {
+                if (templateArguments[i].isConstant)
+                    return false;
+
                 if (!templateParameters[i].Equals(
                         templateArguments[i].type.type,
                         TypeCompareKind.ConsiderEverything)) {

--- a/src/Buckle/Compiler/CodeAnalysis/Symbols/Symbol.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Symbols/Symbol.cs
@@ -862,7 +862,7 @@ internal abstract class Symbol : ISymbol {
     }
 
     private string GetDebuggerDisplay() {
-        return $"{kind} {ToDisplayString(SymbolDisplayFormat.Everything)}";
+        return $"{kind} {ToDisplayString(SymbolDisplayFormat.ErrorMessageFormat)}";
     }
 
     public string ToDisplayString(SymbolDisplayFormat format) {

--- a/src/Buckle/Compiler/CodeAnalysis/Symbols/Synthesized/TypeSubstitutedLocalSymbol.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Symbols/Synthesized/TypeSubstitutedLocalSymbol.cs
@@ -11,7 +11,7 @@ internal sealed class TypeSubstitutedLocalSymbol : DataContainerSymbol {
     private readonly TypeWithAnnotations _type;
     private readonly Symbol _containingSymbol;
 
-    public TypeSubstitutedLocalSymbol(
+    internal TypeSubstitutedLocalSymbol(
         DataContainerSymbol originalVariable,
         TypeWithAnnotations type,
         Symbol containingSymbol) {
@@ -48,9 +48,6 @@ internal sealed class TypeSubstitutedLocalSymbol : DataContainerSymbol {
     internal override bool isPinned => _originalVariable.isPinned;
 
     public override RefKind refKind => _originalVariable.refKind;
-
-    // TODO Any way this backfires/isn't necessary?
-    private protected override Symbol _originalSymbolDefinition => _originalVariable;
 
     internal override ScopedKind scope => throw new System.NotImplementedException();
 

--- a/src/Buckle/Compiler/CodeAnalysis/Symbols/TemplateMap.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Symbols/TemplateMap.cs
@@ -158,7 +158,8 @@ internal class TemplateMap {
             previous.rank,
             previous.sizes,
             previous.lowerBounds,
-            previous.baseType);
+            previous.baseType
+        );
     }
 
     internal NamedTypeSymbol SubstituteNamedType(NamedTypeSymbol previous) {

--- a/src/Buckle/Compiler/CodeAnalysis/Symbols/TemplateMap.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Symbols/TemplateMap.cs
@@ -42,7 +42,7 @@ internal class TemplateMap {
             var templateParameter = from[i];
             var templateArgument = to[i];
 
-            if (!templateArgument.Equals(templateParameter))
+            if (templateArgument.type?.type?.Equals(templateParameter) != true)
                 _mapping.Add(templateParameter, templateArgument);
         }
     }

--- a/src/Buckle/Compiler/CodeAnalysis/Symbols/TypeWithAnnotations.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Symbols/TypeWithAnnotations.cs
@@ -63,7 +63,12 @@ internal sealed class TypeWithAnnotations {
 
     internal TypeOrConstant SubstituteType(TemplateMap templateMap) {
         var typeSymbol = type.StrippedType();
-        var newType = templateMap.SubstituteType(typeSymbol).type;
+        var newTypeOrConstant = templateMap.SubstituteType(typeSymbol);
+
+        if (newTypeOrConstant.isConstant)
+            return newTypeOrConstant;
+
+        var newType = newTypeOrConstant.type;
 
         if (type.IsNullableType() && !newType.IsNullableType())
             newType = newType.SetIsAnnotated();

--- a/src/Buckle/Compiler/CodeAnalysis/Symbols/TypeWithAnnotationsExtensions.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Symbols/TypeWithAnnotationsExtensions.cs
@@ -82,12 +82,17 @@ internal static class TypeWithAnnotationsExtensions {
                     }
 
                     // Skip non-type templates
+                    next = null;
+
                     for (; i >= 0; i--) {
                         next = templateArguments[i].type;
 
                         if (next is not null)
                             break;
                     }
+
+                    if (next is not null)
+                        break;
 
                     return null;
                 case TypeKind.Array:

--- a/src/Buckle/Compiler/CodeAnalysis/Symbols/TypeWithAnnotationsExtensions.cs
+++ b/src/Buckle/Compiler/CodeAnalysis/Symbols/TypeWithAnnotationsExtensions.cs
@@ -60,6 +60,9 @@ internal static class TypeWithAnnotationsExtensions {
 
                     int i;
                     for (i = 0; i < templateArguments.Length - 1; i++) {
+                        if (templateArguments[i].isConstant)
+                            continue;
+
                         (var nextTypeWithAnnotations, var nextType) = GetNextIterationElements(
                             templateArguments[i].type,
                             canDigThroughNullable
@@ -78,9 +81,15 @@ internal static class TypeWithAnnotationsExtensions {
                             return result;
                     }
 
-                    next = templateArguments[i].type;
-                    break;
+                    // Skip non-type templates
+                    for (; i >= 0; i--) {
+                        next = templateArguments[i].type;
 
+                        if (next is not null)
+                            break;
+                    }
+
+                    return null;
                 case TypeKind.Array:
                     next = ((ArrayTypeSymbol)current).elementTypeWithAnnotations;
                     break;

--- a/src/Buckle/Compiler/Diagnostics/DiagnosticCode.cs
+++ b/src/Buckle/Compiler/Diagnostics/DiagnosticCode.cs
@@ -593,7 +593,7 @@ public enum DiagnosticCode : ushort {
 
     // Carving out >=9000 for unsupported errors
     UNS_IndependentCompilation = 9000,
-    // ! Unused slot 9001
+    UNS_NonTypeTemplateFunction = 9001,
     UNS_ILOpCode = 9002,
     UNS_NonIntegralEnum = 9003,
     UNS_GraphicsDll = 9004,

--- a/src/Buckle/Compiler/Diagnostics/DiagnosticCode.cs
+++ b/src/Buckle/Compiler/Diagnostics/DiagnosticCode.cs
@@ -593,7 +593,7 @@ public enum DiagnosticCode : ushort {
 
     // Carving out >=9000 for unsupported errors
     UNS_IndependentCompilation = 9000,
-    UNS_NonTypeTemplate = 9001,
+    // ! Unused slot 9001
     UNS_ILOpCode = 9002,
     UNS_NonIntegralEnum = 9003,
     UNS_GraphicsDll = 9004,

--- a/src/Buckle/Compiler/Diagnostics/Error.cs
+++ b/src/Buckle/Compiler/Diagnostics/Error.cs
@@ -21,6 +21,11 @@ internal static class Error {
     /// Once the compiler is finished, this class will be unnecessary.
     /// </summary>
     internal static class Unsupported {
+        internal static BelteDiagnostic NonTypeTemplateFunction(TextLocation location) {
+            var message = "unsupported: cannot declare a non-type template local function";
+            return CreateError(DiagnosticCode.UNS_NonTypeTemplateFunction, location, message);
+        }
+
         internal static BelteDiagnostic GraphicsDll() {
             var message = "unsupported: cannot use the graphics project type when building for .NET or transpiling to C#; consider executing instead";
             return CreateError(DiagnosticCode.UNS_GraphicsDll, null, message);

--- a/src/Buckle/Compiler/Diagnostics/Error.cs
+++ b/src/Buckle/Compiler/Diagnostics/Error.cs
@@ -21,11 +21,6 @@ internal static class Error {
     /// Once the compiler is finished, this class will be unnecessary.
     /// </summary>
     internal static class Unsupported {
-        internal static BelteDiagnostic NonTypeTemplate(TextLocation location) {
-            var message = "unsupported: cannot declare a non-type template when building for .NET, transpiling to C#, or executing";
-            return CreateError(DiagnosticCode.UNS_NonTypeTemplate, location, message);
-        }
-
         internal static BelteDiagnostic GraphicsDll() {
             var message = "unsupported: cannot use the graphics project type when building for .NET or transpiling to C#; consider executing instead";
             return CreateError(DiagnosticCode.UNS_GraphicsDll, null, message);


### PR DESCRIPTION
# Description

Non-type template support for Executing and IL Emitting endpoints (i.e. .NET support).

This is done by synthesizing a new type/method per non-type template combination instantiation.